### PR TITLE
feat(go,java): add lenient datetime parsing for space-separated formats

### DIFF
--- a/generators/go-v2/base/src/asIs/internal/time.go_
+++ b/generators/go-v2/base/src/asIs/internal/time.go_
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/generators/go-v2/base/src/asIs/internal/time.go_
+++ b/generators/go-v2/base/src/asIs/internal/time.go_
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/generators/go-v2/base/src/asIs/internal/time.go_
+++ b/generators/go-v2/base/src/asIs/internal/time.go_
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/generators/go/internal/fern/ir/internal/time.go
+++ b/generators/go/internal/fern/ir/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/generators/go/internal/fern/ir/internal/time.go
+++ b/generators/go/internal/fern/ir/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/generators/go/internal/fern/ir/internal/time.go
+++ b/generators/go/internal/fern/ir/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/generators/go/internal/generator/model/internal/time.go
+++ b/generators/go/internal/generator/model/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/generators/go/internal/generator/model/internal/time.go
+++ b/generators/go/internal/generator/model/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/generators/go/internal/generator/model/internal/time.go
+++ b/generators/go/internal/generator/model/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/generators/go/sdk/changes/unreleased/lenient-datetime-parsing.yml
+++ b/generators/go/sdk/changes/unreleased/lenient-datetime-parsing.yml
@@ -1,0 +1,5 @@
+- summary: |
+    The Go SDK now accepts space-separated datetime strings (e.g. "2025-02-15 10:30:00+00:00")
+    in addition to standard RFC3339 format during deserialization. This matches the leniency of
+    the Python and TypeScript SDKs.
+  type: feat

--- a/generators/java/generator-utils/src/main/resources/DateTimeDeserializer.java
+++ b/generators/java/generator-utils/src/main/resources/DateTimeDeserializer.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -37,8 +38,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/generators/java/sdk/changes/unreleased/lenient-datetime-parsing.yml
+++ b/generators/java/sdk/changes/unreleased/lenient-datetime-parsing.yml
@@ -1,0 +1,5 @@
+- summary: |
+    The Java SDK now accepts space-separated datetime strings (e.g. "2025-02-15 10:30:00+00:00")
+    in addition to standard ISO 8601 format during deserialization. This matches the leniency of
+    the Python and TypeScript SDKs.
+  type: feat

--- a/seed/go-sdk/accept-header/internal/time.go
+++ b/seed/go-sdk/accept-header/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/accept-header/internal/time.go
+++ b/seed/go-sdk/accept-header/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/accept-header/internal/time.go
+++ b/seed/go-sdk/accept-header/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/alias/internal/time.go
+++ b/seed/go-sdk/alias/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/alias/internal/time.go
+++ b/seed/go-sdk/alias/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/alias/internal/time.go
+++ b/seed/go-sdk/alias/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/allof-inline/internal/time.go
+++ b/seed/go-sdk/allof-inline/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/allof-inline/internal/time.go
+++ b/seed/go-sdk/allof-inline/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/allof-inline/internal/time.go
+++ b/seed/go-sdk/allof-inline/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/allof/internal/time.go
+++ b/seed/go-sdk/allof/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/allof/internal/time.go
+++ b/seed/go-sdk/allof/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/allof/internal/time.go
+++ b/seed/go-sdk/allof/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/any-auth/internal/time.go
+++ b/seed/go-sdk/any-auth/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/any-auth/internal/time.go
+++ b/seed/go-sdk/any-auth/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/any-auth/internal/time.go
+++ b/seed/go-sdk/any-auth/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/api-wide-base-path/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/api-wide-base-path/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/api-wide-base-path/internal/time.go
+++ b/seed/go-sdk/api-wide-base-path/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/audiences/internal/time.go
+++ b/seed/go-sdk/audiences/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/audiences/internal/time.go
+++ b/seed/go-sdk/audiences/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/audiences/internal/time.go
+++ b/seed/go-sdk/audiences/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/basic-auth-environment-variables/internal/time.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/basic-auth-environment-variables/internal/time.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/basic-auth-environment-variables/internal/time.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/time.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/time.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/time.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/basic-auth/internal/time.go
+++ b/seed/go-sdk/basic-auth/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/basic-auth/internal/time.go
+++ b/seed/go-sdk/basic-auth/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/basic-auth/internal/time.go
+++ b/seed/go-sdk/basic-auth/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/bearer-token-environment-variable/internal/time.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/bearer-token-environment-variable/internal/time.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/bearer-token-environment-variable/internal/time.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/bytes-download/internal/time.go
+++ b/seed/go-sdk/bytes-download/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/bytes-download/internal/time.go
+++ b/seed/go-sdk/bytes-download/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/bytes-download/internal/time.go
+++ b/seed/go-sdk/bytes-download/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/bytes-upload/internal/time.go
+++ b/seed/go-sdk/bytes-upload/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/bytes-upload/internal/time.go
+++ b/seed/go-sdk/bytes-upload/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/bytes-upload/internal/time.go
+++ b/seed/go-sdk/bytes-upload/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/circular-references-advanced/internal/time.go
+++ b/seed/go-sdk/circular-references-advanced/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/circular-references-advanced/internal/time.go
+++ b/seed/go-sdk/circular-references-advanced/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/circular-references-advanced/internal/time.go
+++ b/seed/go-sdk/circular-references-advanced/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/circular-references-extends/internal/time.go
+++ b/seed/go-sdk/circular-references-extends/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/circular-references-extends/internal/time.go
+++ b/seed/go-sdk/circular-references-extends/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/circular-references-extends/internal/time.go
+++ b/seed/go-sdk/circular-references-extends/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/circular-references/internal/time.go
+++ b/seed/go-sdk/circular-references/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/circular-references/internal/time.go
+++ b/seed/go-sdk/circular-references/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/circular-references/internal/time.go
+++ b/seed/go-sdk/circular-references/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/time.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/time.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/cli-multi-spec-namespaced/internal/time.go
+++ b/seed/go-sdk/cli-multi-spec-namespaced/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/cli-multi-spec/internal/time.go
+++ b/seed/go-sdk/cli-multi-spec/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/cli-multi-spec/internal/time.go
+++ b/seed/go-sdk/cli-multi-spec/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/cli-multi-spec/internal/time.go
+++ b/seed/go-sdk/cli-multi-spec/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/client-side-params/internal/time.go
+++ b/seed/go-sdk/client-side-params/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/client-side-params/internal/time.go
+++ b/seed/go-sdk/client-side-params/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/client-side-params/internal/time.go
+++ b/seed/go-sdk/client-side-params/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/content-type/internal/time.go
+++ b/seed/go-sdk/content-type/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/content-type/internal/time.go
+++ b/seed/go-sdk/content-type/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/content-type/internal/time.go
+++ b/seed/go-sdk/content-type/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/cross-package-type-names/internal/time.go
+++ b/seed/go-sdk/cross-package-type-names/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/cross-package-type-names/internal/time.go
+++ b/seed/go-sdk/cross-package-type-names/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/cross-package-type-names/internal/time.go
+++ b/seed/go-sdk/cross-package-type-names/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/dollar-string-examples/internal/time.go
+++ b/seed/go-sdk/dollar-string-examples/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/dollar-string-examples/internal/time.go
+++ b/seed/go-sdk/dollar-string-examples/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/dollar-string-examples/internal/time.go
+++ b/seed/go-sdk/dollar-string-examples/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/empty-clients/internal/time.go
+++ b/seed/go-sdk/empty-clients/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/empty-clients/internal/time.go
+++ b/seed/go-sdk/empty-clients/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/empty-clients/internal/time.go
+++ b/seed/go-sdk/empty-clients/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/endpoint-security-auth/internal/time.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/endpoint-security-auth/internal/time.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/endpoint-security-auth/internal/time.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/enum/internal/time.go
+++ b/seed/go-sdk/enum/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/enum/internal/time.go
+++ b/seed/go-sdk/enum/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/enum/internal/time.go
+++ b/seed/go-sdk/enum/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/error-property/internal/time.go
+++ b/seed/go-sdk/error-property/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/error-property/internal/time.go
+++ b/seed/go-sdk/error-property/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/error-property/internal/time.go
+++ b/seed/go-sdk/error-property/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/errors/internal/time.go
+++ b/seed/go-sdk/errors/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/errors/internal/time.go
+++ b/seed/go-sdk/errors/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/errors/internal/time.go
+++ b/seed/go-sdk/errors/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/always-send-required-properties/internal/time.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/always-send-required-properties/internal/time.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/always-send-required-properties/internal/time.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/client-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/client-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/client-name/internal/time.go
+++ b/seed/go-sdk/examples/client-name/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/exported-client-name/internal/time.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/exported-client-name/internal/time.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/exported-client-name/internal/time.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/no-custom-config/internal/time.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/no-custom-config/internal/time.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/no-custom-config/internal/time.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/time.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/time.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/time.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/readme-config/internal/time.go
+++ b/seed/go-sdk/examples/readme-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/readme-config/internal/time.go
+++ b/seed/go-sdk/examples/readme-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/readme-config/internal/time.go
+++ b/seed/go-sdk/examples/readme-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/examples/v0/internal/time.go
+++ b/seed/go-sdk/examples/v0/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/examples/v0/internal/time.go
+++ b/seed/go-sdk/examples/v0/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/examples/v0/internal/time.go
+++ b/seed/go-sdk/examples/v0/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
@@ -7,8 +7,7 @@
     "omitEmptyRequestWrappers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/extends/internal/time.go
+++ b/seed/go-sdk/extends/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/extends/internal/time.go
+++ b/seed/go-sdk/extends/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/extends/internal/time.go
+++ b/seed/go-sdk/extends/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/extra-properties/internal/time.go
+++ b/seed/go-sdk/extra-properties/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/extra-properties/internal/time.go
+++ b/seed/go-sdk/extra-properties/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/extra-properties/internal/time.go
+++ b/seed/go-sdk/extra-properties/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/file-download/internal/time.go
+++ b/seed/go-sdk/file-download/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/file-download/internal/time.go
+++ b/seed/go-sdk/file-download/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/file-download/internal/time.go
+++ b/seed/go-sdk/file-download/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/file-upload-openapi/internal/time.go
+++ b/seed/go-sdk/file-upload-openapi/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/file-upload-openapi/internal/time.go
+++ b/seed/go-sdk/file-upload-openapi/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/file-upload-openapi/internal/time.go
+++ b/seed/go-sdk/file-upload-openapi/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/file-upload/no-custom-config/internal/time.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/file-upload/no-custom-config/internal/time.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/file-upload/no-custom-config/internal/time.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/file-upload/package-name/internal/time.go
+++ b/seed/go-sdk/file-upload/package-name/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/file-upload/package-name/internal/time.go
+++ b/seed/go-sdk/file-upload/package-name/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/file-upload/package-name/internal/time.go
+++ b/seed/go-sdk/file-upload/package-name/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/file-upload/v0/internal/time.go
+++ b/seed/go-sdk/file-upload/v0/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/file-upload/v0/internal/time.go
+++ b/seed/go-sdk/file-upload/v0/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/file-upload/v0/internal/time.go
+++ b/seed/go-sdk/file-upload/v0/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/folders/internal/time.go
+++ b/seed/go-sdk/folders/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/folders/internal/time.go
+++ b/seed/go-sdk/folders/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/folders/internal/time.go
+++ b/seed/go-sdk/folders/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-content-type/internal/time.go
+++ b/seed/go-sdk/go-content-type/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-content-type/internal/time.go
+++ b/seed/go-sdk/go-content-type/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-content-type/internal/time.go
+++ b/seed/go-sdk/go-content-type/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-deterministic-ordering/internal/time.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-deterministic-ordering/internal/time.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-deterministic-ordering/internal/time.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-nested-cross-package/internal/time.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-nested-cross-package/internal/time.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-nested-cross-package/internal/time.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-optional-literal-alias/internal/time.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-optional-literal-alias/internal/time.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-optional-literal-alias/internal/time.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-subpackage-collision/internal/time.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-subpackage-collision/internal/time.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-subpackage-collision/internal/time.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/header-auth-environment-variable/internal/time.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/header-auth-environment-variable/internal/time.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/header-auth-environment-variable/internal/time.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/header-auth/internal/time.go
+++ b/seed/go-sdk/header-auth/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/header-auth/internal/time.go
+++ b/seed/go-sdk/header-auth/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/header-auth/internal/time.go
+++ b/seed/go-sdk/header-auth/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/http-head/internal/time.go
+++ b/seed/go-sdk/http-head/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/http-head/internal/time.go
+++ b/seed/go-sdk/http-head/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/http-head/internal/time.go
+++ b/seed/go-sdk/http-head/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/idempotency-headers/internal/time.go
+++ b/seed/go-sdk/idempotency-headers/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/idempotency-headers/internal/time.go
+++ b/seed/go-sdk/idempotency-headers/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/idempotency-headers/internal/time.go
+++ b/seed/go-sdk/idempotency-headers/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/time.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/time.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/time.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/imdb/no-custom-config/internal/time.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/imdb/no-custom-config/internal/time.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/imdb/no-custom-config/internal/time.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/time.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/time.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/time.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/time.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/time.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/time.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/inferred-auth-explicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/inferred-auth-explicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/inferred-auth-explicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/inferred-auth-implicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/inferred-auth-implicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/inferred-auth-implicit/internal/time.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/license/internal/time.go
+++ b/seed/go-sdk/license/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/license/internal/time.go
+++ b/seed/go-sdk/license/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/license/internal/time.go
+++ b/seed/go-sdk/license/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/literal-user-agent/internal/time.go
+++ b/seed/go-sdk/literal-user-agent/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/literal-user-agent/internal/time.go
+++ b/seed/go-sdk/literal-user-agent/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/literal-user-agent/internal/time.go
+++ b/seed/go-sdk/literal-user-agent/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/literal/internal/time.go
+++ b/seed/go-sdk/literal/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/literal/internal/time.go
+++ b/seed/go-sdk/literal/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/literal/internal/time.go
+++ b/seed/go-sdk/literal/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/mixed-case/default-values/internal/time.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/mixed-case/default-values/internal/time.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/mixed-case/default-values/internal/time.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/mixed-file-directory/internal/time.go
+++ b/seed/go-sdk/mixed-file-directory/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/mixed-file-directory/internal/time.go
+++ b/seed/go-sdk/mixed-file-directory/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/mixed-file-directory/internal/time.go
+++ b/seed/go-sdk/mixed-file-directory/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/multi-line-docs/internal/time.go
+++ b/seed/go-sdk/multi-line-docs/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/multi-line-docs/internal/time.go
+++ b/seed/go-sdk/multi-line-docs/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/multi-line-docs/internal/time.go
+++ b/seed/go-sdk/multi-line-docs/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/multi-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/multi-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/multi-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/multi-url-environment-reference/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/multi-url-environment-reference/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/multi-url-environment-reference/internal/time.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/multi-url-environment/internal/time.go
+++ b/seed/go-sdk/multi-url-environment/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/multi-url-environment/internal/time.go
+++ b/seed/go-sdk/multi-url-environment/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/multi-url-environment/internal/time.go
+++ b/seed/go-sdk/multi-url-environment/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/multiple-request-bodies/internal/time.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/multiple-request-bodies/internal/time.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/multiple-request-bodies/internal/time.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/no-content-response/internal/time.go
+++ b/seed/go-sdk/no-content-response/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/no-content-response/internal/time.go
+++ b/seed/go-sdk/no-content-response/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/no-content-response/internal/time.go
+++ b/seed/go-sdk/no-content-response/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/no-environment/internal/time.go
+++ b/seed/go-sdk/no-environment/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/no-environment/internal/time.go
+++ b/seed/go-sdk/no-environment/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/no-environment/internal/time.go
+++ b/seed/go-sdk/no-environment/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/no-retries/internal/time.go
+++ b/seed/go-sdk/no-retries/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/no-retries/internal/time.go
+++ b/seed/go-sdk/no-retries/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/no-retries/internal/time.go
+++ b/seed/go-sdk/no-retries/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/null-type/internal/time.go
+++ b/seed/go-sdk/null-type/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/null-type/internal/time.go
+++ b/seed/go-sdk/null-type/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/null-type/internal/time.go
+++ b/seed/go-sdk/null-type/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/nullable-allof-extends/internal/time.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/nullable-allof-extends/internal/time.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/nullable-allof-extends/internal/time.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/nullable-optional/internal/time.go
+++ b/seed/go-sdk/nullable-optional/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/nullable-optional/internal/time.go
+++ b/seed/go-sdk/nullable-optional/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/nullable-optional/internal/time.go
+++ b/seed/go-sdk/nullable-optional/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/nullable/internal/time.go
+++ b/seed/go-sdk/nullable/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/nullable/internal/time.go
+++ b/seed/go-sdk/nullable/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/nullable/internal/time.go
+++ b/seed/go-sdk/nullable/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-default/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-default/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-default/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/oauth-client-credentials/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/oauth-client-credentials/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/oauth-client-credentials/internal/time.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/object/internal/time.go
+++ b/seed/go-sdk/object/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/object/internal/time.go
+++ b/seed/go-sdk/object/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/object/internal/time.go
+++ b/seed/go-sdk/object/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/objects-with-imports/internal/time.go
+++ b/seed/go-sdk/objects-with-imports/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/objects-with-imports/internal/time.go
+++ b/seed/go-sdk/objects-with-imports/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/objects-with-imports/internal/time.go
+++ b/seed/go-sdk/objects-with-imports/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/time.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/time.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/time.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/optional/internal/time.go
+++ b/seed/go-sdk/optional/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/optional/internal/time.go
+++ b/seed/go-sdk/optional/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/optional/internal/time.go
+++ b/seed/go-sdk/optional/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/package-yml/no-custom-config/internal/time.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/package-yml/no-custom-config/internal/time.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/package-yml/no-custom-config/internal/time.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/pagination-custom/internal/time.go
+++ b/seed/go-sdk/pagination-custom/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/pagination-custom/internal/time.go
+++ b/seed/go-sdk/pagination-custom/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/pagination-custom/internal/time.go
+++ b/seed/go-sdk/pagination-custom/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/pagination-uri-path/internal/time.go
+++ b/seed/go-sdk/pagination-uri-path/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/pagination-uri-path/internal/time.go
+++ b/seed/go-sdk/pagination-uri-path/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/pagination-uri-path/internal/time.go
+++ b/seed/go-sdk/pagination-uri-path/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/pagination/internal/time.go
+++ b/seed/go-sdk/pagination/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/pagination/internal/time.go
+++ b/seed/go-sdk/pagination/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/pagination/internal/time.go
+++ b/seed/go-sdk/pagination/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/path-parameters/package-name/internal/time.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/path-parameters/package-name/internal/time.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/path-parameters/package-name/internal/time.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/path-parameters/v0/internal/time.go
+++ b/seed/go-sdk/path-parameters/v0/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/path-parameters/v0/internal/time.go
+++ b/seed/go-sdk/path-parameters/v0/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/path-parameters/v0/internal/time.go
+++ b/seed/go-sdk/path-parameters/v0/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/plain-text/internal/time.go
+++ b/seed/go-sdk/plain-text/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/plain-text/internal/time.go
+++ b/seed/go-sdk/plain-text/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/plain-text/internal/time.go
+++ b/seed/go-sdk/plain-text/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/property-access/internal/time.go
+++ b/seed/go-sdk/property-access/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/property-access/internal/time.go
+++ b/seed/go-sdk/property-access/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/property-access/internal/time.go
+++ b/seed/go-sdk/property-access/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/public-object/internal/time.go
+++ b/seed/go-sdk/public-object/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/public-object/internal/time.go
+++ b/seed/go-sdk/public-object/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/public-object/internal/time.go
+++ b/seed/go-sdk/public-object/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/query-param-name-conflict/internal/time.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/query-param-name-conflict/internal/time.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/query-param-name-conflict/internal/time.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/query-parameters-openapi/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/query-parameters-openapi/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/query-parameters-openapi/internal/time.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/query-parameters/internal/time.go
+++ b/seed/go-sdk/query-parameters/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/query-parameters/internal/time.go
+++ b/seed/go-sdk/query-parameters/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/query-parameters/internal/time.go
+++ b/seed/go-sdk/query-parameters/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/required-nullable/internal/time.go
+++ b/seed/go-sdk/required-nullable/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/required-nullable/internal/time.go
+++ b/seed/go-sdk/required-nullable/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/required-nullable/internal/time.go
+++ b/seed/go-sdk/required-nullable/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/reserved-keywords/internal/time.go
+++ b/seed/go-sdk/reserved-keywords/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/reserved-keywords/internal/time.go
+++ b/seed/go-sdk/reserved-keywords/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/reserved-keywords/internal/time.go
+++ b/seed/go-sdk/reserved-keywords/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/response-property/internal/time.go
+++ b/seed/go-sdk/response-property/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/response-property/internal/time.go
+++ b/seed/go-sdk/response-property/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/response-property/internal/time.go
+++ b/seed/go-sdk/response-property/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/schemaless-request-body-examples/internal/time.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/schemaless-request-body-examples/internal/time.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/schemaless-request-body-examples/internal/time.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/server-sent-events-resumable/internal/time.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/server-sent-events-resumable/internal/time.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/server-sent-events-resumable/internal/time.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/server-url-templating/internal/time.go
+++ b/seed/go-sdk/server-url-templating/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/server-url-templating/internal/time.go
+++ b/seed/go-sdk/server-url-templating/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/server-url-templating/internal/time.go
+++ b/seed/go-sdk/server-url-templating/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/simple-api/internal/time.go
+++ b/seed/go-sdk/simple-api/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/simple-api/internal/time.go
+++ b/seed/go-sdk/simple-api/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/simple-api/internal/time.go
+++ b/seed/go-sdk/simple-api/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/simple-fhir/internal/time.go
+++ b/seed/go-sdk/simple-fhir/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/simple-fhir/internal/time.go
+++ b/seed/go-sdk/simple-fhir/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/simple-fhir/internal/time.go
+++ b/seed/go-sdk/simple-fhir/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/single-url-environment-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/single-url-environment-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/single-url-environment-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/single-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/single-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/single-url-environment-no-default/internal/time.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/streaming/internal/time.go
+++ b/seed/go-sdk/streaming/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/streaming/internal/time.go
+++ b/seed/go-sdk/streaming/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/streaming/internal/time.go
+++ b/seed/go-sdk/streaming/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/union-query-parameters/internal/time.go
+++ b/seed/go-sdk/union-query-parameters/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/union-query-parameters/internal/time.go
+++ b/seed/go-sdk/union-query-parameters/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/union-query-parameters/internal/time.go
+++ b/seed/go-sdk/union-query-parameters/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/unions-with-local-date/internal/time.go
+++ b/seed/go-sdk/unions-with-local-date/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/unions-with-local-date/internal/time.go
+++ b/seed/go-sdk/unions-with-local-date/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/unions-with-local-date/internal/time.go
+++ b/seed/go-sdk/unions-with-local-date/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/unions/no-custom-config/internal/time.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/unions/package-name/internal/time.go
+++ b/seed/go-sdk/unions/package-name/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/unions/package-name/internal/time.go
+++ b/seed/go-sdk/unions/package-name/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/unions/package-name/internal/time.go
+++ b/seed/go-sdk/unions/package-name/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/unions/v0/internal/time.go
+++ b/seed/go-sdk/unions/v0/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/unions/v0/internal/time.go
+++ b/seed/go-sdk/unions/v0/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/unions/v0/internal/time.go
+++ b/seed/go-sdk/unions/v0/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/unknown/internal/time.go
+++ b/seed/go-sdk/unknown/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/unknown/internal/time.go
+++ b/seed/go-sdk/unknown/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/unknown/internal/time.go
+++ b/seed/go-sdk/unknown/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/url-form-encoded/internal/time.go
+++ b/seed/go-sdk/url-form-encoded/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/url-form-encoded/internal/time.go
+++ b/seed/go-sdk/url-form-encoded/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/url-form-encoded/internal/time.go
+++ b/seed/go-sdk/url-form-encoded/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/validation/internal/time.go
+++ b/seed/go-sdk/validation/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/validation/internal/time.go
+++ b/seed/go-sdk/validation/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/validation/internal/time.go
+++ b/seed/go-sdk/validation/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/variables/internal/time.go
+++ b/seed/go-sdk/variables/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/variables/internal/time.go
+++ b/seed/go-sdk/variables/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/variables/internal/time.go
+++ b/seed/go-sdk/variables/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/version-no-default/internal/time.go
+++ b/seed/go-sdk/version-no-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/version-no-default/internal/time.go
+++ b/seed/go-sdk/version-no-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/version-no-default/internal/time.go
+++ b/seed/go-sdk/version-no-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/version/internal/time.go
+++ b/seed/go-sdk/version/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/version/internal/time.go
+++ b/seed/go-sdk/version/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/version/internal/time.go
+++ b/seed/go-sdk/version/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/webhook-audience/internal/time.go
+++ b/seed/go-sdk/webhook-audience/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/webhook-audience/internal/time.go
+++ b/seed/go-sdk/webhook-audience/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/webhook-audience/internal/time.go
+++ b/seed/go-sdk/webhook-audience/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/webhooks/internal/time.go
+++ b/seed/go-sdk/webhooks/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/webhooks/internal/time.go
+++ b/seed/go-sdk/webhooks/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/webhooks/internal/time.go
+++ b/seed/go-sdk/webhooks/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/websocket-bearer-auth/internal/time.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/websocket-bearer-auth/internal/time.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/websocket-bearer-auth/internal/time.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/websocket-inferred-auth/internal/time.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/websocket-inferred-auth/internal/time.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/websocket-inferred-auth/internal/time.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/websocket-multi-url/internal/time.go
+++ b/seed/go-sdk/websocket-multi-url/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/websocket-multi-url/internal/time.go
+++ b/seed/go-sdk/websocket-multi-url/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/websocket-multi-url/internal/time.go
+++ b/seed/go-sdk/websocket-multi-url/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/websocket/internal/time.go
+++ b/seed/go-sdk/websocket/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/websocket/internal/time.go
+++ b/seed/go-sdk/websocket/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/websocket/internal/time.go
+++ b/seed/go-sdk/websocket/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/go-sdk/x-fern-default/internal/time.go
+++ b/seed/go-sdk/x-fern-default/internal/time.go
@@ -143,6 +143,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	rfc3339NanoErr := err
 
+	// Fall back to ISO 8601 with fractional seconds, without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02T15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to ISO 8601 without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02T15:04:05", raw)
 	if err == nil {

--- a/seed/go-sdk/x-fern-default/internal/time.go
+++ b/seed/go-sdk/x-fern-default/internal/time.go
@@ -152,6 +152,23 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
+	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceTzErr := err
+
+	// Fall back to space-separated datetime without timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+	spaceNoTzErr := err
+
 	// Fall back to date-only format.
 	parsedTime, err = time.Parse("2006-01-02", raw)
 	if err == nil {
@@ -161,5 +178,5 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	dateOnlyErr := err
 
-	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, dateOnlyErr)
+	return fmt.Errorf("unable to parse datetime string %q: tried RFC3339Nano (%v), ISO8601 (%v), space-separated with tz (%v), space-separated (%v), date-only (%v)", raw, rfc3339NanoErr, iso8601Err, spaceTzErr, spaceNoTzErr, dateOnlyErr)
 }

--- a/seed/go-sdk/x-fern-default/internal/time.go
+++ b/seed/go-sdk/x-fern-default/internal/time.go
@@ -152,6 +152,13 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 	}
 	iso8601Err := err
 
+	// Fall back to space-separated datetime with fractional seconds and timezone offset.
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw)
+	if err == nil {
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
+
 	// Fall back to space-separated datetime with timezone offset (e.g. "2025-02-15 10:30:00+00:00").
 	parsedTime, err = time.Parse("2006-01-02 15:04:05Z07:00", raw)
 	if err == nil {
@@ -159,6 +166,14 @@ func (d *DateTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	spaceTzErr := err
+
+	// Fall back to space-separated datetime with fractional seconds, no timezone (assume UTC).
+	parsedTime, err = time.Parse("2006-01-02 15:04:05.999999999", raw)
+	if err == nil {
+		parsedTime = parsedTime.UTC()
+		*d = DateTime{t: &parsedTime}
+		return nil
+	}
 
 	// Fall back to space-separated datetime without timezone (assume UTC).
 	parsedTime, err = time.Parse("2006-01-02 15:04:05", raw)

--- a/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/alias/src/main/java/com/seed/alias/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/alias/src/main/java/com/seed/alias/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/allof-inline/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/allof-inline/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/allof/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/allof/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/api-wide-base-path-with-default/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/api-wide-base-path-with-default/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/basic-auth-pw-omitted/basic-auth-pw-omitted/src/main/java/com/seed/basicAuthPwOmitted/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/basic-auth-pw-omitted/basic-auth-pw-omitted/src/main/java/com/seed/basicAuthPwOmitted/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/bytes-download/src/main/java/com/seed/bytesDownload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/bytes-download/src/main/java/com/seed/bytesDownload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/circular-references-extends/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/circular-references-extends/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/cli-multi-spec-namespaced/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/cli-multi-spec-namespaced/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/cli-multi-spec/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/cli-multi-spec/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/dollar-string-examples/src/main/java/com/seed/dollarStringExamples/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/dollar-string-examples/src/main/java/com/seed/dollarStringExamples/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/endpoint-security-auth/src/main/java/com/seed/endpointSecurityAuth/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/endpoint-security-auth/src/main/java/com/seed/endpointSecurityAuth/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/errors/src/main/java/com/seed/errors/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/errors/src/main/java/com/seed/errors/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/core/DateTimeDeserializer.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -43,8 +44,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/folders/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/folders/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/header-auth-environment-variable/src/main/java/com/seed/headerTokenEnvironmentVariable/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/header-auth-environment-variable/src/main/java/com/seed/headerTokenEnvironmentVariable/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/idempotency-headers/src/main/java/com/seed/idempotencyHeaders/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/idempotency-headers/src/main/java/com/seed/idempotencyHeaders/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/imdb/omit-fern-headers/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/imdb/omit-fern-headers/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/inferred-auth-explicit/src/main/java/com/seed/inferredAuthExplicit/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/inferred-auth-explicit/src/main/java/com/seed/inferredAuthExplicit/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/inferred-auth-implicit-api-key/src/main/java/com/seed/inferredAuthImplicitApiKey/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/inferred-auth-implicit-api-key/src/main/java/com/seed/inferredAuthImplicitApiKey/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/inferred-auth-implicit-no-expiry/src/main/java/com/seed/inferredAuthImplicitNoExpiry/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/inferred-auth-implicit-no-expiry/src/main/java/com/seed/inferredAuthImplicitNoExpiry/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/inferred-auth-implicit-reference/src/main/java/com/seed/inferredAuthImplicit/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/inferred-auth-implicit-reference/src/main/java/com/seed/inferredAuthImplicit/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/inferred-auth-implicit/src/main/java/com/seed/inferredAuthImplicit/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/inferred-auth-implicit/src/main/java/com/seed/inferredAuthImplicit/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-default-timeout/default/src/main/java/com/seed/javaDefaultTimeout/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-default-timeout/default/src/main/java/com/seed/javaDefaultTimeout/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-idempotency-headers-file-upload/default/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-idempotency-headers-file-upload/default/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-many-properties/default/src/main/java/com/seed/manyProperties/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-many-properties/default/src/main/java/com/seed/manyProperties/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-output-directory/no-config/src/main/java/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-output-directory/no-config/src/main/java/core/DateTimeDeserializer.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -43,8 +44,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-output-directory/project-root/src/main/java/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-output-directory/project-root/src/main/java/core/DateTimeDeserializer.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -43,8 +44,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-output-directory/source-root/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-output-directory/source-root/core/DateTimeDeserializer.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -43,8 +44,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-path-param-key-conflict/default/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-path-param-key-conflict/default/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-staged-builder-ordering/src/main/java/com/seed/stagedBuilderOrdering/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-staged-builder-ordering/src/main/java/com/seed/stagedBuilderOrdering/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-websocket-shared-discriminator/src/main/java/com/seed/javaWebsocketSharedDiscriminator/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-websocket-shared-discriminator/src/main/java/com/seed/javaWebsocketSharedDiscriminator/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/java-with-property-conflict/default/src/main/java/com/seed/javaWithPropertyConflict/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/java-with-property-conflict/default/src/main/java/com/seed/javaWithPropertyConflict/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/license/src/main/java/com/seed/license/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/license/src/main/java/com/seed/license/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/literal-user-agent/src/main/java/com/seed/literalUserAgent/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/literal-user-agent/src/main/java/com/seed/literalUserAgent/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/literal/src/main/java/com/seed/literal/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/literal/src/main/java/com/seed/literal/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/multi-url-environment-reference/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/multi-url-environment-reference/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/no-content-response/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/no-content-response/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/no-retries/src/main/java/com/seed/noRetries/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/no-retries/src/main/java/com/seed/noRetries/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/null-type/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/null-type/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable-allof-extends/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable-allof-extends/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/main/java/com/seed/oauthClientCredentialsMandatoryAuth/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/main/java/com/seed/oauthClientCredentialsMandatoryAuth/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-openapi/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-openapi/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-reference/src/main/java/com/seed/oauthClientCredentialsReference/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-reference/src/main/java/com/seed/oauthClientCredentialsReference/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials/custom-interceptors/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials/custom-interceptors/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/object/src/main/java/com/seed/object/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/object/src/main/java/com/seed/object/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/openapi-request-body-ref/no-custom-config/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/openapi-request-body-ref/no-custom-config/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/optional/wire-tests/src/main/java/com/seed/objectsWithImports/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/optional/wire-tests/src/main/java/com/seed/objectsWithImports/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/pagination-uri-path/wire-tests/src/main/java/com/seed/paginationUriPath/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/pagination-uri-path/wire-tests/src/main/java/com/seed/paginationUriPath/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/query-param-name-conflict/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/query-param-name-conflict/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/schemaless-request-body-examples/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/schemaless-request-body-examples/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/server-sent-events-resumable/src/main/java/com/seed/serverSentEventsResumable/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/server-sent-events-resumable/src/main/java/com/seed/serverSentEventsResumable/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/undiscriminated-union-with-response-property/src/main/java/com/seed/undiscriminatedUnionWithResponseProperty/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/undiscriminated-union-with-response-property/src/main/java/com/seed/undiscriminatedUnionWithResponseProperty/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/unions-with-local-date/default/src/main/java/com/seed/unions/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/unions-with-local-date/default/src/main/java/com/seed/unions/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/url-form-encoded/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/url-form-encoded/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/validation/src/main/java/com/seed/validation/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/validation/src/main/java/com/seed/validation/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/variables/src/main/java/com/seed/variables/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/variables/src/main/java/com/seed/variables/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/webhook-audience/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/webhook-audience/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/webhooks/src/main/java/com/seed/webhooks/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/webhooks/src/main/java/com/seed/webhooks/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/websocket-multi-url/src/main/java/com/seed/websocketMultiUrl/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/websocket-multi-url/src/main/java/com/seed/websocketMultiUrl/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);

--- a/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/core/DateTimeDeserializer.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
@@ -42,8 +43,16 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
         if (token == JsonToken.VALUE_NUMBER_INT) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(parser.getValueAsLong()), ZoneOffset.UTC);
         } else {
-            TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                    parser.getValueAsString(), OffsetDateTime::from, LocalDateTime::from);
+            String value = parser.getValueAsString();
+            TemporalAccessor temporal;
+            try {
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value, OffsetDateTime::from, LocalDateTime::from);
+            } catch (DateTimeParseException e) {
+                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+            }
 
             if (temporal.query(TemporalQueries.offset()) == null) {
                 return LocalDateTime.from(temporal).atOffset(ZoneOffset.UTC);


### PR DESCRIPTION
## Description
Refs FER-11174

The Go and Java SDK generators now accept space-separated datetime strings (e.g. `"2025-02-15 10:30:00+00:00"`) during JSON deserialization, matching the leniency already present in Python and TypeScript SDKs.

## Changes Made

### Go v2 runtime (`generators/go-v2/base/src/asIs/internal/time.go_`)
Added four fallback formats to `DateTime.UnmarshalJSON`:
```go
// existing chain: RFC3339Nano → ISO 8601 no-tz → ... → date-only → epoch
// new additions (between ISO 8601 no-tz and date-only):
time.Parse("2006-01-02 15:04:05.999999999Z07:00", raw) // space + fractional + tz
time.Parse("2006-01-02 15:04:05Z07:00", raw)            // space + tz
time.Parse("2006-01-02 15:04:05.999999999", raw)         // space + fractional, UTC
time.Parse("2006-01-02 15:04:05", raw)                   // space, UTC
```
Zero perf impact on the happy path — standard RFC3339 strings still parse on the first `time.Parse(time.RFC3339Nano, raw)` call. Fractional-second variants tried first so `"2025-02-15 10:30:00.123+00:00"` works too (matching Java's `ISO_DATE_TIME`).

### Java runtime (`generators/java/generator-utils/src/main/resources/DateTimeDeserializer.java`)
Added try/catch fallback: if `DateTimeFormatter.ISO_DATE_TIME` fails, replace space with `T` and retry:
```java
try {
    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, ...);
} catch (DateTimeParseException e) {
    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value.replace(' ', 'T'), ...);
}
```

### Go v1 internal copies
Updated `generators/go/internal/generator/model/internal/time.go` and `generators/go/internal/fern/ir/internal/time.go` for consistency.

### Seed output
- All 152 Go SDK fixture `internal/time.go` files updated
- All 177 Java SDK fixture `DateTimeDeserializer.java` files updated

## Testing
- [x] Go SDK exhaustive seed: 2/2 test cases passed locally
- [x] Manual review: No impact on standard RFC3339 parsing (first-try parse succeeds)
- [ ] Full CI seed validation

Link to Devin session: https://app.devin.ai/sessions/47aa9772f8604cf39516ed89a6fb7dac
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->