### PR TITLE
chore(php): document IR dependency for api-wide-base-path-with-default allowed failure

### DIFF
--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -182,7 +182,12 @@ scripts:
       test:
         - composer test
 allowedFailures:
-  # Dynamic snippet: default-valued base-path param ordered before request body.
+  # Dynamic snippet: a base-path parameter with a clientDefault is optional in the
+  # generated SDK and is ordered after the request body, but the snippet emits it as a
+  # required argument before the body, producing a type mismatch. Fixing this requires the
+  # dynamic IR to carry the parameter's `clientDefault` (it currently drops the field), which
+  # is an additive IR change that must ship via the separate IR-publish flow before the
+  # generator can consume it. Tracked separately; left here until the IR change lands.
   - api-wide-base-path-with-default
   # Wire test: path param request failures unrelated to dynamic snippets.
   - exhaustive:wire-tests


### PR DESCRIPTION
## Description

Per the decision to leave `api-wide-base-path-with-default` in `allowedFailures` (option B), this expands the inline comment in `seed/php-sdk/seed.yml` to document *why* the fixture stays exempt and what is required to fix it.

The fixture fails because a base-path parameter with a `clientDefault` is optional in the generated SDK and ordered **after** the request body, but the dynamic snippet emits it as a **required** argument **before** the body. The only signal that would let the snippet mirror the SDK ordering is the parameter's `clientDefault`, which the published dynamic IR SDK currently drops. Carrying it through is an additive IR change that must ship via the separate IR-publish flow before the generator can consume it — so it is not a self-contained generator fix.

No behavior change; comment only.

## Changes Made
- Expanded the `allowedFailures` comment for `api-wide-base-path-with-default` in `seed/php-sdk/seed.yml`

## Testing
- [ ] N/A — comment-only change, no generated output affected

Link to Devin session: https://app.devin.ai/sessions/061e09e6d9bf4b7dbb24899b3bb9b9a2
Requested by: @iamnamananand996