### PR TITLE
fix(swift): map literal parameters to correct types

### DIFF
--- a/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
+++ b/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
@@ -6,12 +6,16 @@ import {
 } from "@fern-api/base-generator";
 import { assertDefined, assertNever, entries } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { BaseSwiftCustomConfigSchema, Referencer, swift, UndiscriminatedUnion } from "@fern-api/swift-codegen";
+import { BaseSwiftCustomConfigSchema, NameRegistry, Referencer, swift, UndiscriminatedUnion } from "@fern-api/swift-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { AsIsFileDefinition, SourceAsIsFiles, TestAsIsFiles } from "../AsIs.js";
 import { SwiftProject } from "../project/index.js";
 import { CycleDetector } from "./cycle-detector.js";
-import { registerLiteralEnums, registerLiteralEnumsForObjectProperties } from "./register-literal-enums.js";
+import {
+    registerLiteralEnums,
+    registerLiteralEnumsForObjectProperties,
+    registerLiteralEnumsForTypeReference
+} from "./register-literal-enums.js";
 import { registerUndiscriminatedUnionVariants } from "./register-undiscriminated-unions.js";
 
 export abstract class AbstractSwiftGeneratorContext<
@@ -156,12 +160,52 @@ export abstract class AbstractSwiftGeneratorContext<
             });
         });
         Object.entries(ir.subpackages).forEach(([subpackageId, subpackage]) => {
-            nameRegistry.registerSubClientSymbol({
+            const subClientSymbol = nameRegistry.registerSubClientSymbol({
                 subpackageId,
                 fernFilepathPartNamesPascalCase: subpackage.fernFilepath.allParts.map((name) =>
                     this.caseConverter.pascalUnsafe(name)
                 ),
                 subpackageNamePascalCase: this.caseConverter.pascalUnsafe(subpackage.name)
+            });
+            if (subpackage.service != null) {
+                this.registerEndpointParameterLiteralEnums({
+                    parentSymbol: subClientSymbol,
+                    service: ir.services[subpackage.service],
+                    registry: nameRegistry
+                });
+            }
+        });
+        if (ir.rootPackage.service != null) {
+            this.registerEndpointParameterLiteralEnums({
+                parentSymbol: nameRegistry.getRootClientSymbolOrThrow(),
+                service: ir.services[ir.rootPackage.service],
+                registry: nameRegistry
+            });
+        }
+    }
+
+    /**
+     * Inline literal query parameters become method parameters on the generated client, so their
+     * literal enums must be registered under the owning client symbol (matching the scope used to
+     * resolve the parameter's Swift type). Otherwise the parameter falls back to `JSONValue` while
+     * snippets and wire tests emit the literal enum case, producing a type mismatch.
+     */
+    private registerEndpointParameterLiteralEnums({
+        parentSymbol,
+        service,
+        registry
+    }: {
+        parentSymbol: swift.Symbol;
+        service: FernIr.HttpService | undefined;
+        registry: NameRegistry;
+    }): void {
+        service?.endpoints.forEach((endpoint) => {
+            endpoint.queryParameters.forEach((queryParam) => {
+                registerLiteralEnumsForTypeReference({
+                    parentSymbol,
+                    registry,
+                    typeReference: queryParam.valueType
+                });
             });
         });
     }
@@ -282,7 +326,7 @@ export abstract class AbstractSwiftGeneratorContext<
                 return typeReference.container._visit({
                     literal: (literal) =>
                         literal._visit({
-                            boolean: () => referencer.referenceAsIsType("JSONValue"),
+                            boolean: () => referencer.referenceSwiftType("Bool"),
                             string: (literalValue) => {
                                 const symbol = this.project.nameRegistry.getNestedLiteralEnumSymbol(
                                     fromSymbol,

--- a/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
+++ b/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
@@ -6,7 +6,13 @@ import {
 } from "@fern-api/base-generator";
 import { assertDefined, assertNever, entries } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { BaseSwiftCustomConfigSchema, NameRegistry, Referencer, swift, UndiscriminatedUnion } from "@fern-api/swift-codegen";
+import {
+    BaseSwiftCustomConfigSchema,
+    NameRegistry,
+    Referencer,
+    swift,
+    UndiscriminatedUnion
+} from "@fern-api/swift-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { AsIsFileDefinition, SourceAsIsFiles, TestAsIsFiles } from "../AsIs.js";
 import { SwiftProject } from "../project/index.js";

--- a/generators/swift/codegen/src/ast/Class.ts
+++ b/generators/swift/codegen/src/ast/Class.ts
@@ -2,6 +2,7 @@ import { escapeReservedKeyword } from "../syntax/index.js";
 import { AccessLevel } from "./AccessLevel.js";
 import { AstNode, Writer } from "./core/index.js";
 import { DocComment } from "./DocComment.js";
+import { EnumWithRawValues } from "./EnumWithRawValues.js";
 import { Initializer } from "./Initializer.js";
 import { Method } from "./Method.js";
 import { Property } from "./Property.js";
@@ -16,6 +17,7 @@ export declare namespace Class {
         properties: Property[];
         initializers?: Initializer[];
         methods?: Method[];
+        nestedTypes?: EnumWithRawValues[];
         docs?: DocComment;
     }
 }
@@ -28,6 +30,7 @@ export class Class extends AstNode {
     public readonly properties: Property[];
     public readonly initializers: Initializer[];
     public readonly methods: Method[];
+    public readonly nestedTypes: EnumWithRawValues[];
     public readonly docs?: DocComment;
 
     public constructor({
@@ -38,6 +41,7 @@ export class Class extends AstNode {
         properties,
         initializers,
         methods,
+        nestedTypes,
         docs
     }: Class.Args) {
         super();
@@ -48,6 +52,7 @@ export class Class extends AstNode {
         this.properties = properties;
         this.initializers = initializers ?? [];
         this.methods = methods ?? [];
+        this.nestedTypes = nestedTypes ?? [];
         this.docs = docs;
     }
 
@@ -95,6 +100,16 @@ export class Class extends AstNode {
                     writer.newLine();
                 }
                 method.write(writer);
+                writer.newLine();
+            });
+        }
+        if (this.nestedTypes.length > 0) {
+            writer.newLine();
+            this.nestedTypes.forEach((nestedType, nestedTypeIdx) => {
+                if (nestedTypeIdx > 0) {
+                    writer.newLine();
+                }
+                nestedType.write(writer);
                 writer.newLine();
             });
         }

--- a/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -164,12 +164,12 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
             list: (ref) => swift.TypeReference.array(this.getSwiftTypeReferenceFromScope(ref.value, fromSymbol)),
             literal: (ref) => {
                 return visitDiscriminatedUnion(ref.value, "type")._visit({
-                    boolean: () => referencer.referenceAsIsType("JSONValue"),
+                    boolean: () => referencer.referenceSwiftType("Bool"),
                     string: (literalType) => {
-                        const symbol = this.nameRegistry.getNestedLiteralEnumSymbolOrThrow(
-                            fromSymbol,
-                            literalType.value
-                        );
+                        const symbol = this.nameRegistry.getNestedLiteralEnumSymbol(fromSymbol, literalType.value);
+                        if (symbol == null) {
+                            return referencer.referenceAsIsType("JSONValue");
+                        }
                         return referencer.referenceType(symbol);
                     },
                     _other: () => referencer.referenceAsIsType("JSONValue")

--- a/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -9,7 +9,11 @@ import { BaseSwiftCustomConfigSchema, NameRegistry, Referencer, swift } from "@f
 import { pascalCase } from "../util/pascal-case.js";
 import { DynamicTypeLiteralMapper } from "./DynamicTypeLiteralMapper.js";
 import { FilePropertyMapper } from "./FilePropertyMapper.js";
-import { registerLiteralEnums, registerLiteralEnumsForObjectProperties } from "./register-literal-enums.js";
+import {
+    registerLiteralEnums,
+    registerLiteralEnumsForObjectProperties,
+    registerLiteralEnumsForTypeReference
+} from "./register-literal-enums.js";
 import { registerUndiscriminatedUnionVariants } from "./register-undiscriminated-unions.js";
 
 export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGeneratorContext {
@@ -131,6 +135,17 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
                         requestNamePascalCase: endpoint.request.declaration.name.pascalCase.unsafeName
                     });
                 }
+                // Inline literal query parameters are resolved against the source module symbol
+                // (see EndpointSnippetGenerator.getEndpointMethodQueryParameters), so their literal
+                // enums must be registered under that same scope. This mirrors the SDK generator's
+                // AbstractSwiftGeneratorContext, which registers them under the owning client symbol.
+                endpoint.request.queryParameters?.forEach((queryParameter) => {
+                    registerLiteralEnumsForTypeReference({
+                        parentSymbol: registeredSourceModuleSymbol,
+                        registry: nameRegistry,
+                        typeReference: queryParameter.typeReference
+                    });
+                });
             }
         });
 

--- a/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -323,13 +323,30 @@ export class DynamicTypeLiteralMapper {
         value: unknown;
     }): swift.Expression {
         const symbol = this.context.nameRegistry.getSchemaTypeSymbolOrThrow(typeId);
+        const exampleProperties = this.context.getExampleObjectProperties({
+            parameters: object_.properties,
+            snippetObject: value
+        });
+        const examplePropertiesByWireValue = new Map(
+            exampleProperties.map((typeInstance) => [typeInstance.name.wireValue, typeInstance])
+        );
+        // Literal properties are constants that the generated initializer always requires, so emit
+        // them in declaration order even when the example omits them.
+        const orderedProperties = object_.properties
+            .map((property) => {
+                const exampleProperty = examplePropertiesByWireValue.get(property.name.wireValue);
+                if (exampleProperty != null) {
+                    return exampleProperty;
+                }
+                if (property.typeReference.type === "literal") {
+                    return { name: property.name, typeReference: property.typeReference, value: undefined };
+                }
+                return null;
+            })
+            .filter((typeInstance) => typeInstance != null);
         return swift.Expression.structInitialization({
             unsafeName: symbol.name,
-            arguments_: this.context
-                .getExampleObjectProperties({
-                    parameters: object_.properties,
-                    snippetObject: value
-                })
+            arguments_: orderedProperties
                 .map((typeInstance) => {
                     const expression = this.convert({
                         fromSymbol,
@@ -341,11 +358,7 @@ export class DynamicTypeLiteralMapper {
                     }
                     return swift.functionArgument({
                         label: sanitizeSwiftIdentifier(typeInstance.name.name.camelCase.unsafeName),
-                        value: this.convert({
-                            fromSymbol,
-                            typeReference: typeInstance.typeReference,
-                            value: typeInstance.value
-                        })
+                        value: expression
                     });
                 })
                 .filter((argument) => argument != null),

--- a/generators/swift/sdk/changes/unreleased/fix-literal-query-parameters.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-literal-query-parameters.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed inline literal query parameters so they are typed correctly in the
+    generated client method instead of falling back to the placeholder
+    `JSONValue`. A boolean literal now maps to `Bool` and a string literal maps
+    to a dedicated literal enum nested on the owning client. Previously the
+    parameter was typed as `JSONValue` while the generated snippets and wire
+    tests emitted the literal enum case, causing a type mismatch that failed to
+    compile.
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-plain-text-response-type.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-plain-text-response-type.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed endpoints that return a `text/plain` response so the generated method
+    returns `String` instead of the placeholder `JSONValue`. The HTTP client
+    already decodes a `String` response type from the raw UTF-8 body, so the
+    generated wire tests now compile and pass (previously `response == "string"`
+    failed because the response was typed as `JSONValue`).
+  type: fix

--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -187,7 +187,7 @@ export class EndpointMethodGenerator {
             json: (resp) =>
                 this.sdkGeneratorContext.getSwiftTypeReferenceFromScope(resp.responseBodyType, this.parentClassSymbol),
             fileDownload: () => this.referencer.referenceFoundationType("Data"),
-            text: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle text responses
+            text: () => this.referencer.referenceSwiftType("String"),
             bytes: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle bytes responses
             streaming: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle streaming responses
             streamParameter: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle stream parameter responses

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -1,6 +1,7 @@
 import { getWireValue } from "@fern-api/base-generator";
 import { assertNever, visitDiscriminatedUnion } from "@fern-api/core-utils";
 import { Referencer, swift } from "@fern-api/swift-codegen";
+import { LiteralEnumGenerator } from "@fern-api/swift-model";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
@@ -114,11 +115,20 @@ export class RootClientGenerator {
             ],
             initializers: this.generateInitializers(),
             methods: this.generateMethods(),
+            nestedTypes: this.generateNestedLiteralEnums(),
             docs: swift.docComment({
                 summary:
                     "Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions."
             })
         });
+    }
+
+    private generateNestedLiteralEnums(): swift.EnumWithRawValues[] {
+        return this.sdkGeneratorContext.project.nameRegistry
+            .getAllNestedLiteralEnumSymbolsOrThrow(this.symbol)
+            .map(({ symbol, literalValue }) =>
+                new LiteralEnumGenerator({ name: symbol.name, literalValue }).generate()
+            );
     }
 
     private generateInitializers(): swift.Initializer[] {

--- a/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
@@ -1,4 +1,5 @@
 import { Referencer, swift } from "@fern-api/swift-codegen";
+import { LiteralEnumGenerator } from "@fern-api/swift-model";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
@@ -48,8 +49,17 @@ export class SubClientGenerator {
                 this.clientGeneratorContext.httpClient.property
             ],
             initializers: [this.generateInitializer()],
-            methods: this.generateMethods()
+            methods: this.generateMethods(),
+            nestedTypes: this.generateNestedLiteralEnums()
         });
+    }
+
+    private generateNestedLiteralEnums(): swift.EnumWithRawValues[] {
+        return this.sdkGeneratorContext.project.nameRegistry
+            .getAllNestedLiteralEnumSymbolsOrThrow(this.symbol)
+            .map(({ symbol, literalValue }) =>
+                new LiteralEnumGenerator({ name: symbol.name, literalValue }).generate()
+            );
     }
 
     private generateInitializer(): swift.Initializer {

--- a/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
@@ -205,16 +205,7 @@ export class WireTestFunctionGenerator {
                         return literalContainer.literal._visit({
                             string: (val) =>
                                 swift.Expression.enumCaseShorthand(LiteralEnum.generateEnumCaseLabel(val.original)),
-                            boolean: (val) =>
-                                swift.Expression.methodCall({
-                                    target: swift.Expression.reference("JSONValue"),
-                                    methodName: "bool",
-                                    arguments_: [
-                                        swift.functionArgument({
-                                            value: swift.Expression.boolLiteral(val)
-                                        })
-                                    ]
-                                }),
+                            boolean: (val) => swift.Expression.boolLiteral(val),
                             integer: () => swift.Expression.nop(),
                             uint: () => swift.Expression.nop(),
                             uint64: () => swift.Expression.nop(),
@@ -559,7 +550,7 @@ export class WireTestFunctionGenerator {
                                     .createReferencer(fromScope)
                                     .referenceType(literalEnumSymbol);
                             },
-                            boolean: () => this.referencer.referenceAsIsType("JSONValue"),
+                            boolean: () => this.referencer.referenceSwiftType("Bool"),
                             integer: () => this.referencer.referenceAsIsType("JSONValue"),
                             uint: () => this.referencer.referenceAsIsType("JSONValue"),
                             uint64: () => this.referencer.referenceAsIsType("JSONValue"),

--- a/seed/swift-sdk/literal/Sources/Requests/Requests+SendLiteralsInlinedRequest.swift
+++ b/seed/swift-sdk/literal/Sources/Requests/Requests+SendLiteralsInlinedRequest.swift
@@ -6,7 +6,7 @@ extension Requests {
         public let context: YoureSuperWise?
         public let query: String
         public let temperature: Double?
-        public let stream: JSONValue
+        public let stream: Bool
         public let aliasedContext: SomeAliasedLiteral
         public let maybeContext: SomeAliasedLiteral?
         public let objectWithLiteral: ATopLevelLiteral
@@ -18,7 +18,7 @@ extension Requests {
             context: YoureSuperWise? = nil,
             query: String,
             temperature: Double? = nil,
-            stream: JSONValue,
+            stream: Bool,
             aliasedContext: SomeAliasedLiteral,
             maybeContext: SomeAliasedLiteral? = nil,
             objectWithLiteral: ATopLevelLiteral,
@@ -41,7 +41,7 @@ extension Requests {
             self.context = try container.decodeIfPresent(YoureSuperWise.self, forKey: .context)
             self.query = try container.decode(String.self, forKey: .query)
             self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.aliasedContext = try container.decode(SomeAliasedLiteral.self, forKey: .aliasedContext)
             self.maybeContext = try container.decodeIfPresent(SomeAliasedLiteral.self, forKey: .maybeContext)
             self.objectWithLiteral = try container.decode(ATopLevelLiteral.self, forKey: .objectWithLiteral)

--- a/seed/swift-sdk/literal/Sources/Resources/Query/QueryClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Query/QueryClient.swift
@@ -7,23 +7,27 @@ public final class QueryClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(prompt: JSONValue, optionalPrompt: JSONValue? = nil, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt? = nil, query: String, stream: JSONValue, optionalStream: JSONValue? = nil, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream? = nil, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
+    public func send(prompt: YouAreAHelpfulAssistant, optionalPrompt: YouAreAHelpfulAssistant? = nil, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt? = nil, query: String, stream: Bool, optionalStream: Bool? = nil, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream? = nil, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/query",
             queryParams: [
-                "prompt": .unknown(prompt), 
-                "optional_prompt": optionalPrompt.map { .unknown($0) }, 
-                "alias_prompt": .unknown(aliasPrompt), 
+                "prompt": .string(prompt.rawValue), 
+                "optional_prompt": optionalPrompt.map { .string($0.rawValue) }, 
+                "alias_prompt": .string(aliasPrompt.rawValue), 
                 "alias_optional_prompt": aliasOptionalPrompt.map { .unknown($0) }, 
                 "query": .string(query), 
-                "stream": .unknown(stream), 
-                "optional_stream": optionalStream.map { .unknown($0) }, 
-                "alias_stream": .unknown(aliasStream), 
+                "stream": .bool(stream), 
+                "optional_stream": optionalStream.map { .bool($0) }, 
+                "alias_stream": .bool(aliasStream), 
                 "alias_optional_stream": aliasOptionalStream.map { .unknown($0) }
             ],
             requestOptions: requestOptions,
             responseType: SendResponse.self
         )
+    }
+
+    public enum YouAreAHelpfulAssistant: String, Codable, Hashable, CaseIterable, Sendable {
+        case youAreAHelpfulAssistant = "You are a helpful assistant"
     }
 }

--- a/seed/swift-sdk/literal/Sources/Schemas/AliasToStream.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/AliasToStream.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-public typealias AliasToStream = JSONValue
+public typealias AliasToStream = Bool

--- a/seed/swift-sdk/literal/Sources/Schemas/DiscriminatedLiteral.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/DiscriminatedLiteral.swift
@@ -4,7 +4,7 @@ public enum DiscriminatedLiteral: Codable, Hashable, Sendable {
     case customName(String)
     case defaultName(Bob)
     case george(Bool)
-    case literalGeorge(JSONValue)
+    case literalGeorge(Bool)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -17,7 +17,7 @@ public enum DiscriminatedLiteral: Codable, Hashable, Sendable {
         case "george":
             self = .george(try container.decode(Bool.self, forKey: .value))
         case "literalGeorge":
-            self = .literalGeorge(try container.decode(JSONValue.self, forKey: .value))
+            self = .literalGeorge(try container.decode(Bool.self, forKey: .value))
         default:
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(

--- a/seed/swift-sdk/literal/Sources/Schemas/SendRequest.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/SendRequest.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct SendRequest: Codable, Hashable, Sendable {
     public let prompt: YouAreAHelpfulAssistant
     public let query: String
-    public let stream: JSONValue
+    public let stream: Bool
     public let ending: Ending
     public let context: SomeLiteral
     public let maybeContext: SomeLiteral?
@@ -14,7 +14,7 @@ public struct SendRequest: Codable, Hashable, Sendable {
     public init(
         prompt: YouAreAHelpfulAssistant,
         query: String,
-        stream: JSONValue,
+        stream: Bool,
         ending: Ending,
         context: SomeLiteral,
         maybeContext: SomeLiteral? = nil,
@@ -35,7 +35,7 @@ public struct SendRequest: Codable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.prompt = try container.decode(YouAreAHelpfulAssistant.self, forKey: .prompt)
         self.query = try container.decode(String.self, forKey: .query)
-        self.stream = try container.decode(JSONValue.self, forKey: .stream)
+        self.stream = try container.decode(Bool.self, forKey: .stream)
         self.ending = try container.decode(Ending.self, forKey: .ending)
         self.context = try container.decode(SomeLiteral.self, forKey: .context)
         self.maybeContext = try container.decodeIfPresent(SomeLiteral.self, forKey: .maybeContext)

--- a/seed/swift-sdk/literal/Sources/Schemas/SendResponse.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/SendResponse.swift
@@ -3,14 +3,14 @@ import Foundation
 public struct SendResponse: Codable, Hashable, Sendable {
     public let message: String
     public let status: Int
-    public let success: JSONValue
+    public let success: Bool
     /// Additional properties that are not explicitly defined in the schema
     public let additionalProperties: [String: JSONValue]
 
     public init(
         message: String,
         status: Int,
-        success: JSONValue,
+        success: Bool,
         additionalProperties: [String: JSONValue] = .init()
     ) {
         self.message = message
@@ -23,7 +23,7 @@ public struct SendResponse: Codable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.message = try container.decode(String.self, forKey: .message)
         self.status = try container.decode(Int.self, forKey: .status)
-        self.success = try container.decode(JSONValue.self, forKey: .success)
+        self.success = try container.decode(Bool.self, forKey: .success)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 

--- a/seed/swift-sdk/literal/Sources/Schemas/UndiscriminatedLiteral.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/UndiscriminatedLiteral.swift
@@ -3,7 +3,6 @@ import Foundation
 public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
     case bool(Bool)
     case ending(Ending)
-    case jsonValue(JSONValue)
     case string(String)
     case value(Value)
 
@@ -13,8 +12,6 @@ public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
             self = .bool(value)
         } else if let value = try? container.decode(Ending.self) {
             self = .ending(value)
-        } else if let value = try? container.decode(JSONValue.self) {
-            self = .jsonValue(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
         } else if let value = try? container.decode(Value.self) {
@@ -33,8 +30,6 @@ public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
         case .bool(let value):
             try container.encode(value)
         case .ending(let value):
-            try container.encode(value)
-        case .jsonValue(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)

--- a/seed/swift-sdk/literal/Tests/Snippets/Example8.swift
+++ b/seed/swift-sdk/literal/Tests/Snippets/Example8.swift
@@ -9,6 +9,7 @@ enum Example8 {
             prompt: .youAreAHelpfulAssistant,
             query: "What is the weather today",
             stream: false,
+            ending: .ending,
             context: .youreSuperWise,
             containerObject: ContainerObject(
                 nestedObjects: [

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Headers/HeadersClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Headers/HeadersClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.headers.send(
             request: .init(query: "What is the weather today"),
@@ -52,7 +52,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.headers.send(
             request: .init(query: "query"),

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Inlined/InlinedClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Inlined/InlinedClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.inlined.send(
             request: .init(
@@ -65,7 +65,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.inlined.send(
             request: .init(

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Path/PathClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Path/PathClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.path.send(
             id: "123",
@@ -52,7 +52,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.path.send(
             id: "123",

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Query/QueryClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Query/QueryClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.query.send(
             prompt: .youAreAHelpfulAssistant,
@@ -60,7 +60,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.query.send(
             prompt: .youAreAHelpfulAssistant,

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Reference/ReferenceClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Reference/ReferenceClientWireTests.swift
@@ -23,13 +23,14 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.reference.send(
             request: SendRequest(
                 prompt: .youAreAHelpfulAssistant,
                 query: "What is the weather today",
                 stream: false,
+                ending: .ending,
                 context: .youreSuperWise,
                 containerObject: ContainerObject(
                     nestedObjects: [
@@ -66,7 +67,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.reference.send(
             request: SendRequest(

--- a/seed/swift-sdk/literal/reference.md
+++ b/seed/swift-sdk/literal/reference.md
@@ -187,7 +187,7 @@ try await main()
 </details>
 
 ## Query
-<details><summary><code>client.query.<a href="/Sources/Resources/Query/QueryClient.swift">send</a>(prompt: JSONValue, optionalPrompt: JSONValue?, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt?, query: String, stream: JSONValue, optionalStream: JSONValue?, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream?, requestOptions: RequestOptions?) -> SendResponse</code></summary>
+<details><summary><code>client.query.<a href="/Sources/Resources/Query/QueryClient.swift">send</a>(prompt: JSONValue, optionalPrompt: JSONValue?, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt?, query: String, stream: Bool, optionalStream: Bool?, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream?, requestOptions: RequestOptions?) -> SendResponse</code></summary>
 <dl>
 <dd>
 
@@ -274,7 +274,7 @@ try await main()
 <dl>
 <dd>
 
-**stream:** `JSONValue` 
+**stream:** `Bool` 
     
 </dd>
 </dl>
@@ -282,7 +282,7 @@ try await main()
 <dl>
 <dd>
 
-**optionalStream:** `JSONValue?` 
+**optionalStream:** `Bool?` 
     
 </dd>
 </dl>
@@ -342,6 +342,7 @@ private func main() async throws {
         prompt: .youAreAHelpfulAssistant,
         query: "What is the weather today",
         stream: false,
+        ending: .ending,
         context: .youreSuperWise,
         containerObject: ContainerObject(
             nestedObjects: [

--- a/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
@@ -7,12 +7,12 @@ public final class ServiceClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getText(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func getText(requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/text",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: String.self
         )
     }
 }

--- a/seed/swift-sdk/plain-text/reference.md
+++ b/seed/swift-sdk/plain-text/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Service
-<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getText</a>(requestOptions: RequestOptions?) -> JSONValue</code></summary>
+<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getText</a>(requestOptions: RequestOptions?) -> String</code></summary>
 <dl>
 <dd>
 

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -133,7 +133,6 @@ allowedFailures:
   - examples:no-custom-config
   - examples:readme-config
   - exhaustive
-  - literal
   - multi-url-environment
   - multi-url-environment-no-default
   - multi-url-environment-reference

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -140,7 +140,6 @@ allowedFailures:
   - nullable:no-custom-config
   - nullable:nullable-as-optional
   - oauth-client-credentials-with-variables
-  - plain-text
   - query-parameters
   - request-parameters
   - streaming

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionStreamRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionStreamRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response. This field is nullable (OAS 3.1 type array), which previously caused the const literal to be overwritten by the nullable type during spread in the importer.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionStreamRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionStreamRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response. This field is nullable (OAS 3.1 type array), which previously caused the const literal to be overwritten by the nullable type during spread in the importer.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaRequest.swift
@@ -7,14 +7,14 @@ extension Requests {
         /// The model to use.
         public let model: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             prompt: String,
             model: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.prompt = prompt
@@ -27,7 +27,7 @@ extension Requests {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.prompt = try container.decode(String.self, forKey: .prompt)
             self.model = try container.decode(String.self, forKey: .model)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaStreamRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaStreamRequest.swift
@@ -7,14 +7,14 @@ extension Requests {
         /// The model to use.
         public let model: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             prompt: String,
             model: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.prompt = prompt
@@ -27,7 +27,7 @@ extension Requests {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.prompt = try container.decode(String.self, forKey: .prompt)
             self.model = try container.decode(String.self, forKey: .model)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/streaming/Sources/Requests/Requests+GenerateStreamRequest.swift
+++ b/seed/swift-sdk/streaming/Sources/Requests/Requests+GenerateStreamRequest.swift
@@ -2,13 +2,13 @@ import Foundation
 
 extension Requests {
     public struct GenerateStreamRequest: Codable, Hashable, Sendable {
-        public let stream: JSONValue
+        public let stream: Bool
         public let numEvents: Int
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
-            stream: JSONValue,
+            stream: Bool,
             numEvents: Int,
             additionalProperties: [String: JSONValue] = .init()
         ) {
@@ -19,7 +19,7 @@ extension Requests {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.numEvents = try container.decode(Int.self, forKey: .numEvents)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }

--- a/seed/swift-sdk/streaming/Sources/Requests/Requests+Generateequest.swift
+++ b/seed/swift-sdk/streaming/Sources/Requests/Requests+Generateequest.swift
@@ -2,13 +2,13 @@ import Foundation
 
 extension Requests {
     public struct Generateequest: Codable, Hashable, Sendable {
-        public let stream: JSONValue
+        public let stream: Bool
         public let numEvents: Int
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
-            stream: JSONValue,
+            stream: Bool,
             numEvents: Int,
             additionalProperties: [String: JSONValue] = .init()
         ) {
@@ -19,7 +19,7 @@ extension Requests {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.numEvents = try container.decode(Int.self, forKey: .numEvents)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }


### PR DESCRIPTION
## Description

Inline literal query parameters were typed as the placeholder `JSONValue` in the generated client method, while the generated snippets and wire tests emitted the literal value (a `Bool` or a literal-enum case). This type mismatch failed to compile, so the `literal` fixture stayed in `allowedFailures`.

Two distinct problems:

1. **Boolean literals** resolved to `JSONValue` instead of `Bool` (in request bodies, query params, and discriminated-union variants).
2. **String literals** on endpoint query parameters had no literal enum registered under an accessible scope. Literal enums are only registered under schema / request-type symbols, but query-param types are resolved against the owning *client* symbol — so the lookup missed and fell back to `JSONValue`.

### Fix

- Register literal enums for endpoint query parameters under the owning client symbol (sub-client and root-client) during symbol registration, matching the scope used to resolve the parameter's Swift type.
- Generate those literal enums as nested enums on the client class, e.g.:

```swift
public final class QueryClient: Sendable {
    public func send(prompt: YouAreAHelpfulAssistant, /* ... */) async throws -> SendResponse {
        // ... queryParams: ["prompt": .string(prompt.rawValue), ...]
    }

    public enum YouAreAHelpfulAssistant: String, Codable, Hashable, CaseIterable, Sendable {
        case youAreAHelpfulAssistant = "You are a helpful assistant"
    }
}
```

- Add `nestedTypes` support to the `Class` AST node (mirrors the existing support on `Struct`).
- Boolean literals now map to `Bool` everywhere (request bodies, query params, union variants).

Before/after for the `QueryClient.send` signature:

```diff
-    public func send(prompt: JSONValue, optionalPrompt: JSONValue? = nil, ... stream: Bool, ...)
+    public func send(prompt: YouAreAHelpfulAssistant, optionalPrompt: YouAreAHelpfulAssistant? = nil, ... stream: Bool, ...)
```

## Changes Made
- `Class` AST node: add `nestedTypes` (rendered inside the class body like `Struct`).
- `AbstractSwiftGeneratorContext`: register literal enums for endpoint query parameters under the sub-client / root-client symbols.
- `RootClientGenerator` / `SubClientGenerator`: emit the registered nested literal enums on the generated client class.
- Boolean literal type mapping fixes in snippet/wire-test/type-resolution paths.
- Removed `literal` from `seed/swift-sdk/seed.yml` `allowedFailures`.
- Regenerated `literal` fixture; updated `streaming` and `server-sent-events-openapi` snapshots (boolean-literal `JSONValue` → `Bool`, both remain `allowedFailures`).
- Added changelog entry.

## Testing
- [x] `literal` fixture compiles and all 30 wire/snippet tests pass via `swift test -c release` in Docker (`swift:6.1.2`).
- [x] Swift generator unit tests pass (175 codegen + 33 dynamic-snippets + 31 sdk + 14 model).
- [x] Regenerated all 133 other swift-sdk fixtures — no source regressions (only `streaming`/`sse` allowedFailures gained the correct `Bool` typing).
- [x] `pnpm run check` (biome) clean.

Stacked on #16494.

Link to Devin session: https://app.devin.ai/sessions/24c6efc2110b4c8ead19d72f7fe013b2
Requested by: @iamnamananand996