### PR TITLE
fix(php): serialize boolean path params and skip bytes-body wire tests

### DIFF
--- a/generators/php/sdk/changes/unreleased/fix-wire-test-boolean-path-and-bytes-endpoint.yml
+++ b/generators/php/sdk/changes/unreleased/fix-wire-test-boolean-path-and-bytes-endpoint.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Serialize boolean path parameters as "true"/"false" instead of relying on PHP's
+    string coercion (which renders them as "1"/""), producing valid URLs.
+  type: fix
+- summary: |
+    Skip bytes request body endpoints when generating wire tests, matching the WireMock
+    stub generator which omits them. Previously the generated test called an endpoint with
+    no matching stub and failed.
+  type: fix

--- a/generators/php/sdk/src/core/RawClient.ts
+++ b/generators/php/sdk/src/core/RawClient.ts
@@ -77,10 +77,10 @@ export class RawClient {
             {
                 name: "path",
                 assignment: php.codeblock(
-                    `"${this.getPathString({
+                    this.getPathString({
                         endpoint: args.endpoint,
                         pathParameterReferences: args.pathParameterReferences ?? {}
-                    })}"`
+                    })
                 )
             },
             {
@@ -132,7 +132,12 @@ export class RawClient {
         endpoint: FernIr.HttpEndpoint;
         pathParameterReferences: Record<string, string>;
     }): string {
-        let path = endpoint.fullPath.head;
+        // Build a double-quoted PHP string expression for the request path. Most path parameter
+        // references can be interpolated directly (e.g. "/users/{$id}"), but some are expressions
+        // (e.g. a boolean rendered as "true"/"false") that cannot be interpolated and must be
+        // concatenated onto the string literal instead.
+        const segments: string[] = [];
+        let literal = endpoint.fullPath.head;
         for (const part of endpoint.fullPath.parts) {
             const reference = pathParameterReferences[part.pathParameter];
             if (reference == null) {
@@ -140,8 +145,30 @@ export class RawClient {
                     `Failed to find request parameter for the endpoint ${endpoint.id} with path parameter ${part.pathParameter}`
                 );
             }
-            path += `{${reference}}${part.tail}`;
+            if (RawClient.isInterpolatableReference(reference)) {
+                literal += `{${reference}}${part.tail}`;
+            } else {
+                segments.push(`"${literal}"`);
+                segments.push(`(${reference})`);
+                literal = part.tail;
+            }
         }
-        return path;
+        if (segments.length === 0) {
+            return `"${literal}"`;
+        }
+        if (literal.length > 0) {
+            segments.push(`"${literal}"`);
+        }
+        return segments.join(" . ");
+    }
+
+    /**
+     * Returns true when the reference is a simple variable, property, getter, or index access that
+     * can be embedded directly inside a double-quoted PHP string (e.g. `$id`, `$request->id`,
+     * `$request->getId()`, `$map['key']`). Anything else (e.g. a ternary expression) must be
+     * concatenated rather than interpolated.
+     */
+    private static isInterpolatableReference(reference: string): boolean {
+        return /^\$[A-Za-z_]\w*(?:->[A-Za-z_]\w*(?:\(\))?|\['[^']*'\]|\[\d+\])*$/.test(reference);
     }
 }

--- a/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -126,12 +126,23 @@ export abstract class AbstractEndpointGenerator {
         pathParameter: FernIr.PathParameter;
         includePathParametersInEndpointSignature: boolean;
     }): string {
-        if (sdkRequest == null || includePathParametersInEndpointSignature) {
-            return `$${this.context.getPropertyName(pathParameter.name)}`;
+        const reference =
+            sdkRequest == null || includePathParametersInEndpointSignature
+                ? `$${this.context.getPropertyName(pathParameter.name)}`
+                : this.context.accessRequestProperty({
+                      requestParameterName: sdkRequest.requestParameterName,
+                      propertyName: pathParameter.name
+                  });
+        if (this.isBooleanPathParameter(pathParameter)) {
+            // PHP coerces a bool to "1"/"" when interpolated into a string, so a boolean path
+            // parameter must be rendered explicitly as "true"/"false" to produce a valid URL.
+            return `${reference} ? 'true' : 'false'`;
         }
-        return this.context.accessRequestProperty({
-            requestParameterName: sdkRequest.requestParameterName,
-            propertyName: pathParameter.name
-        });
+        return reference;
+    }
+
+    private isBooleanPathParameter(pathParameter: FernIr.PathParameter): boolean {
+        const dereferenced = this.context.dereferenceOptional(pathParameter.valueType);
+        return dereferenced.type === "primitive" && dereferenced.primitive.v1 === FernIr.PrimitiveTypeV1.Boolean;
     }
 }

--- a/generators/php/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestGenerator.ts
@@ -44,6 +44,12 @@ export class WireTestGenerator {
 
         for (const [serviceName, endpoints] of endpointsByService.entries()) {
             const endpointsWithExamples = endpoints.filter((endpoint) => {
+                // Bytes request bodies cannot be exercised against WireMock, so mock-utils omits
+                // their stub mappings. Skip them here too, otherwise the generated test would call
+                // an endpoint with no matching stub and fail.
+                if (endpoint.requestBody?.type === "bytes") {
+                    return false;
+                }
                 const dynamicEndpoint = this.dynamicIr.endpoints[endpoint.id];
                 return dynamicEndpoint?.examples && dynamicEndpoint.examples.length > 0;
             });

--- a/seed/php-sdk/exhaustive/no-custom-config/reference.md
+++ b/seed/php-sdk/exhaustive/no-custom-config/reference.md
@@ -2916,6 +2916,76 @@ $client->inlinedRequests->postWithObjectBodyandResponse(
 </dl>
 </details>
 
+<details><summary><code>$client-&gt;inlinedRequests-&gt;postWithArrayBodyAndHeaders($request) -> ?string</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+POST with root-level array body and header params
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->inlinedRequests->postWithArrayBodyAndHeaders(
+    new PostWithArrayBodyAndHeaders([
+        'xCustomHeader' => 'X-Custom-Header',
+        'body' => [
+            'string',
+            'string',
+        ],
+    ]),
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**$xCustomHeader:** `?string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$request:** `array` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
 ## NoAuth
 <details><summary><code>$client-&gt;noAuth-&gt;postWithNoAuth($request) -> ?bool</code></summary>
 <dl>

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/Params/ParamsClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/Params/ParamsClient.php
@@ -501,7 +501,7 @@ class ParamsClient
             $response = $this->client->sendRequest(
                 new JsonApiRequest(
                     baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
-                    path: "/params/path-bool/{$param}",
+                    path: "/params/path-bool/" . ($param ? 'true' : 'false'),
                     method: HttpMethod::GET,
                 ),
                 $options,

--- a/seed/php-sdk/exhaustive/no-custom-config/src/InlinedRequests/InlinedRequestsClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/InlinedRequests/InlinedRequestsClient.php
@@ -12,6 +12,8 @@ use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
+use Seed\InlinedRequests\Requests\PostWithArrayBodyAndHeaders;
+use Seed\Core\Json\JsonDecoder;
 
 class InlinedRequestsClient
 {
@@ -85,6 +87,60 @@ class InlinedRequestsClient
                     return null;
                 }
                 return ObjectWithOptionalField::fromJson($json);
+            }
+        } catch (JsonException $e) {
+            throw new SeedException(message: "Failed to deserialize response: {$e->getMessage()}", previous: $e);
+        } catch (ClientExceptionInterface $e) {
+            throw new SeedException(message: $e->getMessage(), previous: $e);
+        }
+        throw new SeedApiException(
+            message: 'API request failed',
+            statusCode: $statusCode,
+            body: $response->getBody()->getContents(),
+        );
+    }
+
+    /**
+     * POST with root-level array body and header params
+     *
+     * @param PostWithArrayBodyAndHeaders $request
+     * @param ?array{
+     *   baseUrl?: string,
+     *   maxRetries?: int,
+     *   timeout?: float,
+     *   headers?: array<string, string>,
+     *   queryParameters?: array<string, mixed>,
+     *   bodyProperties?: array<string, mixed>,
+     * } $options
+     * @return ?string
+     * @throws SeedException
+     * @throws SeedApiException
+     */
+    public function postWithArrayBodyAndHeaders(PostWithArrayBodyAndHeaders $request, ?array $options = null): ?string
+    {
+        $options = array_merge($this->options, $options ?? []);
+        $headers = [];
+        if ($request->xCustomHeader != null) {
+            $headers['X-Custom-Header'] = $request->xCustomHeader;
+        }
+        try {
+            $response = $this->client->sendRequest(
+                new JsonApiRequest(
+                    baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
+                    path: "/req-bodies/array-body-with-headers",
+                    method: HttpMethod::POST,
+                    headers: $headers,
+                    body: $request->body,
+                ),
+                $options,
+            );
+            $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                $json = $response->getBody()->getContents();
+                if (empty($json)) {
+                    return null;
+                }
+                return JsonDecoder::decodeString($json);
             }
         } catch (JsonException $e) {
             throw new SeedException(message: "Failed to deserialize response: {$e->getMessage()}", previous: $e);

--- a/seed/php-sdk/exhaustive/no-custom-config/src/InlinedRequests/Requests/PostWithArrayBodyAndHeaders.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/InlinedRequests/Requests/PostWithArrayBodyAndHeaders.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Seed\InlinedRequests\Requests;
+
+use Seed\Core\Json\JsonSerializableType;
+
+class PostWithArrayBodyAndHeaders extends JsonSerializableType
+{
+    /**
+     * @var ?string $xCustomHeader
+     */
+    public ?string $xCustomHeader;
+
+    /**
+     * @var array<string> $body
+     */
+    public array $body;
+
+    /**
+     * @param array{
+     *   body: array<string>,
+     *   xCustomHeader?: ?string,
+     * } $values
+     */
+    public function __construct(
+        array $values,
+    ) {
+        $this->xCustomHeader = $values['xCustomHeader'] ?? null;
+        $this->body = $values['body'];
+    }
+}

--- a/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example62/snippet.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example62/snippet.php
@@ -3,6 +3,7 @@
 namespace Example;
 
 use Seed\SeedClient;
+use Seed\InlinedRequests\Requests\PostWithArrayBodyAndHeaders;
 
 $client = new SeedClient(
     token: '<token>',
@@ -10,8 +11,12 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->noAuth->postWithNoAuth(
-    [
-        'key' => "value",
-    ],
+$client->inlinedRequests->postWithArrayBodyAndHeaders(
+    new PostWithArrayBodyAndHeaders([
+        'xCustomHeader' => 'X-Custom-Header',
+        'body' => [
+            'string',
+            'string',
+        ],
+    ]),
 );

--- a/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example64/snippet.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example64/snippet.php
@@ -10,4 +10,8 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->noReqBody->getWithNoRequestBody();
+$client->noAuth->postWithNoAuth(
+    [
+        'key' => "value",
+    ],
+);

--- a/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example65/snippet.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example65/snippet.php
@@ -10,4 +10,4 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->noReqBody->postWithNoRequestBody();
+$client->noReqBody->getWithNoRequestBody();

--- a/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example66/snippet.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example66/snippet.php
@@ -3,7 +3,6 @@
 namespace Example;
 
 use Seed\SeedClient;
-use Seed\ReqWithHeaders\Requests\ReqWithHeaders;
 
 $client = new SeedClient(
     token: '<token>',
@@ -11,10 +10,4 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->reqWithHeaders->getWithCustomHeader(
-    new ReqWithHeaders([
-        'xTestServiceHeader' => 'X-TEST-SERVICE-HEADER',
-        'xTestEndpointHeader' => 'X-TEST-ENDPOINT-HEADER',
-        'body' => 'string',
-    ]),
-);
+$client->noReqBody->postWithNoRequestBody();

--- a/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example67/snippet.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/dynamic-snippets/example67/snippet.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Example;
+
+use Seed\SeedClient;
+use Seed\ReqWithHeaders\Requests\ReqWithHeaders;
+
+$client = new SeedClient(
+    token: '<token>',
+    options: [
+        'baseUrl' => 'https://api.fern.com',
+    ],
+);
+$client->reqWithHeaders->getWithCustomHeader(
+    new ReqWithHeaders([
+        'xTestServiceHeader' => 'X-TEST-SERVICE-HEADER',
+        'xTestEndpointHeader' => 'X-TEST-ENDPOINT-HEADER',
+        'body' => 'string',
+    ]),
+);

--- a/seed/php-sdk/exhaustive/wire-tests/reference.md
+++ b/seed/php-sdk/exhaustive/wire-tests/reference.md
@@ -2916,6 +2916,76 @@ $client->inlinedRequests->postWithObjectBodyandResponse(
 </dl>
 </details>
 
+<details><summary><code>$client-&gt;inlinedRequests-&gt;postWithArrayBodyAndHeaders($request) -> ?string</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+POST with root-level array body and header params
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```php
+$client->inlinedRequests->postWithArrayBodyAndHeaders(
+    new PostWithArrayBodyAndHeaders([
+        'xCustomHeader' => 'X-Custom-Header',
+        'body' => [
+            'string',
+            'string',
+        ],
+    ]),
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**$xCustomHeader:** `?string` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**$request:** `array` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
 ## NoAuth
 <details><summary><code>$client-&gt;noAuth-&gt;postWithNoAuth($request) -> ?bool</code></summary>
 <dl>

--- a/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/Params/ParamsClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/Params/ParamsClient.php
@@ -501,7 +501,7 @@ class ParamsClient
             $response = $this->client->sendRequest(
                 new JsonApiRequest(
                     baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
-                    path: "/params/path-bool/{$param}",
+                    path: "/params/path-bool/" . ($param ? 'true' : 'false'),
                     method: HttpMethod::GET,
                 ),
                 $options,

--- a/seed/php-sdk/exhaustive/wire-tests/src/InlinedRequests/InlinedRequestsClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/InlinedRequests/InlinedRequestsClient.php
@@ -12,6 +12,8 @@ use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
+use Seed\InlinedRequests\Requests\PostWithArrayBodyAndHeaders;
+use Seed\Core\Json\JsonDecoder;
 
 class InlinedRequestsClient
 {
@@ -85,6 +87,60 @@ class InlinedRequestsClient
                     return null;
                 }
                 return ObjectWithOptionalField::fromJson($json);
+            }
+        } catch (JsonException $e) {
+            throw new SeedException(message: "Failed to deserialize response: {$e->getMessage()}", previous: $e);
+        } catch (ClientExceptionInterface $e) {
+            throw new SeedException(message: $e->getMessage(), previous: $e);
+        }
+        throw new SeedApiException(
+            message: 'API request failed',
+            statusCode: $statusCode,
+            body: $response->getBody()->getContents(),
+        );
+    }
+
+    /**
+     * POST with root-level array body and header params
+     *
+     * @param PostWithArrayBodyAndHeaders $request
+     * @param ?array{
+     *   baseUrl?: string,
+     *   maxRetries?: int,
+     *   timeout?: float,
+     *   headers?: array<string, string>,
+     *   queryParameters?: array<string, mixed>,
+     *   bodyProperties?: array<string, mixed>,
+     * } $options
+     * @return ?string
+     * @throws SeedException
+     * @throws SeedApiException
+     */
+    public function postWithArrayBodyAndHeaders(PostWithArrayBodyAndHeaders $request, ?array $options = null): ?string
+    {
+        $options = array_merge($this->options, $options ?? []);
+        $headers = [];
+        if ($request->xCustomHeader != null) {
+            $headers['X-Custom-Header'] = $request->xCustomHeader;
+        }
+        try {
+            $response = $this->client->sendRequest(
+                new JsonApiRequest(
+                    baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
+                    path: "/req-bodies/array-body-with-headers",
+                    method: HttpMethod::POST,
+                    headers: $headers,
+                    body: $request->body,
+                ),
+                $options,
+            );
+            $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                $json = $response->getBody()->getContents();
+                if (empty($json)) {
+                    return null;
+                }
+                return JsonDecoder::decodeString($json);
             }
         } catch (JsonException $e) {
             throw new SeedException(message: "Failed to deserialize response: {$e->getMessage()}", previous: $e);

--- a/seed/php-sdk/exhaustive/wire-tests/src/InlinedRequests/Requests/PostWithArrayBodyAndHeaders.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/InlinedRequests/Requests/PostWithArrayBodyAndHeaders.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Seed\InlinedRequests\Requests;
+
+use Seed\Core\Json\JsonSerializableType;
+
+class PostWithArrayBodyAndHeaders extends JsonSerializableType
+{
+    /**
+     * @var ?string $xCustomHeader
+     */
+    public ?string $xCustomHeader;
+
+    /**
+     * @var array<string> $body
+     */
+    public array $body;
+
+    /**
+     * @param array{
+     *   body: array<string>,
+     *   xCustomHeader?: ?string,
+     * } $values
+     */
+    public function __construct(
+        array $values,
+    ) {
+        $this->xCustomHeader = $values['xCustomHeader'] ?? null;
+        $this->body = $values['body'];
+    }
+}

--- a/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example62/snippet.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example62/snippet.php
@@ -3,6 +3,7 @@
 namespace Example;
 
 use Seed\SeedClient;
+use Seed\InlinedRequests\Requests\PostWithArrayBodyAndHeaders;
 
 $client = new SeedClient(
     token: '<token>',
@@ -10,8 +11,12 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->noAuth->postWithNoAuth(
-    [
-        'key' => "value",
-    ],
+$client->inlinedRequests->postWithArrayBodyAndHeaders(
+    new PostWithArrayBodyAndHeaders([
+        'xCustomHeader' => 'X-Custom-Header',
+        'body' => [
+            'string',
+            'string',
+        ],
+    ]),
 );

--- a/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example64/snippet.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example64/snippet.php
@@ -10,4 +10,8 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->noReqBody->getWithNoRequestBody();
+$client->noAuth->postWithNoAuth(
+    [
+        'key' => "value",
+    ],
+);

--- a/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example65/snippet.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example65/snippet.php
@@ -10,4 +10,4 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->noReqBody->postWithNoRequestBody();
+$client->noReqBody->getWithNoRequestBody();

--- a/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example66/snippet.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example66/snippet.php
@@ -3,7 +3,6 @@
 namespace Example;
 
 use Seed\SeedClient;
-use Seed\ReqWithHeaders\Requests\ReqWithHeaders;
 
 $client = new SeedClient(
     token: '<token>',
@@ -11,10 +10,4 @@ $client = new SeedClient(
         'baseUrl' => 'https://api.fern.com',
     ],
 );
-$client->reqWithHeaders->getWithCustomHeader(
-    new ReqWithHeaders([
-        'xTestServiceHeader' => 'X-TEST-SERVICE-HEADER',
-        'xTestEndpointHeader' => 'X-TEST-ENDPOINT-HEADER',
-        'body' => 'string',
-    ]),
-);
+$client->noReqBody->postWithNoRequestBody();

--- a/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example67/snippet.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/dynamic-snippets/example67/snippet.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Example;
+
+use Seed\SeedClient;
+use Seed\ReqWithHeaders\Requests\ReqWithHeaders;
+
+$client = new SeedClient(
+    token: '<token>',
+    options: [
+        'baseUrl' => 'https://api.fern.com',
+    ],
+);
+$client->reqWithHeaders->getWithCustomHeader(
+    new ReqWithHeaders([
+        'xTestServiceHeader' => 'X-TEST-SERVICE-HEADER',
+        'xTestEndpointHeader' => 'X-TEST-ENDPOINT-HEADER',
+        'body' => 'string',
+    ]),
+);

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsParamsWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/EndpointsParamsWireTest.php
@@ -198,27 +198,6 @@ class EndpointsParamsWireTest extends WireMockTestCase
 
     /**
      */
-    public function testUploadWithPath(): void {
-        $testId = 'endpoints.params.upload_with_path.0';
-        $this->client->endpoints->params->uploadWithPath(
-            'upload-path',
-            [
-                'headers' => [
-                    'X-Test-Id' => 'endpoints.params.upload_with_path.0',
-                ],
-            ],
-        );
-        $this->verifyRequestCount(
-            $testId,
-            "POST",
-            "/params/path/{param}",
-            null,
-            1
-        );
-    }
-
-    /**
-     */
     public function testGetWithBooleanPath(): void {
         $testId = 'endpoints.params.get_with_boolean_path.0';
         $this->client->endpoints->params->getWithBooleanPath(

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/InlinedRequestsWireTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/InlinedRequestsWireTest.php
@@ -7,6 +7,7 @@ use Seed\SeedClient;
 use Seed\InlinedRequests\Requests\PostWithObjectBody;
 use Seed\Types\Object\Types\ObjectWithOptionalField;
 use DateTime;
+use Seed\InlinedRequests\Requests\PostWithArrayBodyAndHeaders;
 
 class InlinedRequestsWireTest extends WireMockTestCase
 {
@@ -56,6 +57,33 @@ class InlinedRequestsWireTest extends WireMockTestCase
             $testId,
             "POST",
             "/req-bodies/object",
+            null,
+            1
+        );
+    }
+
+    /**
+     */
+    public function testPostWithArrayBodyAndHeaders(): void {
+        $testId = 'inlined_requests.post_with_array_body_and_headers.0';
+        $this->client->inlinedRequests->postWithArrayBodyAndHeaders(
+            new PostWithArrayBodyAndHeaders([
+                'xCustomHeader' => 'X-Custom-Header',
+                'body' => [
+                    'string',
+                    'string',
+                ],
+            ]),
+            [
+                'headers' => [
+                    'X-Test-Id' => 'inlined_requests.post_with_array_body_and_headers.0',
+                ],
+            ],
+        );
+        $this->verifyRequestCount(
+            $testId,
+            "POST",
+            "/req-bodies/array-body-with-headers",
             null,
             1
         );

--- a/seed/php-sdk/exhaustive/wire-tests/wiremock/wiremock-mappings.json
+++ b/seed/php-sdk/exhaustive/wire-tests/wiremock/wiremock-mappings.json
@@ -1812,6 +1812,32 @@
       }
     },
     {
+      "id": "0989bd27-188d-4515-9e03-85d554a2df57",
+      "name": "postWithArrayBodyAndHeaders - default",
+      "request": {
+        "urlPathTemplate": "/req-bodies/array-body-with-headers",
+        "method": "POST"
+      },
+      "response": {
+        "status": 200,
+        "body": "\"string\"",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      },
+      "uuid": "0989bd27-188d-4515-9e03-85d554a2df57",
+      "persistent": true,
+      "priority": 3,
+      "metadata": {
+        "mocklab": {
+          "created": {
+            "at": "2020-01-01T00:00:00.000Z",
+            "via": "SYSTEM"
+          }
+        }
+      }
+    },
+    {
       "id": "c6e7cc6c-b76f-4860-a9ad-52dc8f55b6e6",
       "name": "postWithNoAuth - default",
       "request": {
@@ -1933,6 +1959,6 @@
     }
   ],
   "meta": {
-    "total": 59
+    "total": 60
   }
 }

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -184,8 +184,6 @@ scripts:
 allowedFailures:
   # Dynamic snippet: default-valued base-path param ordered before request body.
   - api-wide-base-path-with-default
-  # Wire test: path param request failures unrelated to dynamic snippets.
-  - exhaustive:wire-tests
   # Dynamic snippet: variable-typed path params not provided in snippet request.
   - variables
   - oauth-client-credentials-with-variables


### PR DESCRIPTION
## Description

Removes `exhaustive:wire-tests` from the php-sdk `allowedFailures` by fixing the two generator bugs that made it fail.

**Bug 1 — boolean path params serialized as `1`/``.** A boolean path parameter was interpolated directly into the URL string, so PHP's bool→string coercion rendered `true` as `"1"` and `false` as `""`. The SDK sent `GET /params/path-bool/1` while the WireMock stub (correctly built by `mock-utils` as `String(true)`) expected `/params/path-bool/true`, so the wire test failed.

`getPathString` now emits a concatenation for non-interpolatable references, and boolean path params render explicitly:

```php
// before
path: "/params/path-bool/{$param}",          // bool true -> "1"
// after
path: "/params/path-bool/" . ($param ? 'true' : 'false'),
```

Normal (string/property/getter) references still interpolate exactly as before — verified byte-identical by regenerating `basic-auth/wire-tests` (zero diff).

**Bug 2 — wire test generated for a bytes-body endpoint with no stub.** `mock-utils` intentionally omits WireMock stubs for `bytes` request bodies, but the php wire-test generator still emitted a test (`testUploadWithPath`) that called the endpoint, hitting no stub and failing. The generator now skips `bytes` request-body endpoints too.

## Changes Made
- `AbstractEndpointGenerator`: render boolean path params as `($x ? 'true' : 'false')` (via `dereferenceOptional` → primitive boolean check).
- `RawClient.getPathString`: build the path as a concatenation when a reference can't be string-interpolated; keep pure interpolation (byte-identical) for simple variable/property/getter/index references.
- `WireTestGenerator`: skip `bytes` request-body endpoints, matching `mock-utils`.
- Remove `exhaustive:wire-tests` from `seed/php-sdk/seed.yml` `allowedFailures`.
- Regenerate the `exhaustive` fixtures. This also refreshes the `postWithArrayBodyAndHeaders` endpoint added to the exhaustive test definition in #16426 (the php fixtures were never regenerated then; since `no-custom-config` is not in `allowedFailures` and the boolean fix touches it, a full regen is required and brings it back in sync).
- Add php-sdk changelog entry.

## Testing
- [x] Ran the full `exhaustive/wire-tests` suite against standalone WireMock with the regenerated mappings: **126 tests, 382 assertions, all passing** (boolean path test now hits `/params/path-bool/true`; `testUploadWithPath` removed).
- [x] PHPStan clean on both `exhaustive/wire-tests` and `exhaustive/no-custom-config`.
- [x] `@fern-api/php-sdk` unit tests pass; biome clean on changed TS.
- [x] `basic-auth/wire-tests` regenerates byte-identical (confirms the path refactor doesn't alter normal endpoints).


Link to Devin session: https://app.devin.ai/sessions/061e09e6d9bf4b7dbb24899b3bb9b9a2
Requested by: @iamnamananand996