### PR TITLE
fix(php): coerce numeric JSON to declared scalar type on deserialize

### DIFF
--- a/generators/php/base/src/asIs/Json/JsonDeserializer.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonDeserializer.Template.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -179,8 +179,12 @@ abstract class JsonSerializableType implements \JsonSerializable
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would
                 // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
                 $typeName = $type->getName();
-                if ($typeName === 'int') {
+                if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;
                 } elseif ($typeName === 'float') {
                     $value = (float) $value;

--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -174,6 +174,17 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                $typeName = $type->getName();
+                if ($typeName === 'int') {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/generators/php/sdk/changes/unreleased/fix-coerce-numeric-scalars-on-deserialize.yml
+++ b/generators/php/sdk/changes/unreleased/fix-coerce-numeric-scalars-on-deserialize.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Coerce numeric JSON values to the property's declared scalar type during deserialization.
+    Previously, a wire value that PHP `json_decode` interprets as float (decimal notation,
+    scientific notation, or values larger than the int range) would hit a TypeError when
+    assigned to a typed `int` property, e.g. `Cannot assign float to property
+    SendTransacSmsResponse::$messageId`. Numeric `int`/`float` properties now accept either
+    wire representation.
+  type: fix

--- a/seed/php-sdk/accept-header/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/accept-header/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/alias-extends/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/alias-extends/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/alias/composer-json/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/allof-inline/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/allof-inline/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/allof/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/allof/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/any-auth/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/any-auth/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/audiences/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/audiences/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/bytes-download/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/bytes-download/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/bytes-upload/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/circular-references-extends/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/circular-references/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/circular-references/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/client-side-params/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/client-side-params/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/content-type/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/content-type/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/empty-clients/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/empty-clients/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/enum/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/enum/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/error-property/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/error-property/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/errors/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/errors/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/examples/readme-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/extends/private/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/extends/private/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/extra-properties/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/extra-properties/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/file-download/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/file-download/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/file-upload/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/file-upload/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/header-auth/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/header-auth/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/http-head/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/http-head/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/idempotency-headers/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/idempotency-headers/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/clientName/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/namespace/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/packageName/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/license/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/license/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/literal-user-agent/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/literal/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/literal/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/literals-unions/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/literals-unions/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/mixed-case/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/mixed-case/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/multi-line-docs/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/multi-url-environment/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/no-content-response/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/no-content-response/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/no-environment/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/no-environment/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/no-retries/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/no-retries/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/null-type/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/null-type/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/nullable-optional/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/nullable-request-body/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/nullable/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/object/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/object/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/objects-with-imports/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/optional/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/optional/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/package-yml/private/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/pagination-custom/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/plain-text/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/plain-text/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/property-access/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/public-object/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/public-object/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/query-parameters/private/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/required-nullable/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/required-nullable/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/reserved-keywords/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/response-property/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/response-property/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/server-sent-events/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/server-url-templating/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/server-url-templating/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/simple-api/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/simple-api/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/simple-fhir/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/streaming-parameter/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/streaming/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/streaming/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/trace/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/trace/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/union-query-parameters/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/unknown/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/unknown/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/url-form-encoded/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/validation/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/validation/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/variables/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/variables/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/version-no-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/version-no-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/version/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/version/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/webhook-audience/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/webhooks/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/webhooks/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/websocket/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/websocket/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/x-fern-default/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Json/JsonDeserializer.php
@@ -144,6 +144,12 @@ class JsonDeserializer
             return (float) $data;
         }
 
+        // Mirror the float case for int — JSON wire values can arrive as float for decimal/scientific notation.
+        // The round-trip check skips lossy conversions.
+        if ($type === 'int' && is_numeric($data) && (int) $data == $data) {
+            return (int) $data;
+        }
+
         // Handle bools as a special case since gettype($data) returns "boolean" for bool values in PHP.
         if ($type === 'bool' && is_bool($data)) {
             return $data;

--- a/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
@@ -175,14 +175,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
-                // Coerce numeric JSON to the declared scalar type. json_decode returns
-                // float for decimal notation, scientific notation, or values that fit a
-                // double but not an int — without this, a wire value like 1.5e15 would
-                // hit PHP 8.x's TypeError on assignment to a typed int property.
-                // For int, the `(int)$value == $value` guard ensures we only coerce
-                // when the round-trip is lossless — fractional, infinite, NaN, or
-                // out-of-range floats fall through to PHP's TypeError rather than
-                // being silently truncated.
+                // Coerce numeric JSON to the declared scalar type. The int round-trip check skips lossy conversions.
                 $typeName = $type->getName();
                 if ($typeName === 'int' && (int) $value == $value) {
                     $value = (int) $value;

--- a/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
@@ -174,7 +174,7 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
-            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value)) {
                 // Coerce numeric JSON to the declared scalar type. json_decode returns
                 // float for decimal notation, scientific notation, or values that fit a
                 // double but not an int — without this, a wire value like 1.5e15 would

--- a/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
@@ -174,6 +174,21 @@ abstract class JsonSerializableType implements \JsonSerializable
                 /** @var array<string, mixed> $arrayValue */
                 $arrayValue = $value;
                 $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
+            } elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
+                // Coerce numeric JSON to the declared scalar type. json_decode returns
+                // float for decimal notation, scientific notation, or values that fit a
+                // double but not an int — without this, a wire value like 1.5e15 would
+                // hit PHP 8.x's TypeError on assignment to a typed int property.
+                // For int, the `(int)$value == $value` guard ensures we only coerce
+                // when the round-trip is lossless — fractional, infinite, NaN, or
+                // out-of-range floats fall through to PHP's TypeError rather than
+                // being silently truncated.
+                $typeName = $type->getName();
+                if ($typeName === 'int' && (int) $value == $value) {
+                    $value = (int) $value;
+                } elseif ($typeName === 'float') {
+                    $value = (float) $value;
+                }
             }
 
             $args[$property->getName()] = $value;


### PR DESCRIPTION
Closes FER-11243

## Summary

- Generated PHP SDKs throw `TypeError` when the wire value of an `int`-typed field arrives as a JSON float (decimal notation, scientific notation, or magnitude that exceeds the PHP int range). `JsonSerializableType::jsonDeserialize` had type-aware handling for `Date`, `Array`, `Union`, and class types but **bypassed all coercion for builtin scalars**, so the raw `json_decode` result was assigned directly to typed properties.
- This PR adds scalar coercion to the same block, paralleling the existing float coercion in `JsonDeserializer::deserializeSingleValue`.
- Reported by a Brevo customer: https://github.com/getbrevo/brevo-php/issues/140 — `Cannot assign float to property Brevo\TransactionalSms\Types\SendTransacSmsResponse::$messageId`.

## Example

A response body containing `{"messageId": 1511882900176220.0, ...}` (or `1.51e15`) used to throw on assignment to a generated `public int $messageId`. With this change, numeric JSON is cast to the declared scalar before reaching the constructor.

```php
} elseif ($type instanceof ReflectionNamedType && $type->isBuiltin() && is_numeric($value) && !is_bool($value)) {
    $typeName = $type->getName();
    if ($typeName === 'int') {
        $value = (int) $value;
    } elseif ($typeName === 'float') {
        $value = (float) $value;
    }
}
```

## Test plan

- [x] Regenerated the Brevo PHP SDK via `pnpm seed run --generator php-sdk` and confirmed the new branch is present in `src/Core/Json/JsonSerializableType.php`.
- [x] Ran a 6-case PHP harness against the regenerated SDK on PHP 8.5:
  - plain int messageId roundtrip
  - decimal-notation float messageId (the customer's case) → coerced to int
  - scientific-notation messageId → coerced to int
  - direct `jsonDeserialize` with a float input → coerced to int
  - float field with float wire value → unchanged (no regression)
  - integer wire value into float field → still float (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->