### PR TITLE
chore(deps): bump generator-cli catalog to 0.9.39 and re-release java/python/typescript SDK generators

### DIFF
--- a/generators/java/sdk/changes/unreleased/bump-generator-cli-0.9.39.yml
+++ b/generators/java/sdk/changes/unreleased/bump-generator-cli-0.9.39.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump bundled @fern-api/generator-cli to 0.9.39 (Replay 0.18.0) for more reliable
+    customization detection during regeneration.
+  type: chore

--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.39.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.39.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump bundled @fern-api/generator-cli to 0.9.39 (Replay 0.18.0) for more reliable
+    customization detection during regeneration.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.39.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.39.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump bundled @fern-api/generator-cli to 0.9.39 (Replay 0.18.0) for more reliable
+    customization detection during regeneration.
+  type: chore

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.35
-      version: 0.9.35
+      specifier: 0.9.39
+      version: 0.9.39
     '@fern-api/venus-api-sdk':
       specifier: 5.0.0
       version: 5.0.0
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.35
+        version: 0.9.39
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.35
+        version: 0.9.39
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2481,7 +2481,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.35
+        version: 0.9.39
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9516,13 +9516,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.32-f5a3d6f517':
     resolution: {integrity: sha512-9MrrQ4L18ebqrxx4i1rdYVBnbESqr0QtLFZO6+RWxBzA+IctRZ+dfYI9e8AXmDNW2OkvgkldPEpOh4EhfExBBw==}
 
-  '@fern-api/generator-cli@0.9.35':
-    resolution: {integrity: sha512-84+K5K4jquuqpMo3p2NDk/OJuiyZtRcQW5tlEYH3R9y7G5wX71qwAWM21qWqu6+vYfN1oZ+4fUcqgqp6tOhxVA==}
-    hasBin: true
-
-  '@fern-api/replay@0.16.2':
-    resolution: {integrity: sha512-eUg5d5qay8C+3nin5dWCOLGji/HcmWsA9hQL1cISO+eH58dJjufGd92hxjsD02sw5eX0CuDzzq6LMuYVW2Swzg==}
-    engines: {node: '>=18'}
+  '@fern-api/generator-cli@0.9.39':
+    resolution: {integrity: sha512-ANgQButS7+YLpdfUGAjedhEkzZGfLxNJj7UKL7trRjuWy7DPWh9ePtx8IblAHnXPoYLkSInEoJB00EFCpkSE7A==}
     hasBin: true
 
   '@fern-api/replay@0.18.0':
@@ -16496,23 +16491,14 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.35':
+  '@fern-api/generator-cli@0.9.39':
     dependencies:
       '@boundaryml/baml': 0.219.0
-      '@fern-api/replay': 0.16.2
+      '@fern-api/replay': 0.18.0
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
       semver: 7.7.4
       tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.16.2':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.36.0
-      yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.32-f5a3d6f517
-  "@fern-api/generator-cli": 0.9.35
+  "@fern-api/generator-cli": 0.9.39
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 5.0.0
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## What
Advances the `@fern-api/generator-cli` catalog pin **`0.9.35 → 0.9.39`** and re-releases the java / python / typescript SDK generators so their Docker images rebuild bundling the new generator-cli.

## Why
generator-cli `0.9.39` bundles **`@fern-api/replay@0.18.0`**, and the generators consume generator-cli as a build-time dependency (`generators/base` → `"@fern-api/generator-cli": "catalog:"`). Remote (Fiddle) generation runs the generator-cli **baked into each generator image**, so a replay fix only reaches customers once the catalog is advanced *and* the generators are re-released. Replay `0.18.0` brings `.fernignore`-aware customization detection (commits touching only protected paths skip patch materialization), gitignore-style trailing-slash pattern support, and an EPIPE crash fix → more reliable customization preservation during regeneration.

## Changes
- `pnpm-workspace.yaml`: catalog `@fern-api/generator-cli` `0.9.35 → 0.9.39` (+ `pnpm-lock.yaml`)
- java-sdk `4.10.0 → 4.10.1`
- python-sdk `5.14.14 → 5.14.15`
- typescript-sdk `3.71.9 → 3.71.10`

The three generator bumps are `chore` patch releases whose only purpose is to rebuild the images against the new catalog. No generated-output changes — Replay only affects the post-generation customization step, not the emitted SDK code.
