### PR TITLE
feat(typescript): add `serdeLayer` config option as positive alternative to `noSerdeLayer`

### DIFF
--- a/generators/typescript-v2/ast/src/ast/TypeLiteral.ts
+++ b/generators/typescript-v2/ast/src/ast/TypeLiteral.ts
@@ -1,5 +1,6 @@
 import { assertNever } from "@fern-api/core-utils";
 
+import { resolveNoSerdeLayer } from "../custom-config/TypescriptCustomConfigSchema.js";
 import { AstNode, Writer } from "./core/index.js";
 
 type InternalTypeLiteral =
@@ -108,7 +109,7 @@ export class TypeLiteral extends AstNode {
     }
 
     public write(writer: Writer): void {
-        const noSerdeLayer = !!writer.customConfig?.noSerdeLayer;
+        const noSerdeLayer = resolveNoSerdeLayer(writer.customConfig);
         const useBigInt = !!writer.customConfig?.useBigInt;
         switch (this.internalType.type) {
             case "array": {

--- a/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
+++ b/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
@@ -113,3 +113,14 @@ export const TypescriptCustomConfigSchema = z.strictObject({
 });
 
 export type TypescriptCustomConfigSchema = z.infer<typeof TypescriptCustomConfigSchema>;
+
+/**
+ * Resolves the effective noSerdeLayer value from config.
+ * `serdeLayer` takes precedence over `noSerdeLayer` when set.
+ */
+export function resolveNoSerdeLayer(config: TypescriptCustomConfigSchema | undefined): boolean {
+    if (config?.serdeLayer != null) {
+        return !config.serdeLayer;
+    }
+    return !!config?.noSerdeLayer;
+}

--- a/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
+++ b/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts
@@ -78,6 +78,7 @@ export const TypescriptCustomConfigSchema = z.strictObject({
     // namespaceExport is kept for backwards compatibility
     namespaceExport: z.optional(z.string()),
     noSerdeLayer: z.optional(z.boolean()),
+    serdeLayer: z.optional(z.boolean()),
     private: z.optional(z.boolean()),
     requireDefaultEnvironment: z.optional(z.boolean()),
     retainOriginalCasing: z.optional(z.boolean()),

--- a/generators/typescript-v2/ast/src/index.ts
+++ b/generators/typescript-v2/ast/src/index.ts
@@ -2,7 +2,7 @@ export * from "./ast/core/index.js";
 export {
     NamingConfigSchema,
     NamingObjectSchema,
-    TypescriptCustomConfigSchema,
-    resolveNoSerdeLayer
+    resolveNoSerdeLayer,
+    TypescriptCustomConfigSchema
 } from "./custom-config/TypescriptCustomConfigSchema.js";
 export * as ts from "./typescript.js";

--- a/generators/typescript-v2/ast/src/index.ts
+++ b/generators/typescript-v2/ast/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ast/core/index.js";
 export {
     NamingConfigSchema,
     NamingObjectSchema,
-    TypescriptCustomConfigSchema
+    TypescriptCustomConfigSchema,
+    resolveNoSerdeLayer
 } from "./custom-config/TypescriptCustomConfigSchema.js";
 export * as ts from "./typescript.js";

--- a/generators/typescript-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -3,7 +3,7 @@ import {
     FernGeneratorExec
 } from "@fern-api/browser-compatible-base-generator";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
-import { TypescriptCustomConfigSchema, ts } from "@fern-api/typescript-ast";
+import { TypescriptCustomConfigSchema, resolveNoSerdeLayer, ts } from "@fern-api/typescript-ast";
 import { constructNpmPackage, getNamespaceExport, resolveNaming } from "@fern-api/typescript-browser-compatible-base";
 
 import { DynamicTypeLiteralMapper } from "./DynamicTypeLiteralMapper.js";
@@ -66,7 +66,7 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getPropertyName(name: FernIr.Name): string {
-        if (this.customConfig?.retainOriginalCasing || this.customConfig?.noSerdeLayer) {
+        if (this.customConfig?.retainOriginalCasing || resolveNoSerdeLayer(this.customConfig)) {
             return this.formatOriginalPropertyName(name.originalName);
         }
         return name.camelCase.unsafeName;

--- a/generators/typescript-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -3,7 +3,7 @@ import {
     FernGeneratorExec
 } from "@fern-api/browser-compatible-base-generator";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
-import { TypescriptCustomConfigSchema, resolveNoSerdeLayer, ts } from "@fern-api/typescript-ast";
+import { resolveNoSerdeLayer, TypescriptCustomConfigSchema, ts } from "@fern-api/typescript-ast";
 import { constructNpmPackage, getNamespaceExport, resolveNaming } from "@fern-api/typescript-browser-compatible-base";
 
 import { DynamicTypeLiteralMapper } from "./DynamicTypeLiteralMapper.js";

--- a/generators/typescript/sdk/changes/unreleased/add-serde-layer-flag.yml
+++ b/generators/typescript/sdk/changes/unreleased/add-serde-layer-flag.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Add `serdeLayer` config option as a positive alternative to the `noSerdeLayer` double negative.
+    When both are specified, `serdeLayer` takes precedence.
+  type: feat

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -108,7 +108,13 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             retryStatusCodes: parsed?.retryStatusCodes ?? "legacy"
         };
 
-        const serdeLayerExplicitlyEnabled = parsed?.serdeLayer === true || parsed?.noSerdeLayer === false;
+        if (parsed?.serdeLayer != null && parsed?.noSerdeLayer != null) {
+            logger.warn(
+                "Both `serdeLayer` and `noSerdeLayer` are set. `serdeLayer` takes precedence; consider removing `noSerdeLayer`."
+            );
+        }
+        const serdeLayerExplicitlyEnabled =
+            parsed?.serdeLayer != null ? parsed.serdeLayer === true : parsed?.noSerdeLayer === false;
         if (serdeLayerExplicitlyEnabled && typeof parsed?.enableInlineTypes === "undefined") {
             logger.info(
                 "serdeLayer is enabled while enableInlineTypes is implicitly true. Changing enableInlineTypes to false."

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -35,7 +35,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
 
     protected parseCustomConfig(customConfig: unknown, logger: Logger): SdkCustomConfig {
         const parsed = customConfig != null ? SdkCustomConfigSchema.parse(customConfig) : undefined;
-        const noSerdeLayer = parsed?.noSerdeLayer ?? true;
+        const noSerdeLayer = parsed?.serdeLayer != null ? !parsed.serdeLayer : (parsed?.noSerdeLayer ?? true);
         const config = {
             useBrandedStringAliases: parsed?.useBrandedStringAliases ?? false,
             outputSourceFiles: parsed?.outputSourceFiles ?? true,
@@ -108,18 +108,19 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             retryStatusCodes: parsed?.retryStatusCodes ?? "legacy"
         };
 
-        if (parsed?.noSerdeLayer === false && typeof parsed?.enableInlineTypes === "undefined") {
+        const serdeLayerExplicitlyEnabled = parsed?.serdeLayer === true || parsed?.noSerdeLayer === false;
+        if (serdeLayerExplicitlyEnabled && typeof parsed?.enableInlineTypes === "undefined") {
             logger.info(
-                "noSerdeLayer is explicitly false while enableInlineTypes is implicitly true. Changing enableInlineTypes to false."
+                "serdeLayer is enabled while enableInlineTypes is implicitly true. Changing enableInlineTypes to false."
             );
             config.enableInlineTypes = false;
         }
-        if (parsed?.noSerdeLayer === false && parsed?.enableInlineTypes === true) {
-            logger.error("Incompatible configuration: noSerdeLayer cannot be false while enableInlineTypes is true.");
+        if (serdeLayerExplicitlyEnabled && parsed?.enableInlineTypes === true) {
+            logger.error("Incompatible configuration: serdeLayer cannot be true while enableInlineTypes is true.");
         }
-        if (parsed?.noSerdeLayer === false && parsed?.experimentalGenerateReadWriteOnlyTypes === true) {
+        if (serdeLayerExplicitlyEnabled && parsed?.experimentalGenerateReadWriteOnlyTypes === true) {
             logger.error(
-                "Incompatible configuration: noSerdeLayer cannot be false while experimentalGenerateReadWriteOnlyTypes is true."
+                "Incompatible configuration: serdeLayer cannot be true while experimentalGenerateReadWriteOnlyTypes is true."
             );
         }
         const isUsingVitest = (parsed?.testFramework ?? "vitest") === "vitest";


### PR DESCRIPTION
## Description

Adds a `serdeLayer` boolean config option to the TypeScript SDK generator so users can write `serdeLayer: true` instead of the double-negative `noSerdeLayer: false`.

## Changes Made

- Added `serdeLayer: z.optional(z.boolean())` to `TypescriptCustomConfigSchema`
- Resolution in `SdkGeneratorCli.parseCustomConfig`:
  ```
  serdeLayer set  → noSerdeLayer = !serdeLayer   (serdeLayer wins)
  serdeLayer unset → noSerdeLayer = parsed.noSerdeLayer ?? true  (old behavior)
  ```
- Updated incompatibility checks (`enableInlineTypes`, `experimentalGenerateReadWriteOnlyTypes`) to trigger on either `serdeLayer: true` or `noSerdeLayer: false`, respecting `serdeLayer` precedence
- Warns when both `serdeLayer` and `noSerdeLayer` are set simultaneously
- Extracted shared `resolveNoSerdeLayer(config)` helper and updated typescript-v2 consumers (`TypeLiteral.ts`, `DynamicSnippetsGeneratorContext.ts`)
- `noSerdeLayer` remains fully supported — no breaking change, no migration needed

## Testing

- [x] `pnpm lint:biome` passes
- [x] `pnpm format` passes

Link to Devin session: https://app.devin.ai/sessions/c8280dee3c7d4e0e99c751a9d60976ca
Requested by: @Swimburger