### PR TITLE
fix(go): skip generating empty wire test files when all endpoints are skipped

### DIFF
--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -83,7 +83,9 @@ export class WireTestGenerator {
                 }
             );
 
-            this.context.project.addGoFiles(serviceTestFile);
+            if (serviceTestFile != null) {
+                this.context.project.addGoFiles(serviceTestFile);
+            }
         }
         // Generate docker-compose.test.yml and wiremock-mappings.json for WireMock
         new WireTestSetupGenerator(this.context, this.context.ir).generate();
@@ -107,7 +109,7 @@ export class WireTestGenerator {
         serviceName: string,
         endpoints: FernIr.HttpEndpoint[],
         filePath: FernIr.FernFilepath
-    ): Promise<GoFile> {
+    ): Promise<GoFile | null> {
         const endpointTestCases = new Map<string, string>();
         for (const endpoint of endpoints) {
             // Skip bytes request body endpoints — they cannot be properly exercised in wire tests
@@ -189,6 +191,11 @@ export class WireTestGenerator {
                 return endpointTestCaseCodeBlock;
             })
             .filter((endpointTestCaseCodeBlock) => endpointTestCaseCodeBlock !== null);
+
+        // If all endpoints were skipped (e.g., file downloads, bytes requests), don't generate the file
+        if (endpointTestCaseCodeBlocks.length === 0) {
+            return null;
+        }
 
         const serviceTestFileContent = go.codeblock((writer) => {
             const sortedImports = Array.from(imports.entries()).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));

--- a/generators/go/sdk/changes/unreleased/skip-empty-wire-test-files.yml
+++ b/generators/go/sdk/changes/unreleased/skip-empty-wire-test-files.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Skip generating wire test files when all endpoints in a service are
+    skipped (e.g., file download or bytes request body endpoints). Previously
+    this produced a test file with a missing `require` import.
+  type: fix


### PR DESCRIPTION
## Description

Follows up on https://github.com/fern-api/fern/pull/16507. When all endpoints in a service are skipped (file downloads, bytes request bodies), the generator still produced a test file containing only the `VerifyRequestCount` helper — which uses `require` without importing it, causing a build failure.

## Changes Made

- `generateServiceTestFile` returns `null` when `endpointTestCaseCodeBlocks` is empty
- Caller checks for `null` before adding the file to the project
- Return type updated to `Promise<GoFile | null>`

This fixes the mercury-go-sdk build failure where `statements/statements_test/statements_test.go` had `undefined: require` because the only endpoint in that service (`statements.download`) is a file download that gets skipped.

## Testing

- [x] `pnpm turbo run compile --filter @fern-api/go-sdk` passes
- [x] `pnpm seed test --generator go-sdk --fixture file-download --skip-scripts` passes (no test files generated for all-download services)

Link to Devin session: https://app.devin.ai/sessions/c9169be4ff964f9488637101d3b6c3fc
Requested by: @Swimburger