### PR TITLE
chore(generator-cli): setup changelog-based release configuration

### DIFF
--- a/.claude/release-versioning.md
+++ b/.claude/release-versioning.md
@@ -35,6 +35,7 @@ If a path falls under **`softwareDirectory`**, use the matching **`changelogFold
 | `swift` | `generators/swift` | `generators/swift/sdk/changes/unreleased/` |
 | `typescript` | `generators/typescript` | `generators/typescript/sdk/changes/unreleased/` |
 | `cli-generator` | `generators/cli` | `generators/cli/changes/unreleased/` |
+| `generator-cli` | `packages/generator-cli` | `packages/generator-cli/changes/unreleased/` |
 
 Pick the narrowest matching **`softwareDirectory`** when several could apply (e.g. generator-only work under `generators/python/...` uses the Python generator row, not CLI). If a single PR spans multiple **`softwareDirectory`** trees, add a changelog file in **each** corresponding **`changelogFolder/unreleased/`**.
 

--- a/.github/workflows/release-software.yml
+++ b/.github/workflows/release-software.yml
@@ -17,6 +17,7 @@ on:
       - "generators/swift/sdk/changes/**"
       - "generators/typescript/sdk/changes/**"
       - "generators/cli/changes/**"
+      - "packages/generator-cli/changes/**"
   workflow_dispatch:
     inputs:
       software:
@@ -38,6 +39,7 @@ on:
           - swift
           - typescript
           - cli-generator
+          - generator-cli
 
 # Prevent concurrent release runs to avoid git conflicts.
 # NOTE: cancel-in-progress: false protects the running job, but GitHub still

--- a/packages/generator-cli/CLAUDE.md
+++ b/packages/generator-cli/CLAUDE.md
@@ -101,15 +101,12 @@ Configuration:
 
 ## Versioning & Release Process
 
-### Version bump process (can be one commit)
+### Version bump process
 
-When making changes to generator-cli, update these three files together:
+generator-cli uses the changelog-based release flow (see `.claude/release-versioning.md`). Do **not** hand-edit `packages/generator-cli/versions.yml`:
 
-1. `packages/generator-cli/versions.yml` — Add new version entry (triggers npm publish via CI)
-2. `pnpm-workspace.yaml` — Update the catalog pin (e.g., `"@fern-api/generator-cli": 0.8.1`)
-3. `packages/cli/cli/versions.yml` — Bump CLI version (triggers CLI publish via CI)
-
-Both CI workflows (`publish-generator-cli.yml` and `publish-cli.yml`) trigger from the same push to main.
+1. Add an unreleased changelog file under `packages/generator-cli/changes/unreleased/` (copy `.template.yml`). The `release-software.yml` workflow bumps `versions.yml` automatically when the change lands on main, which triggers npm publish via `publish-generator-cli.yml`.
+2. After the new version is published, update the catalog pin in `pnpm-workspace.yaml` (e.g., `"@fern-api/generator-cli": 0.8.1`) and add a CLI changelog entry under `packages/cli/cli/changes/unreleased/` so the CLI picks up the new version.
 
 ### How generators pick up the change
 

--- a/packages/generator-cli/changes/unreleased/.gitkeep
+++ b/packages/generator-cli/changes/unreleased/.gitkeep
@@ -1,0 +1,2 @@
+# This directory contains unreleased changelog entries
+# Create files here following the format in fern-changes-yml.schema.json

--- a/packages/generator-cli/changes/unreleased/.template.yml
+++ b/packages/generator-cli/changes/unreleased/.template.yml
@@ -1,0 +1,8 @@
+# Template for changelog entries
+# Copy this file and rename it to describe your change (e.g., add-auth-feature.yml)
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Brief description of your change.
+    You can use multiple lines for longer descriptions.
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major version bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.

--- a/packages/generator-cli/changes/unreleased/test-dry-run.yml
+++ b/packages/generator-cli/changes/unreleased/test-dry-run.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Test entry for dry-run validation.
+  type: fix

--- a/packages/generator-cli/changes/unreleased/test-dry-run.yml
+++ b/packages/generator-cli/changes/unreleased/test-dry-run.yml
@@ -1,3 +1,0 @@
-- summary: |
-    Test entry for dry-run validation.
-  type: fix

--- a/release-config.json
+++ b/release-config.json
@@ -67,6 +67,12 @@
       "versionsFile": "generators/cli/versions.yml",
       "changelogFolder": "generators/cli/changes",
       "softwareDirectory": "generators/cli"
+    },
+    "generator-cli": {
+      "name": "Generator CLI",
+      "versionsFile": "packages/generator-cli/versions.yml",
+      "changelogFolder": "packages/generator-cli/changes",
+      "softwareDirectory": "packages/generator-cli"
     }
   }
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -108,7 +108,7 @@ interface VersionEntry {
     version: string;
     changelogEntry: Array<{ summary: string; type: string }>;
     createdAt: string;
-    irVersion: number;
+    irVersion?: number;
 }
 
 interface UnreleasedChange {
@@ -275,7 +275,11 @@ function getCurrentVersion(versionsFile: string): string {
     return versions[0].version;
 }
 
-function getCurrentIrVersion(versionsFile: string): number {
+/**
+ * Returns the irVersion of the latest entry, or undefined for software whose
+ * versions.yml does not track an IR version (e.g. the generator CLI).
+ */
+function getCurrentIrVersion(versionsFile: string): number | undefined {
     const content = readFileSync(versionsFile, "utf-8");
     const versions = parseYaml(content) as VersionEntry[];
 
@@ -284,19 +288,14 @@ function getCurrentIrVersion(versionsFile: string): number {
         process.exit(1);
     }
 
-    if (!versions[0] || versions[0].irVersion === undefined) {
-        console.error("Error: versions.yml does not contain a valid irVersion entry");
-        process.exit(1);
-    }
-
-    return versions[0].irVersion;
+    return versions[0]?.irVersion;
 }
 
 function updateVersionsFile(
     versionsFile: string,
     newVersion: string,
     changes: UnreleasedChange[],
-    irVersion: number
+    irVersion: number | undefined
 ): void {
     const existingContent = readFileSync(versionsFile, "utf-8");
 
@@ -316,7 +315,7 @@ function updateVersionsFile(
         version: newVersion,
         changelogEntry,
         createdAt: new Date().toISOString().split("T")[0] ?? "",
-        irVersion
+        ...(irVersion !== undefined ? { irVersion } : {})
     };
 
     // Use yaml.stringify() for the new entry with literal block style (|) for multi-line summaries.
@@ -465,8 +464,10 @@ function prepareRelease(softwareName: string, config: SoftwareConfig): void {
     const irVersion = irVersionFromChangelog ?? getCurrentIrVersion(versionsFile);
     if (irVersionFromChangelog != null) {
         console.log(`📊 IR version: ${irVersion} (overridden by changelog entry)`);
-    } else {
+    } else if (irVersion !== undefined) {
         console.log(`📊 Current IR version: ${irVersion}`);
+    } else {
+        console.log("📊 No IR version tracked for this software");
     }
 
     // Determine next version


### PR DESCRIPTION
## Description
Brings `@fern-api/generator-cli` into the same changelog-based release flow used by the CLI and SDK generators. Instead of hand-editing `packages/generator-cli/versions.yml`, contributors now drop a YAML entry in `packages/generator-cli/changes/unreleased/` and the `release-software.yml` workflow bumps the version automatically (which in turn triggers the existing `publish-generator-cli.yml` npm publish on the `versions.yml` change).

## Changes Made
- Added `generator-cli` entry to `release-config.json` (`versionsFile: packages/generator-cli/versions.yml`, `changelogFolder: packages/generator-cli/changes`)
- Created `packages/generator-cli/changes/unreleased/` with `.template.yml` + `.gitkeep` (same structure `release-setup.ts` generates)
- Added `packages/generator-cli/changes/**` push path and `generator-cli` dispatch option to `.github/workflows/release-software.yml`
- Made `irVersion` optional in `scripts/release.ts` — generator-cli's `versions-yml.schema.json` has no `irVersion` (it isn't an IR consumer), so the release script now omits the field when the latest entry doesn't have one instead of hard-failing:
  ```ts
  function getCurrentIrVersion(versionsFile: string): number | undefined
  // updateVersionsFile: ...(irVersion !== undefined ? { irVersion } : {})
  ```
- Updated docs: `.claude/release-versioning.md` mapping table and the release section of `packages/generator-cli/CLAUDE.md` (note: the `pnpm-workspace.yaml` catalog pin + CLI changelog entry are still manual follow-ups after a publish)
- [ ] Updated README.md generator (not applicable)

## Testing
- [ ] Unit tests added/updated (script has no test harness)
- [x] Manual testing completed — ran `pnpm release generator-cli` on this branch with a throwaway unreleased entry: it computed `0.9.39 → 0.9.40`, prepended a schema-valid entry (no `irVersion`) to `versions.yml`, moved the file to `changes/0.9.40/`, and produced the `chore(generator-cli): release 0.9.40` commit; rolled back before pushing


Link to Devin session: https://app.devin.ai/sessions/c9ef3bb869174b708cd4e300f46f4f35
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->