### PR TITLE
fix(cli): preserve leading zeros in frontmatter during docs publish

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-leading-zeros-frontmatter.yml
+++ b/packages/cli/cli/changes/unreleased/fix-leading-zeros-frontmatter.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix frontmatter values with leading zeros being corrupted during docs publish.
+    `grayMatter.stringify()` in `parseImagePaths` would strip quotes from values
+    like `'001999'` (non-octal digits), causing downstream YAML 1.2 parsers to
+    interpret them as integers and lose leading zeros.
+  type: fix

--- a/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
@@ -1135,4 +1135,49 @@ describe("consistency between AST and streaming parsers", () => {
         expect(streamingResult.filepaths.sort()).toEqual(astResult.filepaths.sort());
         expect(streamingResult.markdown.trim()).toEqual(astResult.markdown.trim());
     });
+
+    describe("leading zero preservation in frontmatter", () => {
+        it("should preserve quoted leading-zero title through parse+stringify round-trip", () => {
+            const page = "---\ntitle: '001999'\ndescription: test\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toContain('"001999"');
+            expect(result.markdown).not.toMatch(/title: 001999\n/);
+        });
+
+        it("should preserve all-octal leading-zero title (already re-quoted by js-yaml)", () => {
+            const page = "---\ntitle: '001015'\ndescription: test\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toMatch(/title: '001015'/);
+        });
+
+        it("should preserve all-zeros title", () => {
+            const page = "---\ntitle: '000000'\ndescription: test\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toMatch(/title: '000000'/);
+        });
+
+        it("should preserve non-octal leading-zero titles that js-yaml would leave unquoted", () => {
+            const nonOctalCases = ["009999", "001599", "002996", "002997", "002998"];
+            for (const val of nonOctalCases) {
+                const page = `---\ntitle: '${val}'\ndescription: test\n---\nBody content`;
+                const result = parseImagePaths(page, PATHS);
+                expect(result.markdown).toContain(`"${val}"`);
+                expect(result.markdown).not.toMatch(new RegExp(`title: ${val}\n`));
+            }
+        });
+
+        it("should not add quotes to normal numeric values without leading zeros", () => {
+            const page = "---\ntitle: 42\nposition: 3\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toContain("title: 42");
+            expect(result.markdown).toContain("position: 3");
+        });
+
+        it("should not add quotes to bare zero", () => {
+            const page = "---\ntitle: 0\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toContain("title: 0");
+            expect(result.markdown).not.toContain('title: "0"');
+        });
+    });
 });

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -17,6 +17,17 @@ import { isMdxExpression, isMdxJsxAttribute, isMdxJsxElement, isMdxJsxExpression
 import { parseMarkdownToTree } from "./parseMarkdownToTree.js";
 import { walkEstreeJsxAttributes } from "./walk-estree-jsx-attributes.js";
 
+/**
+ * Re-quotes unquoted YAML values that have leading zeros after gray-matter's
+ * stringify pass. js-yaml's dump correctly quotes values that are valid octal
+ * (all digits 0-7, e.g. 001015) but leaves values with non-octal digits (8, 9)
+ * unquoted (e.g. 001999). A downstream YAML 1.2 parser then interprets bare
+ * 001999 as the integer 1999, losing the leading zeros.
+ */
+function requoteLeadingZeroValues(yaml: string): string {
+    return yaml.replace(/^(\s*[\w][\w-]*:\s+)(0\d+)\s*$/gm, '$1"$2"');
+}
+
 function getLargeFileBytes(): number {
     return parseInt(process.env.FERN_DOCS_LARGE_FILE_BYTES ?? "5000000", 10);
 }
@@ -527,7 +538,7 @@ export function parseImagePaths(
         replacedContent = applyEdits(content, edits);
     }
 
-    return { filepaths: [...filepaths], markdown: grayMatter.stringify(replacedContent, data) };
+    return { filepaths: [...filepaths], markdown: requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data)) };
 }
 
 function resolvePath(
@@ -933,7 +944,7 @@ export function replaceImagePathsAndUrls(
         replacedContent = applyEdits(content, edits);
     }
 
-    return grayMatter.stringify(replacedContent, data);
+    return requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data));
 }
 
 function getPosition(

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -538,7 +538,10 @@ export function parseImagePaths(
         replacedContent = applyEdits(content, edits);
     }
 
-    return { filepaths: [...filepaths], markdown: requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data)) };
+    return {
+        filepaths: [...filepaths],
+        markdown: requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data))
+    };
 }
 
 function resolvePath(


### PR DESCRIPTION
## Description

Fixes frontmatter values with leading zeros being silently corrupted during `fern generate --docs`. When a page has `title: '001999'` in its MDX frontmatter, the published docs render the title as `1999`.

## Root Cause

`parseImagePaths()` and `replaceImagePathsAndUrls()` round-trip frontmatter through `grayMatter()` → `grayMatter.stringify()`. Under the hood, `grayMatter.stringify` calls `js-yaml.dump()`, which has a subtle quoting bug:

- Values with **only octal digits (0–7)** are correctly re-quoted: `'001015'` → `'001015'` ✓
- Values with **non-octal digits (8, 9)** are left **unquoted**: `'001999'` → `001999` ✗

When the downstream YAML 1.2 parser (in the docs rendering pipeline) sees bare `001999`, it interprets it as integer `1999` — leading zeros gone.

```
source:   title: '001999'
           ↓ gray-matter parse
          data.title = "001999" (string, correct)
           ↓ grayMatter.stringify (js-yaml.dump)
          title: 001999              ← quotes dropped!
           ↓ YAML 1.2 parse in docs renderer
          title = 1999 (integer)     ← leading zeros lost
```

This explains why mangopay error code pages `001015`, `000000`, `002601` (all-octal digits) rendered correctly, while `001999`, `009999`, `001599`, `002996–002998` (contain 8 or 9) were broken.

## Changes Made

- Added `requoteLeadingZeroValues()` post-processing after both `grayMatter.stringify()` call sites in `parseImagePaths.ts`
- The regex `^(\s*[\w][\w-]*:\s+)(0\d+)\s*$` matches only unquoted YAML values starting with `0` followed by more digits — the same values js-yaml failed to quote
- [x] Unit tests added covering working (octal), broken (non-octal), and negative cases (normal numbers, bare zero)
- [x] Changelog entry added

## Testing

- [x] Unit tests added/updated — 6 new test cases covering the exact mangopay page values
- [x] `pnpm turbo run test --filter @fern-api/docs-markdown-utils` passes
- [x] Biome formatting verified

**Note**: A complementary defense-in-depth fix exists in fern-platform (https://github.com/fern-api/fern-platform/pull/12126) at the rendering layer. This CLI fix prevents the data corruption at the source so FDR stores correct frontmatter going forward.

Link to Devin session: https://app.devin.ai/sessions/1796b7a10df74ac4a8d41974e6696cae
Requested by: @cdonel707
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->