### PR TITLE
fix(cli): preserve leading zeros in frontmatter during docs publish

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-leading-zeros-frontmatter.yml
+++ b/packages/cli/cli/changes/unreleased/fix-leading-zeros-frontmatter.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix frontmatter values with leading zeros being corrupted during docs publish.
+    `grayMatter.stringify()` in `parseImagePaths` would strip quotes from values
+    like `'001999'` (non-octal digits), causing downstream YAML 1.2 parsers to
+    interpret them as integers and lose leading zeros.
+  type: fix

--- a/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
@@ -1135,4 +1135,49 @@ describe("consistency between AST and streaming parsers", () => {
         expect(streamingResult.filepaths.sort()).toEqual(astResult.filepaths.sort());
         expect(streamingResult.markdown.trim()).toEqual(astResult.markdown.trim());
     });
+
+    describe("leading zero preservation in frontmatter", () => {
+        it("should preserve quoted leading-zero title through parse+stringify round-trip", () => {
+            const page = "---\ntitle: '001999'\ndescription: test\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toContain('"001999"');
+            expect(result.markdown).not.toMatch(/title: 001999\n/);
+        });
+
+        it("should preserve all-octal leading-zero title (already re-quoted by js-yaml)", () => {
+            const page = "---\ntitle: '001015'\ndescription: test\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toMatch(/title: '001015'/);
+        });
+
+        it("should preserve all-zeros title", () => {
+            const page = "---\ntitle: '000000'\ndescription: test\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toMatch(/title: '000000'/);
+        });
+
+        it("should preserve non-octal leading-zero titles that js-yaml would leave unquoted", () => {
+            const nonOctalCases = ["009999", "001599", "002996", "002997", "002998"];
+            for (const val of nonOctalCases) {
+                const page = `---\ntitle: '${val}'\ndescription: test\n---\nBody content`;
+                const result = parseImagePaths(page, PATHS);
+                expect(result.markdown).toContain(`"${val}"`);
+                expect(result.markdown).not.toMatch(new RegExp(`title: ${val}\n`));
+            }
+        });
+
+        it("should not add quotes to normal numeric values without leading zeros", () => {
+            const page = "---\ntitle: 42\nposition: 3\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toContain("title: 42");
+            expect(result.markdown).toContain("position: 3");
+        });
+
+        it("should not add quotes to bare zero", () => {
+            const page = "---\ntitle: 0\n---\nBody content";
+            const result = parseImagePaths(page, PATHS);
+            expect(result.markdown).toContain("title: 0");
+            expect(result.markdown).not.toContain('title: "0"');
+        });
+    });
 });

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -17,6 +17,17 @@ import { isMdxExpression, isMdxJsxAttribute, isMdxJsxElement, isMdxJsxExpression
 import { parseMarkdownToTree } from "./parseMarkdownToTree.js";
 import { walkEstreeJsxAttributes } from "./walk-estree-jsx-attributes.js";
 
+/**
+ * Re-quotes unquoted YAML values that have leading zeros after gray-matter's
+ * stringify pass. js-yaml's dump correctly quotes values that are valid octal
+ * (all digits 0-7, e.g. 001015) but leaves values with non-octal digits (8, 9)
+ * unquoted (e.g. 001999). A downstream YAML 1.2 parser then interprets bare
+ * 001999 as the integer 1999, losing the leading zeros.
+ */
+function requoteLeadingZeroValues(yaml: string): string {
+    return yaml.replace(/^(\s*[\w][\w-]*:\s+)(0\d+)\s*$/gm, '$1"$2"');
+}
+
 function getLargeFileBytes(): number {
     return parseInt(process.env.FERN_DOCS_LARGE_FILE_BYTES ?? "5000000", 10);
 }
@@ -527,7 +538,7 @@ export function parseImagePaths(
         replacedContent = applyEdits(content, edits);
     }
 
-    return { filepaths: [...filepaths], markdown: grayMatter.stringify(replacedContent, data) };
+    return { filepaths: [...filepaths], markdown: requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data)) };
 }
 
 function resolvePath(
@@ -933,7 +944,7 @@ export function replaceImagePathsAndUrls(
         replacedContent = applyEdits(content, edits);
     }
 
-    return grayMatter.stringify(replacedContent, data);
+    return requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data));
 }
 
 function getPosition(

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -538,7 +538,10 @@ export function parseImagePaths(
         replacedContent = applyEdits(content, edits);
     }
 
-    return { filepaths: [...filepaths], markdown: requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data)) };
+    return {
+        filepaths: [...filepaths],
+        markdown: requoteLeadingZeroValues(grayMatter.stringify(replacedContent, data))
+    };
 }
 
 function resolvePath(


### PR DESCRIPTION
## Description

Fixes frontmatter values with leading zeros being corrupted during docs publish.

`grayMatter.stringify()` in `parseImagePaths` re-serializes frontmatter through js-yaml's `dump`, which only quotes leading-zero values that are valid octal (all digits 0–7, e.g. `001015`). Values containing non-octal digits (8, 9) such as `001999` are emitted unquoted, and downstream YAML 1.2 parsers then read bare `001999` as the integer `1999` — silently dropping the leading zeros.

## Changes Made
- Added `requoteLeadingZeroValues` to `packages/cli/docs-markdown-utils/src/parseImagePaths.ts`, re-quoting unquoted top-level frontmatter values with leading zeros after gray-matter's stringify pass
- Applied it to both `parseImagePaths` and `replaceImagePathsAndUrls` return paths
- Added CLI changelog entry (`type: fix`)

## Testing
- [x] Unit tests added/updated — new cases in `parseImagePaths.test.ts` covering leading-zero values (octal and non-octal digit forms)
- [x] Manual testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->