### PR TITLE
feat(generator-cli): surface replay-degraded runs — PR banner, pipeline JSON, telemetry (train 6/9)

### DIFF
--- a/packages/generator-cli/src/__test__/replay-degraded.test.ts
+++ b/packages/generator-cli/src/__test__/replay-degraded.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplayReport } from "@fern-api/replay";
+import { buildReplayTelemetryProps } from "../pipeline/buildReplayTelemetryProps.js";
+import { composePrBody, formatReplayDegradedBlock, logReplaySummary } from "../pipeline/replay-summary";
+import { ReplayStep } from "../pipeline/steps/ReplayStep";
+import type { PipelineLogger } from "../pipeline/PipelineLogger";
+import type { PipelineResult, ReplayStepConfig, ReplayStepResult } from "../pipeline/types";
+import { readReplayDegraded, replayRun } from "../replay/replay-run";
+
+vi.mock("../replay/replay-run", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../replay/replay-run")>();
+    return {
+        ...actual,
+        replayRun: vi.fn(),
+        replayApply: vi.fn()
+    };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * The degraded fields ship in a future @fern-api/replay release; the pinned
+ * 0.18.0 `ReplayReport` doesn't declare them. Tests intersect the published
+ * type with this shape so fixtures stay cast-free both before and after the
+ * engine version bump.
+ */
+type DegradedReplayFields = {
+    degraded?: boolean;
+    degradedReasons?: unknown;
+};
+
+function makeEngineReport(extra: DegradedReplayFields = {}): ReplayReport & DegradedReplayFields {
+    return {
+        flow: "normal-regeneration",
+        patchesDetected: 1,
+        patchesApplied: 1,
+        patchesWithConflicts: 0,
+        patchesSkipped: 0,
+        conflicts: [],
+        ...extra
+    };
+}
+
+function makeLogger(): PipelineLogger & { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> } {
+    return {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+    };
+}
+
+const DEGRADED_REASONS = [
+    {
+        code: "generation-tree-unreachable",
+        message: "The previous generation (abc1234) was not reachable during this run."
+    },
+    {
+        code: "patch-base-unreachable",
+        message: "2 customization file(s) could not be checked against the generation they were made on."
+    }
+];
+
+// ---------------------------------------------------------------------------
+// readReplayDegraded — tolerant reader over the published engine types
+// ---------------------------------------------------------------------------
+
+describe("readReplayDegraded", () => {
+    it("returns [] for a 0.18.0-shaped report without degraded fields", () => {
+        expect(readReplayDegraded(makeEngineReport())).toEqual([]);
+    });
+
+    it("returns [] when degradedReasons is not an array", () => {
+        expect(readReplayDegraded(makeEngineReport({ degradedReasons: "not-an-array" }))).toEqual([]);
+        expect(readReplayDegraded(makeEngineReport({ degradedReasons: { code: "x", message: "y" } }))).toEqual([]);
+        expect(readReplayDegraded(makeEngineReport({ degradedReasons: null }))).toEqual([]);
+    });
+
+    it("skips malformed entries (missing or non-string code/message)", () => {
+        const reasons = readReplayDegraded(
+            makeEngineReport({
+                degradedReasons: [
+                    { code: "generation-anchor-unreachable", message: "valid entry" },
+                    { code: 42, message: "bad code type" },
+                    { message: "missing code" },
+                    { code: "missing-message" },
+                    null,
+                    "not-an-object"
+                ]
+            })
+        );
+        expect(reasons).toEqual([{ code: "generation-anchor-unreachable", message: "valid entry" }]);
+    });
+
+    it("returns the typed array for well-formed degraded reasons", () => {
+        const reasons = readReplayDegraded(makeEngineReport({ degraded: true, degradedReasons: DEGRADED_REASONS }));
+        expect(reasons).toEqual(DEGRADED_REASONS);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatReplayDegradedBlock
+// ---------------------------------------------------------------------------
+
+describe("formatReplayDegradedBlock", () => {
+    it("returns undefined for undefined / non-executed / healthy results", () => {
+        expect(formatReplayDegradedBlock(undefined)).toBeUndefined();
+        expect(formatReplayDegradedBlock({ executed: false, success: true })).toBeUndefined();
+        expect(
+            formatReplayDegradedBlock({
+                executed: true,
+                success: true,
+                flow: "normal-regeneration",
+                patchesApplied: 3
+            })
+        ).toBeUndefined();
+    });
+
+    it("renders a GitHub warning alert with each reason message when degraded", () => {
+        const block = formatReplayDegradedBlock({
+            executed: true,
+            success: true,
+            flow: "normal-regeneration",
+            degraded: true,
+            degradedReasons: DEGRADED_REASONS
+        });
+        expect(block).toBeDefined();
+        expect(block).toContain("[!WARNING]");
+        expect(block?.toLowerCase()).toContain("may not have been preserved");
+        expect(block?.toLowerCase()).toContain("review");
+        for (const reason of DEGRADED_REASONS) {
+            expect(block).toContain(reason.message);
+        }
+    });
+
+    it("renders the warning block when replay crashed (no reasons list)", () => {
+        const block = formatReplayDegradedBlock({
+            executed: true,
+            success: true,
+            replayCrashed: true,
+            errorMessage: "Error: lockfile corrupted",
+            flow: "normal-regeneration"
+        });
+        expect(block).toBeDefined();
+        expect(block).toContain("[!WARNING]");
+        expect(block?.toLowerCase()).toContain("may not have been preserved");
+        expect(block).toContain("Error: lockfile corrupted");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// composePrBody — degraded block sits at the TOP of the PR body
+// ---------------------------------------------------------------------------
+
+describe("composePrBody", () => {
+    it("returns the plain body when no replay section and no degraded block", () => {
+        expect(composePrBody({ prBody: "SDK update" })).toBe("SDK update");
+    });
+
+    it("appends the replay section after the body", () => {
+        const body = composePrBody({ prBody: "SDK update", replaySection: "replay stuff" });
+        expect(body.indexOf("SDK update")).toBeLessThan(body.indexOf("replay stuff"));
+        expect(body).toContain("---");
+    });
+
+    it("prepends the degraded block at index 0, above the body and the replay section", () => {
+        const body = composePrBody({
+            prBody: "## Version 1.2.3\nSDK update",
+            replaySection: "replay conflict table",
+            degradedBlock: "> [!WARNING]\n> degraded"
+        });
+        expect(body.indexOf("> [!WARNING]")).toBe(0);
+        expect(body.indexOf("> [!WARNING]")).toBeLessThan(body.indexOf("## Version 1.2.3"));
+        expect(body.indexOf("## Version 1.2.3")).toBeLessThan(body.indexOf("replay conflict table"));
+    });
+
+    it("omits the degraded block when absent", () => {
+        const body = composePrBody({ prBody: "SDK update", replaySection: "replay stuff" });
+        expect(body).not.toContain("[!WARNING]");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// logReplaySummary — structured [replay] line gains a trailing degraded= key
+// ---------------------------------------------------------------------------
+
+describe("logReplaySummary degraded key", () => {
+    it("appends degraded=true to the structured line on degraded runs", () => {
+        const logger = makeLogger();
+        logReplaySummary(
+            {
+                executed: true,
+                success: true,
+                flow: "normal-regeneration",
+                degraded: true,
+                degradedReasons: DEGRADED_REASONS
+            },
+            logger
+        );
+        const structured = logger.info.mock.calls[0]?.[0];
+        expect(structured).toContain("[replay] flow=normal-regeneration");
+        expect(structured).toContain("degraded=true");
+    });
+
+    it("appends degraded=false on healthy runs (append-only; existing keys unchanged)", () => {
+        const logger = makeLogger();
+        logReplaySummary(
+            { executed: true, success: true, flow: "normal-regeneration", patchesDetected: 2, patchesApplied: 2 },
+            logger
+        );
+        const structured = logger.info.mock.calls[0]?.[0];
+        expect(structured).toContain("degraded=false");
+        // Frozen grep keys stay present and in order.
+        for (const key of ["flow=", "detected=", "applied=", "conflicts=", "absorbed=", "repointed=", "content_rebased=", "kept_as_user_owned=", "unresolved=", "unresolved_files=", "warnings=", "success="]) {
+            expect(structured).toContain(key);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ReplayStep — maps engine degraded fields into ReplayStepResult
+// ---------------------------------------------------------------------------
+
+describe("ReplayStep degraded mapping", () => {
+    function makeRunResult(report: ReplayReport) {
+        return {
+            report,
+            fernignoreUpdated: false,
+            previousGenerationSha: "prev-sha",
+            currentGenerationSha: "curr-sha",
+            autoBootstrapped: false,
+            bootstrapAttempted: false
+        };
+    }
+
+    it("surfaces degraded reasons from the engine report", async () => {
+        const report: ReplayReport = makeEngineReport({ degraded: true, degradedReasons: DEGRADED_REASONS });
+        vi.mocked(replayRun).mockResolvedValue(makeRunResult(report));
+
+        const config: ReplayStepConfig = { enabled: true, stageOnly: true };
+        const step = new ReplayStep("/tmp/fake", makeLogger(), config);
+        const result = await step.execute({ previousStepResults: {} });
+
+        expect(result.degraded).toBe(true);
+        expect(result.degradedReasons).toEqual(DEGRADED_REASONS);
+    });
+
+    it("leaves degraded fields undefined when the engine report has none (0.18.0)", async () => {
+        vi.mocked(replayRun).mockResolvedValue(makeRunResult(makeEngineReport()));
+
+        const config: ReplayStepConfig = { enabled: true, stageOnly: true };
+        const step = new ReplayStep("/tmp/fake", makeLogger(), config);
+        const result = await step.execute({ previousStepResults: {} });
+
+        expect(result.degraded).toBeUndefined();
+        expect(result.degradedReasons).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline JSON — degraded fields survive serialization (the structured
+// degraded flag in the pipeline JSON is exactly JSON.stringify(PipelineResult))
+// ---------------------------------------------------------------------------
+
+describe("pipeline JSON serialization of degraded fields", () => {
+    it("degraded fields round-trip through JSON.stringify(PipelineResult)", () => {
+        const replay: ReplayStepResult = {
+            executed: true,
+            success: true,
+            flow: "normal-regeneration",
+            patchesDetected: 1,
+            patchesApplied: 0,
+            patchesWithConflicts: 0,
+            degraded: true,
+            degradedReasons: DEGRADED_REASONS
+        };
+        const pipelineResult: PipelineResult = { success: true, steps: { replay } };
+
+        const roundTripped: unknown = JSON.parse(JSON.stringify(pipelineResult));
+        expect(roundTripped).toMatchObject({
+            steps: {
+                replay: {
+                    degraded: true,
+                    degradedReasons: DEGRADED_REASONS
+                }
+            }
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Telemetry — replay_degraded + replay_degraded_reason_codes (append-only)
+// ---------------------------------------------------------------------------
+
+describe("buildReplayTelemetryProps degraded props", () => {
+    const BASE_INPUT = {
+        generatorName: "fernapi/fern-typescript-node-sdk",
+        generatorVersion: "2.6.3",
+        cliVersion: "0.30.0",
+        repoUri: "acme/sdk-typescript",
+        automationMode: false,
+        autoMerge: false,
+        skipIfNoDiff: false,
+        hasBreakingChanges: false,
+        versionArg: "auto" as const,
+        versionBump: "MINOR",
+        replayConfigEnabled: true,
+        noReplayFlag: false,
+        githubMode: "pull-request" as const,
+        previewMode: false,
+        durationMs: 100
+    };
+
+    function propsFor(replay: ReplayStepResult | undefined) {
+        const pipelineResult: PipelineResult = { success: true, steps: { replay } };
+        return buildReplayTelemetryProps({ ...BASE_INPUT, pipelineResult });
+    }
+
+    it("emits replay_degraded=true and joined reason codes on degraded runs", () => {
+        const props = propsFor({
+            executed: true,
+            success: true,
+            flow: "normal-regeneration",
+            degraded: true,
+            degradedReasons: DEGRADED_REASONS
+        });
+        expect(props.replay_degraded).toBe(true);
+        expect(props.replay_degraded_reason_codes).toBe("generation-tree-unreachable,patch-base-unreachable");
+    });
+
+    it("emits replay_degraded=false and null codes on healthy runs", () => {
+        const props = propsFor({ executed: true, success: true, flow: "normal-regeneration" });
+        expect(props.replay_degraded).toBe(false);
+        expect(props.replay_degraded_reason_codes).toBeNull();
+    });
+});

--- a/packages/generator-cli/src/pipeline/buildReplayTelemetryProps.ts
+++ b/packages/generator-cli/src/pipeline/buildReplayTelemetryProps.ts
@@ -147,6 +147,12 @@ export function buildReplayTelemetryProps(input: {
         patches_refreshed: replay?.patchesRefreshed ?? 0,
         unresolved_patches_count: unresolvedPatches.length,
         unresolved_conflict_files_count: unresolvedConflictFilesCount,
+        // Degraded channel (append-only props; frozen dashboard keys once shipped).
+        replay_degraded: replay?.degraded === true,
+        replay_degraded_reason_codes:
+            replay?.degradedReasons != null && replay.degradedReasons.length > 0
+                ? replay.degradedReasons.map((reason) => reason.code).join(",")
+                : null,
         conflicts_same_line_edit: conflictBuckets["same-line-edit"],
         conflicts_new_file_both: conflictBuckets["new-file-both"],
         conflicts_base_generation_mismatch: conflictBuckets["base-generation-mismatch"],

--- a/packages/generator-cli/src/pipeline/replay-summary.ts
+++ b/packages/generator-cli/src/pipeline/replay-summary.ts
@@ -47,6 +47,8 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
     // `success=` reflects whether the replay logic itself succeeded (NOT step.success,
     // which stays true on replay crashes so the orchestrator doesn't abort generation).
     const replayLogicSucceeded = result.replayCrashed !== true;
+    // `degraded=` is APPEND-ONLY: the existing keys are frozen on-call grep
+    // keys (see CONTEXT.md in fern-replay) — never rename or reorder them.
     logger.info(
         `[replay] flow=${result.flow ?? "unknown"} detected=${result.patchesDetected ?? 0} ` +
             `applied=${applied} conflicts=${result.patchesWithConflicts ?? 0} ` +
@@ -54,7 +56,8 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
             `content_rebased=${result.patchesContentRebased ?? 0} ` +
             `kept_as_user_owned=${result.patchesKeptAsUserOwned ?? 0} ` +
             `unresolved=${unresolvedCount} unresolved_files=${unresolvedFiles} ` +
-            `warnings=${result.warnings?.length ?? 0} success=${replayLogicSucceeded}`
+            `warnings=${result.warnings?.length ?? 0} success=${replayLogicSucceeded} ` +
+            `degraded=${result.degraded === true}`
     );
 
     if (preserved > 0) {
@@ -115,6 +118,72 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
     for (const warning of result.warnings ?? []) {
         logger.warn(`Replay: ${warning}`);
     }
+}
+
+/**
+ * Renders the degraded-run warning block for the TOP of a PR body, or
+ * undefined when the run was healthy.
+ *
+ * Deliberately separate from `formatReplayPrBody`: that function returns
+ * undefined when nothing was preserved and nothing conflicted — exactly the
+ * shape of a degraded run — so a degraded warning routed through it would
+ * never render. This block is composed independently via `composePrBody`.
+ *
+ * Also renders when the replay logic crashed (`replayCrashed === true`):
+ * a crashed run ships a PR with zero replay signal otherwise, which is the
+ * same silent-loss hole.
+ */
+export function formatReplayDegradedBlock(result: ReplayStepResult | undefined): string | undefined {
+    if (result == null || !result.executed) {
+        return undefined;
+    }
+
+    const reasons = result.degradedReasons ?? [];
+    const isDegraded = result.degraded === true || reasons.length > 0;
+    const crashed = result.replayCrashed === true;
+    if (!isDegraded && !crashed) {
+        return undefined;
+    }
+
+    const lines: string[] = [];
+    lines.push(`> [!WARNING]`);
+    lines.push(
+        `> **Customizations may not have been preserved in this update — review the diff before merging.**`
+    );
+    if (reasons.length > 0) {
+        lines.push(`>`);
+        for (const reason of reasons) {
+            lines.push(`> - ${reason.message}`);
+        }
+    } else if (crashed) {
+        lines.push(`>`);
+        const detail = result.errorMessage != null ? ` (${result.errorMessage})` : "";
+        lines.push(`> - Replay did not complete on this run${detail}.`);
+    }
+    lines.push(`>`);
+    lines.push(
+        `> The previous generation was not reachable while this update was prepared. ` +
+            `To verify customizations were carried forward, widen the clone window ` +
+            `(e.g. \`git fetch --unshallow\`) and re-run generation.`
+    );
+    return lines.join("\n");
+}
+
+/**
+ * Pure PR-body composition. The degraded block — when present — sits at the
+ * very top, above the version header; the replay section appends after a
+ * divider. One composition site serves both the create-PR and
+ * update-existing-PR paths in GithubStep.
+ */
+export function composePrBody(parts: { prBody: string; replaySection?: string; degradedBlock?: string }): string {
+    let body = parts.prBody;
+    if (parts.replaySection != null) {
+        body = body + "\n\n---\n\n" + parts.replaySection;
+    }
+    if (parts.degradedBlock != null) {
+        body = parts.degradedBlock + "\n\n---\n\n" + body;
+    }
+    return body;
 }
 
 export function formatReplayPrBody(

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -8,7 +8,7 @@ import { findExistingUpdatablePR } from "../github/findExistingUpdatablePR";
 import { parseCommitMessageForPR } from "../github/parseCommitMessage";
 import { pushSignedCommit } from "../github/pushSignedCommit";
 import type { PipelineLogger } from "../PipelineLogger";
-import { formatReplayPrBody } from "../replay-summary";
+import { composePrBody, formatReplayDegradedBlock, formatReplayPrBody } from "../replay-summary";
 import type {
     AutoVersionStepResult,
     GithubStepConfig,
@@ -235,7 +235,12 @@ export class GithubStep extends BaseStep {
             changelogUrl
         );
         const replaySection = formatReplayPrBody(replayResult, { branchName: prBranch, repoUri: this.config.uri });
-        let enrichedBody = replaySection != null ? prBody + "\n\n---\n\n" + replaySection : prBody;
+        // Degraded runs ship loudly, never withheld: the warning block sits at
+        // the TOP of the PR body, above the version header. It is composed
+        // separately from `replaySection` because formatReplayPrBody returns
+        // undefined for the zero-preserved/zero-conflict shape of degraded runs.
+        const degradedBlock = formatReplayDegradedBlock(replayResult);
+        let enrichedBody = composePrBody({ prBody, replaySection, degradedBlock });
         enrichedBody = enrichPrBodyForAutomation(enrichedBody, this.config, resolved);
 
         if (isUpdatingExistingPR && existingPR != null) {

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -1,4 +1,4 @@
-import { replayApply, replayRun } from "../../replay/replay-run";
+import { readReplayDegraded, replayApply, replayRun } from "../../replay/replay-run";
 import type { PipelineLogger } from "../PipelineLogger";
 import type { PipelineContext, ReplayStepConfig, ReplayStepResult } from "../types";
 import { BaseStep } from "./BaseStep";
@@ -116,9 +116,14 @@ export class ReplayStep extends BaseStep {
         }
 
         const report = result.report;
+        // Tolerant of engine versions without the degraded channel: the reader
+        // returns [] on reports that predate `degradedReasons`.
+        const degradedReasons = readReplayDegraded(report);
         return {
             executed: true,
             success: true,
+            degraded: degradedReasons.length > 0 ? true : undefined,
+            degradedReasons: degradedReasons.length > 0 ? degradedReasons : undefined,
             previousGenerationSha: result.previousGenerationSha ?? undefined,
             currentGenerationSha: result.currentGenerationSha ?? undefined,
             autoBootstrapped: result.autoBootstrapped,

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -229,6 +229,23 @@ export interface ReplayStepResult extends StepResult {
         }>;
     }>;
     warnings?: string[];
+    /**
+     * True when the replay run completed but could not guarantee customizations
+     * were preserved — the previous generation (the baseline) was unreachable
+     * during the run (shallow clone / pruned history). Mirrors the engine
+     * report's `degraded` field; undefined on healthy runs AND on engine
+     * versions that don't emit it yet. Serialized into the pipeline JSON.
+     */
+    degraded?: boolean;
+    /**
+     * Structured reasons for a degraded run. `code` is intentionally widened to
+     * `string` so future engine reason codes pass through without a consumer
+     * release. The same facts also appear as strings in `warnings`.
+     */
+    degradedReasons?: Array<{
+        code: string;
+        message: string;
+    }>;
 }
 
 export interface FernignoreStepResult extends StepResult {

--- a/packages/generator-cli/src/replay/replay-run.ts
+++ b/packages/generator-cli/src/replay/replay-run.ts
@@ -236,6 +236,45 @@ export async function replayApply(prepared: PreparedReplay, params: ReplayApplyP
 }
 
 /**
+ * Tolerant reader for the engine's degraded channel. The pinned
+ * `@fern-api/replay` release may predate `ReplayReport.degradedReasons`
+ * (added after 0.18.0), so this walks the report as `unknown` and returns
+ * only well-formed `{ code, message }` entries — `[]` when the field is
+ * absent or malformed. Reason codes are kept as plain strings so future
+ * engine codes pass through without a consumer release.
+ */
+export function readReplayDegraded(report: ReplayReport): Array<{ code: string; message: string }> {
+    const candidate: unknown = report;
+    if (typeof candidate !== "object" || candidate == null) {
+        return [];
+    }
+    if (!("degradedReasons" in candidate)) {
+        return [];
+    }
+    const value: unknown = candidate.degradedReasons;
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    const reasons: Array<{ code: string; message: string }> = [];
+    for (const entry of value) {
+        const candidateEntry: unknown = entry;
+        if (typeof candidateEntry !== "object" || candidateEntry == null) {
+            continue;
+        }
+        if (!("code" in candidateEntry) || !("message" in candidateEntry)) {
+            continue;
+        }
+        const code: unknown = candidateEntry.code;
+        const message: unknown = candidateEntry.message;
+        if (typeof code !== "string" || typeof message !== "string") {
+            continue;
+        }
+        reasons.push({ code, message });
+    }
+    return reasons;
+}
+
+/**
  * Backwards-compatible atomic entry point. Composes `replayPrepare` +
  * `replayApply` with byte-identical behavior for existing callers.
  */


### PR DESCRIPTION
## Merge train: 6 of 9 (generator-cli 1/4) — merge after the engine train (PRs 1–5)

Part of the replay hardening train from the 2026-06-11 coingecko incident (Linear: FER-11258). Consumer half of engine train PR 1. Safe to merge against the currently pinned `@fern-api/replay` 0.18.0 — the reader is tolerant and returns no degraded reasons until the engine publish + pin bump activates the feature end-to-end.

## Summary

When a replay run cannot verify that customizations were preserved (unreachable anchor in a shallow clone — the incident shape), the regen PR used to ship with no signal. Per the recorded decision (engine ADR-0003): **the PR always ships, loudly** — no withholding, no commit-status/label gating (replay is force-disabled outside pull-request mode, so a human gate always exists).

- `composePrBody` prepends a prominent warning block at **index 0** of the PR body ("customizations may not have been preserved — review before merging"); `enrichPrBodyForAutomation` only appends, so the block stays at the top; one composition site serves both `pulls.create` and `pulls.update`
- Structured `degraded` flag rides `ReplayStepResult` into the pipeline JSON (round-trip tested) and telemetry
- A crashed replay run (previously zero replay signal on the PR) also renders a degraded block
- `logReplaySummary` grep keys remain frozen (append-only change, pinned by test)

## Test plan

- New `replay-degraded.test.ts` 18/18 (independently re-run); PR-body block position asserted at index 0, above the version header
- Six adjacent suites (replay-pure, serialization, telemetry, github-step-branch, createReplayBranch, automation) 81/81
- Full generator-cli suite: 434 passed / 1 skipped, uncached re-run; `pnpm turbo run compile` 13/13
- Forward-compat (engine-linked) path verified via an alias run against the engine branch build: degraded reasons flow through end-to-end

## Review

Adversarially reviewed: **approve, zero required changes**. One cosmetic follow-up flagged (not applied here to keep the reviewed tree intact): the degraded-block footer asserts "the previous generation was not reachable", which can be inaccurate for crash-only renders — make it conditional on `degradedReasons` being non-empty when convenient.

Linear: FER-11258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->