### PR TITLE
feat(generator-cli): permanent-dismiss path for conflicted customizations; unhide forget (train 7/9)

### DIFF
--- a/packages/generator-cli/src/__test__/replay-pure.test.ts
+++ b/packages/generator-cli/src/__test__/replay-pure.test.ts
@@ -331,6 +331,33 @@ describe("formatReplayPrBody", () => {
         expect(dataRows[0]).toContain("a.ts");
         expect(dataRows[1]).toContain("b.ts");
     });
+
+    it("conflict body offers the permanent-dismiss alternative with an actionable patch ID", () => {
+        const body = formatReplayPrBody({
+            executed: true,
+            success: false,
+            patchesApplied: 0,
+            patchesAbsorbed: 0,
+            unresolvedPatches: [
+                {
+                    patchId: "patch-6cf172ea",
+                    patchMessage: "add retry logic",
+                    files: ["src/client.ts"],
+                    conflictDetails: [{ file: "src/client.ts", conflictReason: "same-line-edit" }]
+                }
+            ]
+        });
+        expect(body).toBeDefined();
+        // The alternative instruction names the forget command...
+        expect(body).toContain("permanently dismiss");
+        expect(body).toContain("fern replay forget <patch-id>");
+        // ...and the table surfaces the patch ID so the command is actionable.
+        const lines = body?.split("\n") ?? [];
+        const dataRows = lines.filter((l) => l.startsWith("| `"));
+        expect(dataRows.some((row) => row.includes("patch-6cf172ea"))).toBe(true);
+        // The remembered-on-future-generations promise stays.
+        expect(body).toContain("Your resolved customizations will be remembered on future SDK generations.");
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -455,7 +455,7 @@ void yargs(hideBin(process.argv))
                 )
                 .command(
                     "forget [args..]",
-                    false, // hidden from --help
+                    "Permanently dismiss tracked customizations by patch ID, file pattern, or --all",
                     (subYargs) => {
                         return subYargs
                             .positional("args", {

--- a/packages/generator-cli/src/pipeline/replay-summary.ts
+++ b/packages/generator-cli/src/pipeline/replay-summary.ts
@@ -158,8 +158,11 @@ export function formatReplayPrBody(
         parts.push(`|------|-------------------|-------------------|`);
         for (const patch of unresolvedPatches) {
             const description = patchDescription(patch);
+            // Surface the patch ID so the permanent-dismiss instruction below
+            // (`fern replay forget <patch-id>`) is actionable from the PR body.
+            const descriptionWithId = patch.patchId ? `${description} (\`${patch.patchId}\`)` : description;
             for (const file of patch.conflictDetails) {
-                parts.push(`| \`${file.file}\` | ${description} | ${formatConflictReason(file.conflictReason)} |`);
+                parts.push(`| \`${file.file}\` | ${descriptionWithId} | ${formatConflictReason(file.conflictReason)} |`);
             }
         }
 
@@ -185,6 +188,9 @@ export function formatReplayPrBody(
         parts.push(`4. Resolve using your editor's merge tools (VS Code, IntelliJ, etc.)`);
         parts.push(`5. Run: \`fern replay resolve\` again to finalize`);
         parts.push(`6. Push your changes\n`);
+        parts.push(
+            `To permanently dismiss a customization instead — keep the generated code, and it will not return on future generations — run: \`fern replay forget <patch-id>\` (patch IDs are shown in the table above).\n`
+        );
         parts.push(`Your resolved customizations will be remembered on future SDK generations.`);
         parts.push(
             `If you merge this PR without resolving, your unresolved customizations will conflict again on the next generation.`


### PR DESCRIPTION
## Merge train: 7 of 9 (generator-cli 2/4) — merge after train PR 6

Part of the replay hardening train from the 2026-06-11 coingecko incident (Linear: FER-11258). Consumer half of engine train PR 2 (resolve-by-rejection tombstones, engine ADR-0004). Safe against the pinned `@fern-api/replay` 0.18.0; dismissal data flows automatically after the pin bump.

## Summary

Rejected conflicts now stay rejected on the engine side — this PR makes the dismissal path visible to customers:

- Conflict PR bodies gain the alternative instruction: *to permanently dismiss this customization: `fern replay forget <patch-id>`* — with patch IDs appended to the conflict table so the command is actionable
- The `forget` subcommand is unhidden in help with real text (it previously had a `false` description)
- The existing PR-body promise "Your resolved customizations will be remembered on future SDK generations" becomes true for rejections once the engine side lands
- Pure string/template changes — no `any`, no casts; `replay status` remains a JSON pass-through, so dismissed entries flow automatically post-bump

## Test plan

- Generator-cli suite uncached: 417 passed / 1 skipped with the package's exact vitest flags (a turbo cache replay was rejected as evidence; this is a genuine re-run)
- PR-body snapshot/string assertions for the dismiss instruction and table IDs

## Review

Adversarially reviewed: **approve, zero required changes**. Coordination item recorded on FER-11258: at the next `@fern-api/replay` pin bump, `replay-forget.ts` and its yargs handler must `await` the now-async `forget` (tsc will catch it — explicit `ForgetResult` return type).

Linear: FER-11258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->