### PR TITLE
fix(swift): support API types named Data and optional request bodies

### DIFF
--- a/generators/swift/base/src/template/Sources/HTTPClient.Template.swift
+++ b/generators/swift/base/src/template/Sources/HTTPClient.Template.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/generators/swift/base/src/template/Tests/ClientErrorTests.Template.swift
+++ b/generators/swift/base/src/template/Tests/ClientErrorTests.Template.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
 <%= clientDeclaration %>
@@ -35,7 +35,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
 <%= clientDeclaration %>
@@ -60,7 +60,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
 <%= clientDeclaration %>
@@ -87,7 +87,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
 <%= clientDeclaration %>
@@ -112,7 +112,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
 <%= clientDeclaration %>
@@ -139,7 +139,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
 <%= clientDeclaration %>
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
 <%= clientDeclaration %>

--- a/generators/swift/base/src/template/Tests/ClientRetryTests.Template.swift
+++ b/generators/swift/base/src/template/Tests/ClientRetryTests.Template.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -25,11 +25,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -44,11 +44,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -63,10 +63,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -83,7 +83,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -101,7 +101,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -134,11 +134,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -167,11 +167,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -196,11 +196,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -221,27 +221,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -256,7 +256,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
 <%= clientDeclaration %>
@@ -273,7 +273,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/generators/swift/base/src/template/Tests/HTTPStub.Template.swift
+++ b/generators/swift/base/src/template/Tests/HTTPStub.Template.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -739,7 +739,12 @@ export class EndpointSnippetGenerator {
 
         this.context.errors.scope(Scope.RequestBody);
         if (request.body != null) {
-            args.push(this.getEndpointMethodBodyRequestArg({ body: request.body, value: snippet.requestBody }));
+            const bodyArg = this.getEndpointMethodBodyRequestArg({ body: request.body, value: snippet.requestBody });
+            // Omit the body argument entirely when it has no literal (e.g. an absent optional
+            // request body), rather than emitting `request: ` with an empty value.
+            if (!bodyArg.value.isNop()) {
+                args.push(bodyArg);
+            }
         }
         this.context.errors.unscope();
 
@@ -761,6 +766,11 @@ export class EndpointSnippetGenerator {
                     value: this.getBytesBodyRequestArg({ value })
                 });
             case "typeReference":
+                // An absent optional request body produces no literal, so the `request`
+                // argument is omitted entirely rather than emitting an empty initializer.
+                if (body.value.type === "optional" && value == null) {
+                    return swift.functionArgument({ label: "request", value: swift.Expression.nop() });
+                }
                 return swift.functionArgument({
                     label: "request",
                     value: this.context.dynamicTypeLiteralMapper.convert({

--- a/generators/swift/sdk/changes/unreleased/fix-data-type-name-shadowing.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-data-type-name-shadowing.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fully qualify `Foundation.Data` in the generated HTTP client and test
+    templates. When an API defined a type named `Data`, the generated
+    top-level `Data` type shadowed `Foundation.Data` in those templates, so the
+    request-body builder and stub helpers resolved to the wrong type and failed
+    to compile. The remaining bare `Data` references now use `Foundation.Data`,
+    matching the convention already used elsewhere in the runtime.
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-optional-request-body.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-optional-request-body.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Default an optional referenced request body to `nil` in the generated client
+    method, and omit the `request` argument from snippets and wire tests when an
+    example provides no body. Previously the parameter had no default value while
+    snippets emitted an empty initializer for the wrapped type, so endpoints with
+    an absent optional request body failed to compile.
+  type: fix

--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -114,14 +114,19 @@ export class EndpointMethodGenerator {
 
         if (endpoint.requestBody) {
             if (endpoint.requestBody.type === "reference") {
+                const requestBodySwiftType = this.sdkGeneratorContext.getSwiftTypeReferenceFromScope(
+                    endpoint.requestBody.requestBodyType,
+                    this.parentClassSymbol
+                );
                 params.push(
                     swift.functionParameter({
                         argumentLabel: "request",
                         unsafeName: "request",
-                        type: this.sdkGeneratorContext.getSwiftTypeReferenceFromScope(
-                            endpoint.requestBody.requestBodyType,
-                            this.parentClassSymbol
-                        ),
+                        type: requestBodySwiftType,
+                        defaultValue:
+                            requestBodySwiftType.variant.type === "optional"
+                                ? swift.Expression.rawValue("nil")
+                                : undefined,
                         docsContent: endpoint.requestBody.docs
                     })
                 );

--- a/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
@@ -93,7 +93,7 @@ export class WireTestFunctionGenerator {
                                 swift.functionArgument({
                                     label: "body",
                                     value: swift.Expression.structInitialization({
-                                        unsafeName: "Data",
+                                        unsafeName: "Foundation.Data",
                                         arguments_: [
                                             swift.functionArgument({
                                                 value: swift.Expression.memberAccess({

--- a/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/accept-header/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/accept-header/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/accept-header/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = AcceptClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = AcceptClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = AcceptClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = AcceptClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = AcceptClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = AcceptClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = AcceptClient(

--- a/seed/swift-sdk/accept-header/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/accept-header/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = AcceptClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/accept-header/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/accept-header/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/alias-extends/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/alias-extends/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = AliasExtendsClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = AliasExtendsClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = AliasExtendsClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = AliasExtendsClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = AliasExtendsClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = AliasExtendsClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = AliasExtendsClient(

--- a/seed/swift-sdk/alias-extends/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/alias-extends/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = AliasExtendsClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/alias-extends/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/alias-extends/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/alias/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/alias/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/alias/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = AliasClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = AliasClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = AliasClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = AliasClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = AliasClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = AliasClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = AliasClient(

--- a/seed/swift-sdk/alias/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/alias/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = AliasClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/alias/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/alias/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/allof-inline/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/allof-inline/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/allof-inline/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/allof-inline/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/allof-inline/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/allof-inline/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/allof-inline/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/allof-inline/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/allof/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/allof/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/allof/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/allof/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/allof/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/allof/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/allof/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/allof/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/any-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/any-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/any-auth/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = AnyAuthClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = AnyAuthClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = AnyAuthClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = AnyAuthClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = AnyAuthClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = AnyAuthClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = AnyAuthClient(

--- a/seed/swift-sdk/any-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/any-auth/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = AnyAuthClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/any-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/any-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/any-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/any-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import AnyAuth
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/any-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/any-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import AnyAuth
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -43,7 +43,7 @@ import AnyAuth
     @Test func getAdmins1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/api-wide-base-path-with-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path-with-default/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/api-wide-base-path-with-default/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/api-wide-base-path-with-default/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/api-wide-base-path-with-default/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/api-wide-base-path-with-default/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/api-wide-base-path-with-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/api-wide-base-path-with-default/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/api-wide-base-path-with-default/Tests/Wire/Resources/Widgets/WidgetsClientWireTests.swift
+++ b/seed/swift-sdk/api-wide-base-path-with-default/Tests/Wire/Resources/Widgets/WidgetsClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func create1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name"
@@ -34,7 +34,7 @@ import Api
     @Test func create2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name"

--- a/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/api-wide-base-path/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/api-wide-base-path/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiWideBasePathClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiWideBasePathClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiWideBasePathClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiWideBasePathClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiWideBasePathClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiWideBasePathClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiWideBasePathClient(

--- a/seed/swift-sdk/api-wide-base-path/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/api-wide-base-path/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiWideBasePathClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/api-wide-base-path/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/api-wide-base-path/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/audiences/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/audiences/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = AudiencesClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = AudiencesClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = AudiencesClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = AudiencesClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = AudiencesClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = AudiencesClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = AudiencesClient(

--- a/seed/swift-sdk/audiences/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = AudiencesClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/audiences/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/audiences/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Audiences
     @Test func getDirectThread1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "foo": {

--- a/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Audiences
     @Test func getDirectThread1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "foo": "foo"

--- a/seed/swift-sdk/audiences/Tests/Wire/Resources/Foo/FooClientWireTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Wire/Resources/Foo/FooClientWireTests.swift
@@ -6,7 +6,7 @@ import Audiences
     @Test func find1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "imported": "imported"

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/basic-auth-environment-variables/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -42,7 +42,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -74,7 +74,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -108,7 +108,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -140,7 +140,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -174,7 +174,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -206,7 +206,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = BasicAuthEnvironmentVariablesClient(

--- a/seed/swift-sdk/basic-auth-environment-variables/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -32,11 +32,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -58,11 +58,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,10 +84,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -111,7 +111,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -136,7 +136,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -186,11 +186,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -226,11 +226,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -262,11 +262,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -294,27 +294,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -336,7 +336,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = BasicAuthEnvironmentVariablesClient(
@@ -360,7 +360,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/basic-auth-environment-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/basic-auth-environment-variables/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
@@ -6,7 +6,7 @@ import BasicAuthEnvironmentVariables
     @Test func getWithBasicAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -26,7 +26,7 @@ import BasicAuthEnvironmentVariables
     @Test func postWithBasicAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/basic-auth-pw-omitted/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/basic-auth-pw-omitted/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = BasicAuthPwOmittedClient(
@@ -42,7 +42,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = BasicAuthPwOmittedClient(
@@ -74,7 +74,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = BasicAuthPwOmittedClient(
@@ -108,7 +108,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = BasicAuthPwOmittedClient(
@@ -140,7 +140,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = BasicAuthPwOmittedClient(
@@ -174,7 +174,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = BasicAuthPwOmittedClient(
@@ -206,7 +206,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = BasicAuthPwOmittedClient(

--- a/seed/swift-sdk/basic-auth-pw-omitted/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -32,11 +32,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -58,11 +58,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,10 +84,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -111,7 +111,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -136,7 +136,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -186,11 +186,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -226,11 +226,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -262,11 +262,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -294,27 +294,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -336,7 +336,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = BasicAuthPwOmittedClient(
@@ -360,7 +360,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/basic-auth-pw-omitted/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/basic-auth-pw-omitted/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
@@ -6,7 +6,7 @@ import BasicAuthPwOmitted
     @Test func getWithBasicAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -26,7 +26,7 @@ import BasicAuthPwOmitted
     @Test func getWithBasicAuth2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -46,7 +46,7 @@ import BasicAuthPwOmitted
     @Test func postWithBasicAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -71,7 +71,7 @@ import BasicAuthPwOmitted
     @Test func postWithBasicAuth2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/basic-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/basic-auth/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = BasicAuthClient(
@@ -42,7 +42,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = BasicAuthClient(
@@ -74,7 +74,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = BasicAuthClient(
@@ -108,7 +108,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = BasicAuthClient(
@@ -140,7 +140,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = BasicAuthClient(
@@ -174,7 +174,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = BasicAuthClient(
@@ -206,7 +206,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = BasicAuthClient(

--- a/seed/swift-sdk/basic-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/basic-auth/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -32,11 +32,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -58,11 +58,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,10 +84,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -111,7 +111,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -136,7 +136,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -186,11 +186,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -226,11 +226,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -262,11 +262,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -294,27 +294,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -336,7 +336,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = BasicAuthClient(
@@ -360,7 +360,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/basic-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/basic-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/basic-auth/Tests/Wire/Resources/BasicAuth/BasicAuthClient_WireTests.swift
+++ b/seed/swift-sdk/basic-auth/Tests/Wire/Resources/BasicAuth/BasicAuthClient_WireTests.swift
@@ -6,7 +6,7 @@ import BasicAuth
     @Test func getWithBasicAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -26,7 +26,7 @@ import BasicAuth
     @Test func getWithBasicAuth2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -46,7 +46,7 @@ import BasicAuth
     @Test func postWithBasicAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -71,7 +71,7 @@ import BasicAuth
     @Test func postWithBasicAuth2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/bearer-token-environment-variable/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = BearerTokenEnvironmentVariableClient(

--- a/seed/swift-sdk/bearer-token-environment-variable/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = BearerTokenEnvironmentVariableClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/bearer-token-environment-variable/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/bearer-token-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import BearerTokenEnvironmentVariable
     @Test func getWithBearerToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/bytes-download/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/bytes-download/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = BytesDownloadClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = BytesDownloadClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = BytesDownloadClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = BytesDownloadClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = BytesDownloadClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = BytesDownloadClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = BytesDownloadClient(

--- a/seed/swift-sdk/bytes-download/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/bytes-download/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = BytesDownloadClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/bytes-download/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/bytes-download/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/bytes-upload/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/bytes-upload/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = BytesUploadClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = BytesUploadClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = BytesUploadClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = BytesUploadClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = BytesUploadClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = BytesUploadClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = BytesUploadClient(

--- a/seed/swift-sdk/bytes-upload/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/bytes-upload/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = BytesUploadClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/bytes-upload/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/bytes-upload/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/circular-references-advanced/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/circular-references-advanced/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/circular-references-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references-extends/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/circular-references-extends/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/circular-references-extends/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/circular-references/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/circular-references/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/cli-multi-spec-namespaced/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cli-multi-spec-namespaced/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -42,7 +42,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -74,7 +74,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -108,7 +108,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -140,7 +140,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -174,7 +174,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -206,7 +206,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -32,11 +32,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -58,11 +58,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,10 +84,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -111,7 +111,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -136,7 +136,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -186,11 +186,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -226,11 +226,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -262,11 +262,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -294,27 +294,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -336,7 +336,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -360,7 +360,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Wire/Resources/V1/V1ClientWireTests.swift
+++ b/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Wire/Resources/V1/V1ClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func listUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -36,7 +36,7 @@ import Api
     @Test func listUsers2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Wire/Resources/V2/V2ClientWireTests.swift
+++ b/seed/swift-sdk/cli-multi-spec-namespaced/Tests/Wire/Resources/V2/V2ClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func listUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -42,7 +42,7 @@ import Api
     @Test func listUsers2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/cli-multi-spec/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cli-multi-spec/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/cli-multi-spec/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/cli-multi-spec/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/cli-multi-spec/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/cli-multi-spec/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/cli-multi-spec/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/cli-multi-spec/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ClientSideParamsClient(
@@ -50,7 +50,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ClientSideParamsClient(
@@ -90,7 +90,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ClientSideParamsClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ClientSideParamsClient(
@@ -172,7 +172,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ClientSideParamsClient(
@@ -214,7 +214,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ClientSideParamsClient(
@@ -254,7 +254,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ClientSideParamsClient(

--- a/seed/swift-sdk/client-side-params/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -40,11 +40,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -74,11 +74,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -108,10 +108,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -143,7 +143,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -176,7 +176,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -290,11 +290,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,11 +334,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -374,27 +374,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,7 +424,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ClientSideParamsClient(
@@ -456,7 +456,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/client-side-params/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/client-side-params/no-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import ClientSideParams
     @Test func listResources1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -88,7 +88,7 @@ import ClientSideParams
     @Test func getResource1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -136,7 +136,7 @@ import ClientSideParams
     @Test func searchResources1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [
@@ -229,7 +229,7 @@ import ClientSideParams
     @Test func listUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "users": [
@@ -484,7 +484,7 @@ import ClientSideParams
     @Test func getUserById1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "user_id": "user_id",
@@ -612,7 +612,7 @@ import ClientSideParams
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "user_id": "user_id",
@@ -756,7 +756,7 @@ import ClientSideParams
     @Test func updateUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "user_id": "user_id",
@@ -901,7 +901,7 @@ import ClientSideParams
     @Test func listConnections1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -1035,7 +1035,7 @@ import ClientSideParams
     @Test func getConnection1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -1110,7 +1110,7 @@ import ClientSideParams
     @Test func listClients1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "start": 1,
@@ -1484,7 +1484,7 @@ import ClientSideParams
     @Test func getClient1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "client_id": "client_id",

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/client-side-params/with-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = MyCustomClient(
@@ -50,7 +50,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = MyCustomClient(
@@ -90,7 +90,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = MyCustomClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = MyCustomClient(
@@ -172,7 +172,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = MyCustomClient(
@@ -214,7 +214,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = MyCustomClient(
@@ -254,7 +254,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = MyCustomClient(

--- a/seed/swift-sdk/client-side-params/with-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -40,11 +40,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -74,11 +74,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -108,10 +108,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -143,7 +143,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -176,7 +176,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -290,11 +290,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,11 +334,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -374,27 +374,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,7 +424,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = MyCustomClient(
@@ -456,7 +456,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/client-side-params/with-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/client-side-params/with-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import MyCustomModule
     @Test func listResources1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -88,7 +88,7 @@ import MyCustomModule
     @Test func getResource1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -136,7 +136,7 @@ import MyCustomModule
     @Test func searchResources1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [
@@ -229,7 +229,7 @@ import MyCustomModule
     @Test func listUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "users": [
@@ -484,7 +484,7 @@ import MyCustomModule
     @Test func getUserById1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "user_id": "user_id",
@@ -612,7 +612,7 @@ import MyCustomModule
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "user_id": "user_id",
@@ -756,7 +756,7 @@ import MyCustomModule
     @Test func updateUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "user_id": "user_id",
@@ -901,7 +901,7 @@ import MyCustomModule
     @Test func listConnections1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -1035,7 +1035,7 @@ import MyCustomModule
     @Test func getConnection1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -1110,7 +1110,7 @@ import MyCustomModule
     @Test func listClients1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "start": 1,
@@ -1484,7 +1484,7 @@ import MyCustomModule
     @Test func getClient1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "client_id": "client_id",

--- a/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/content-type/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/content-type/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/content-type/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ContentTypesClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ContentTypesClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ContentTypesClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ContentTypesClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ContentTypesClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ContentTypesClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ContentTypesClient(

--- a/seed/swift-sdk/content-type/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/content-type/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ContentTypesClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/content-type/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/content-type/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/cross-package-type-names/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = CrossPackageTypeNamesClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = CrossPackageTypeNamesClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = CrossPackageTypeNamesClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = CrossPackageTypeNamesClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = CrossPackageTypeNamesClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = CrossPackageTypeNamesClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = CrossPackageTypeNamesClient(

--- a/seed/swift-sdk/cross-package-type-names/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = CrossPackageTypeNamesClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/cross-package-type-names/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import CrossPackageTypeNames
     @Test func getDirectThread1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "foo": {

--- a/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import CrossPackageTypeNames
     @Test func getDirectThread1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "foo": {

--- a/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/Foo/FooClientWireTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/Foo/FooClientWireTests.swift
@@ -6,7 +6,7 @@ import CrossPackageTypeNames
     @Test func find1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "imported": "imported"

--- a/seed/swift-sdk/dollar-string-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/dollar-string-examples/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/dollar-string-examples/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/dollar-string-examples/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/empty-clients/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/empty-clients/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/endpoint-security-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = EndpointSecurityAuthClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = EndpointSecurityAuthClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = EndpointSecurityAuthClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = EndpointSecurityAuthClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = EndpointSecurityAuthClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = EndpointSecurityAuthClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = EndpointSecurityAuthClient(

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = EndpointSecurityAuthClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import EndpointSecurityAuth
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import EndpointSecurityAuth
     @Test func getWithBearer1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -43,7 +43,7 @@ import EndpointSecurityAuth
     @Test func getWithApiKey1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -80,7 +80,7 @@ import EndpointSecurityAuth
     @Test func getWithOAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -117,7 +117,7 @@ import EndpointSecurityAuth
     @Test func getWithBasic1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -154,7 +154,7 @@ import EndpointSecurityAuth
     @Test func getWithInferredAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -191,7 +191,7 @@ import EndpointSecurityAuth
     @Test func getWithAnyAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -228,7 +228,7 @@ import EndpointSecurityAuth
     @Test func getWithAllAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/enum/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/enum/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/enum/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = EnumClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = EnumClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = EnumClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = EnumClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = EnumClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = EnumClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = EnumClient(

--- a/seed/swift-sdk/enum/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/enum/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = EnumClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/enum/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/enum/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/error-property/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/error-property/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/error-property/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ErrorPropertyClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ErrorPropertyClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ErrorPropertyClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ErrorPropertyClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ErrorPropertyClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ErrorPropertyClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ErrorPropertyClient(

--- a/seed/swift-sdk/error-property/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/error-property/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ErrorPropertyClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/error-property/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/error-property/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/error-property/Tests/Wire/Resources/PropertyBasedError/PropertyBasedErrorClientWireTests.swift
+++ b/seed/swift-sdk/error-property/Tests/Wire/Resources/PropertyBasedError/PropertyBasedErrorClientWireTests.swift
@@ -6,7 +6,7 @@ import ErrorProperty
     @Test func throwError1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/errors/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/errors/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/errors/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ErrorsClient(
@@ -45,7 +45,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ErrorsClient(
@@ -80,7 +80,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ErrorsClient(
@@ -117,7 +117,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ErrorsClient(
@@ -152,7 +152,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ErrorsClient(
@@ -189,7 +189,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ErrorsClient(
@@ -224,7 +224,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ErrorsClient(

--- a/seed/swift-sdk/errors/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/errors/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -35,11 +35,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -64,11 +64,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -93,10 +93,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,7 +123,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -151,7 +151,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -207,11 +207,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -250,11 +250,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -289,11 +289,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -324,27 +324,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -369,7 +369,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ErrorsClient(
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/errors/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/errors/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/errors/Tests/Wire/Resources/Simple/SimpleClientWireTests.swift
+++ b/seed/swift-sdk/errors/Tests/Wire/Resources/Simple/SimpleClientWireTests.swift
@@ -6,7 +6,7 @@ import Errors
     @Test func fooWithoutEndpointError1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "bar": "bar"
@@ -33,7 +33,7 @@ import Errors
     @Test func foo1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "bar": "bar"
@@ -60,7 +60,7 @@ import Errors
     @Test func fooWithExamples1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "bar": "hello"
@@ -87,7 +87,7 @@ import Errors
     @Test func fooWithExamples4() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "bar": "bar"

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Service/ServiceClient_.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Resources/Service/ServiceClient_.swift
@@ -52,7 +52,7 @@ public final class ServiceClient_: Sendable {
         )
     }
 
-    public func refreshToken(request: RefreshTokenRequest?, requestOptions: RequestOptions? = nil) async throws -> Void {
+    public func refreshToken(request: RefreshTokenRequest? = nil, requestOptions: RequestOptions? = nil) async throws -> Void {
         return try await httpClient.performRequest(
             method: .post,
             path: "/refresh-token",

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ExamplesClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ExamplesClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example20.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example20.swift
@@ -8,8 +8,6 @@ enum Example20 {
             token: "<token>"
         )
 
-        _ = try await client.service.refreshToken(request: RefreshTokenRequest(
-
-        ))
+        _ = try await client.service.refreshToken()
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func getException1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "generic",
@@ -42,7 +42,7 @@ import Examples
     @Test func getException2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "generic",

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func getFile2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func ping1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -25,7 +25,7 @@ import Examples
     @Test func ping2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func getMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "movie-c06a4ad7",
@@ -72,7 +72,7 @@ import Examples
     @Test func getMovie2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -126,7 +126,7 @@ import Examples
     @Test func createMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 movie-c06a4ad7
                 """#.utf8
@@ -169,7 +169,7 @@ import Examples
     @Test func createMovie2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -206,7 +206,7 @@ import Examples
     @Test func getMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "html",
@@ -240,7 +240,7 @@ import Examples
     @Test func getMetadata2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "html",
@@ -272,7 +272,7 @@ import Examples
     @Test func createBigEntity1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "response": {

--- a/seed/swift-sdk/examples/no-custom-config/reference.md
+++ b/seed/swift-sdk/examples/no-custom-config/reference.md
@@ -881,9 +881,7 @@ import Examples
 private func main() async throws {
     let client = ExamplesClient(token: "<token>")
 
-    _ = try await client.service.refreshToken(request: RefreshTokenRequest(
-
-    ))
+    _ = try await client.service.refreshToken()
 }
 
 try await main()

--- a/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/examples/readme-config/Sources/Resources/Service/ServiceClient_.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Resources/Service/ServiceClient_.swift
@@ -52,7 +52,7 @@ public final class ServiceClient_: Sendable {
         )
     }
 
-    public func refreshToken(request: RefreshTokenRequest?, requestOptions: RequestOptions? = nil) async throws -> Void {
+    public func refreshToken(request: RefreshTokenRequest? = nil, requestOptions: RequestOptions? = nil) async throws -> Void {
         return try await httpClient.performRequest(
             method: .post,
             path: "/refresh-token",

--- a/seed/swift-sdk/examples/readme-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ExamplesClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ExamplesClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/readme-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ExamplesClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example20.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example20.swift
@@ -8,8 +8,6 @@ enum Example20 {
             token: "<token>"
         )
 
-        _ = try await client.service.refreshToken(request: RefreshTokenRequest(
-
-        ))
+        _ = try await client.service.refreshToken()
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func getException1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "generic",
@@ -42,7 +42,7 @@ import Examples
     @Test func getException2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "generic",

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func getFile2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func ping1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -25,7 +25,7 @@ import Examples
     @Test func ping2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -6,7 +6,7 @@ import Examples
     @Test func getMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "movie-c06a4ad7",
@@ -72,7 +72,7 @@ import Examples
     @Test func getMovie2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -126,7 +126,7 @@ import Examples
     @Test func createMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 movie-c06a4ad7
                 """#.utf8
@@ -169,7 +169,7 @@ import Examples
     @Test func createMovie2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -206,7 +206,7 @@ import Examples
     @Test func getMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "html",
@@ -240,7 +240,7 @@ import Examples
     @Test func getMetadata2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "html",
@@ -272,7 +272,7 @@ import Examples
     @Test func createBigEntity1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "response": {

--- a/seed/swift-sdk/examples/readme-config/reference.md
+++ b/seed/swift-sdk/examples/readme-config/reference.md
@@ -881,9 +881,7 @@ import Examples
 private func main() async throws {
     let client = ExamplesClient(token: "<token>")
 
-    _ = try await client.service.refreshToken(request: RefreshTokenRequest(
-
-    ))
+    _ = try await client.service.refreshToken()
 }
 
 try await main()

--- a/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Container/ContainerClient.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Resources/Endpoints/Container/ContainerClient.swift
@@ -77,7 +77,7 @@ public final class ContainerClient: Sendable {
         )
     }
 
-    public func getAndReturnOptional(request: ObjectWithRequiredField?, requestOptions: RequestOptions? = nil) async throws -> ObjectWithRequiredField? {
+    public func getAndReturnOptional(request: ObjectWithRequiredField? = nil, requestOptions: RequestOptions? = nil) async throws -> ObjectWithRequiredField? {
         return try await httpClient.performRequest(
             method: .post,
             path: "/container/opt-objects",

--- a/seed/swift-sdk/exhaustive/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ExhaustiveClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ExhaustiveClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ExhaustiveClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ExhaustiveClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ExhaustiveClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ExhaustiveClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ExhaustiveClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/exhaustive/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Container/ContainerClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Container/ContainerClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getAndReturnListOfPrimitives1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   "string",
@@ -37,7 +37,7 @@ import Exhaustive
     @Test func getAndReturnListOfObjects1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -80,7 +80,7 @@ import Exhaustive
     @Test func getAndReturnSetOfPrimitives1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   "string"
@@ -101,7 +101,7 @@ import Exhaustive
     @Test func getAndReturnSetOfObjects1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -124,7 +124,7 @@ import Exhaustive
     @Test func getAndReturnMapPrimToPrim1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string"
@@ -152,7 +152,7 @@ import Exhaustive
     @Test func getAndReturnMapOfPrimToObject1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": {
@@ -186,7 +186,7 @@ import Exhaustive
     @Test func getAndReturnMapOfPrimToUndiscriminatedUnion1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": 1.1
@@ -218,7 +218,7 @@ import Exhaustive
     @Test func getAndReturnOptional1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string"

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Enum/EnumClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Enum/EnumClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getAndReturnEnum1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "SUNNY"
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/HttpMethods/HttpMethodsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/HttpMethods/HttpMethodsClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func testGet1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -28,7 +28,7 @@ import Exhaustive
     @Test func testPost1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -92,7 +92,7 @@ import Exhaustive
     @Test func testPut1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -157,7 +157,7 @@ import Exhaustive
     @Test func testPatch1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -237,7 +237,7 @@ import Exhaustive
     @Test func testDelete1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Object/ObjectClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Object/ObjectClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getAndReturnWithOptionalField1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -85,7 +85,7 @@ import Exhaustive
     @Test func getAndReturnWithRequiredField1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string"
@@ -113,7 +113,7 @@ import Exhaustive
     @Test func getAndReturnWithMapOfMap1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "map": {
@@ -153,7 +153,7 @@ import Exhaustive
     @Test func getAndReturnNestedWithOptionalField1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -241,7 +241,7 @@ import Exhaustive
     @Test func getAndReturnNestedWithRequiredField1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -330,7 +330,7 @@ import Exhaustive
     @Test func getAndReturnNestedWithRequiredFieldAsList1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -441,7 +441,7 @@ import Exhaustive
     @Test func getAndReturnWithUnknownField1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "unknown": {
@@ -477,7 +477,7 @@ import Exhaustive
     @Test func getAndReturnWithUnknownField2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "unknown": {
@@ -513,7 +513,7 @@ import Exhaustive
     @Test func getAndReturnWithDocumentedUnknownType1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "documentedUnknownType": {
@@ -549,7 +549,7 @@ import Exhaustive
     @Test func getAndReturnMapOfDocumentedUnknownType1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": {
@@ -585,7 +585,7 @@ import Exhaustive
     @Test func getAndReturnWithMixedRequiredAndOptionalFields1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "requiredString": "hello",
@@ -622,7 +622,7 @@ import Exhaustive
     @Test func getAndReturnWithMixedRequiredAndOptionalFields2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "requiredString": "requiredString",
@@ -659,7 +659,7 @@ import Exhaustive
     @Test func getAndReturnWithRequiredNestedObject1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "requiredString": "hello",
@@ -703,7 +703,7 @@ import Exhaustive
     @Test func getAndReturnWithRequiredNestedObject2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "requiredString": "requiredString",
@@ -800,7 +800,7 @@ import Exhaustive
     @Test func getAndReturnWithDatetimeLikeString1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "datetimeLikeString": "2023-08-31T14:15:22Z",
@@ -831,7 +831,7 @@ import Exhaustive
     @Test func getAndReturnWithDatetimeLikeString2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "datetimeLikeString": "datetimeLikeString",

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Pagination/PaginationClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Pagination/PaginationClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func listItems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "items": [

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Params/ParamsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Params/ParamsClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getWithPath1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -28,7 +28,7 @@ import Exhaustive
     @Test func getWithInlinePath1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -50,7 +50,7 @@ import Exhaustive
     @Test func modifyWithPath1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -73,7 +73,7 @@ import Exhaustive
     @Test func modifyWithInlinePath1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -96,7 +96,7 @@ import Exhaustive
     @Test func uploadWithPath1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "uploaded"
@@ -123,7 +123,7 @@ import Exhaustive
     @Test func getWithBooleanPath1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -145,7 +145,7 @@ import Exhaustive
     @Test func getWithPathAndErrors1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Primitive/PrimitiveClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Primitive/PrimitiveClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getAndReturnString1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -28,7 +28,7 @@ import Exhaustive
     @Test func getAndReturnInt1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 1
                 """#.utf8
@@ -50,7 +50,7 @@ import Exhaustive
     @Test func getAndReturnLong1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 1000000
                 """#.utf8
@@ -72,7 +72,7 @@ import Exhaustive
     @Test func getAndReturnDouble1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 1.1
                 """#.utf8
@@ -94,7 +94,7 @@ import Exhaustive
     @Test func getAndReturnBool1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -116,7 +116,7 @@ import Exhaustive
     @Test func getAndReturnDatetime1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "2024-01-15T09:30:00Z"
                 """#.utf8
@@ -138,7 +138,7 @@ import Exhaustive
     @Test func getAndReturnDate1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "2023-01-15"
                 """#.utf8
@@ -160,7 +160,7 @@ import Exhaustive
     @Test func getAndReturnUuid1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 """#.utf8
@@ -182,7 +182,7 @@ import Exhaustive
     @Test func getAndReturnBase641() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 SGVsbG8gd29ybGQh
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Put/PutClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Put/PutClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func add1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "errors": [

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Union/UnionClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getAndReturnUnion1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "animal": "dog",

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Urls/UrlsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Urls/UrlsClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func withMixedCase1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -25,7 +25,7 @@ import Exhaustive
     @Test func noEndingSlash1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -44,7 +44,7 @@ import Exhaustive
     @Test func withEndingSlash1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -63,7 +63,7 @@ import Exhaustive
     @Test func withUnderscores1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/InlinedRequests/InlinedRequestsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/InlinedRequests/InlinedRequestsClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func postWithObjectBodyandResponse1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -89,7 +89,7 @@ import Exhaustive
     @Test func postWithArrayBodyAndHeaders1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoAuth/NoAuthClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoAuth/NoAuthClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func postWithNoAuth1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoReqBody/NoReqBodyClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoReqBody/NoReqBodyClientWireTests.swift
@@ -6,7 +6,7 @@ import Exhaustive
     @Test func getWithNoRequestBody1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": "string",
@@ -65,7 +65,7 @@ import Exhaustive
     @Test func postWithNoRequestBody1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extends/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/extends/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/extends/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ExtendsClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ExtendsClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ExtendsClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ExtendsClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ExtendsClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ExtendsClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ExtendsClient(

--- a/seed/swift-sdk/extends/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/extends/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ExtendsClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/extends/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/extends/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/extra-properties/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/extra-properties/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ExtraPropertiesClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ExtraPropertiesClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ExtraPropertiesClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ExtraPropertiesClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ExtraPropertiesClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ExtraPropertiesClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ExtraPropertiesClient(

--- a/seed/swift-sdk/extra-properties/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/extra-properties/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ExtraPropertiesClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/extra-properties/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/extra-properties/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/extra-properties/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/extra-properties/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import ExtraProperties
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "Alice",
@@ -41,7 +41,7 @@ import ExtraProperties
     @Test func createUser2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name"

--- a/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-download/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/file-download/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/file-download/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = FileDownloadClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = FileDownloadClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = FileDownloadClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = FileDownloadClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = FileDownloadClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = FileDownloadClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = FileDownloadClient(

--- a/seed/swift-sdk/file-download/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/file-download/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = FileDownloadClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/file-download/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/file-download/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/file-upload-openapi/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/file-upload-openapi/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/file-upload-openapi/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/file-upload-openapi/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/file-upload-openapi/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/file-upload-openapi/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/file-upload-openapi/Tests/Wire/Resources/FileUploadExample/FileUploadExampleClientWireTests.swift
+++ b/seed/swift-sdk/file-upload-openapi/Tests/Wire/Resources/FileUploadExample/FileUploadExampleClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func uploadFile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/file-upload/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/file-upload/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/file-upload/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/file-upload/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/file-upload/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import FileUpload
     @Test func optionalArgs1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 Foo
                 """#.utf8
@@ -27,7 +27,7 @@ import FileUpload
     @Test func withRefBody1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 Success
                 """#.utf8

--- a/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/folders/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/folders/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/folders/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/folders/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/folders/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/folders/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/folders/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/header-auth-environment-variable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = HeaderTokenEnvironmentVariableClient(

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = HeaderTokenEnvironmentVariableClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import HeaderTokenEnvironmentVariable
     @Test func getWithBearerToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/header-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/header-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/header-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/header-auth/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = HeaderTokenClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = HeaderTokenClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = HeaderTokenClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = HeaderTokenClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = HeaderTokenClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = HeaderTokenClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = HeaderTokenClient(

--- a/seed/swift-sdk/header-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/header-auth/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = HeaderTokenClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/header-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/header-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/header-auth/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/header-auth/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import HeaderToken
     @Test func getWithBearerToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/http-head/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/http-head/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/http-head/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = HttpHeadClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = HttpHeadClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = HttpHeadClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = HttpHeadClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = HttpHeadClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = HttpHeadClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = HttpHeadClient(

--- a/seed/swift-sdk/http-head/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/http-head/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = HttpHeadClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/http-head/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/http-head/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/http-head/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/http-head/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import HttpHead
     @Test func list1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/idempotency-headers/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = IdempotencyHeadersClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = IdempotencyHeadersClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = IdempotencyHeadersClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = IdempotencyHeadersClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = IdempotencyHeadersClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = IdempotencyHeadersClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = IdempotencyHeadersClient(

--- a/seed/swift-sdk/idempotency-headers/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = IdempotencyHeadersClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/idempotency-headers/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/idempotency-headers/Tests/Wire/Resources/Payment/PaymentClientWireTests.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Wire/Resources/Payment/PaymentClientWireTests.swift
@@ -6,7 +6,7 @@ import IdempotencyHeaders
     @Test func create1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 """#.utf8

--- a/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/imdb/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/imdb/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/imdb/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/imdb/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/imdb/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/imdb/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/imdb/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/imdb/Tests/Wire/Resources/Imdb/ImdbClientWireTests.swift
+++ b/seed/swift-sdk/imdb/Tests/Wire/Resources/Imdb/ImdbClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func createMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -31,7 +31,7 @@ import Api
     @Test func createMovie2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -56,7 +56,7 @@ import Api
     @Test func getMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -86,7 +86,7 @@ import Api
     @Test func getMovie2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = InferredAuthExplicitClient(
@@ -50,7 +50,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = InferredAuthExplicitClient(
@@ -90,7 +90,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = InferredAuthExplicitClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = InferredAuthExplicitClient(
@@ -172,7 +172,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = InferredAuthExplicitClient(
@@ -214,7 +214,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = InferredAuthExplicitClient(
@@ -254,7 +254,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = InferredAuthExplicitClient(

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -40,11 +40,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -74,11 +74,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -108,10 +108,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -143,7 +143,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -176,7 +176,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -290,11 +290,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,11 +334,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -374,27 +374,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,7 +424,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = InferredAuthExplicitClient(
@@ -456,7 +456,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import InferredAuthExplicit
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -42,7 +42,7 @@ import InferredAuthExplicit
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = InferredAuthImplicitApiKeyClient(

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = InferredAuthImplicitApiKeyClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import InferredAuthImplicitApiKey
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -50,7 +50,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -90,7 +90,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -172,7 +172,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -214,7 +214,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -254,7 +254,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = InferredAuthImplicitNoExpiryClient(

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -40,11 +40,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -74,11 +74,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -108,10 +108,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -143,7 +143,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -176,7 +176,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -290,11 +290,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,11 +334,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -374,27 +374,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,7 +424,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = InferredAuthImplicitNoExpiryClient(
@@ -456,7 +456,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import InferredAuthImplicitNoExpiry
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -40,7 +40,7 @@ import InferredAuthImplicitNoExpiry
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = InferredAuthImplicitClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = InferredAuthImplicitClient(

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = InferredAuthImplicitClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import InferredAuthImplicit
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -41,7 +41,7 @@ import InferredAuthImplicit
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -50,7 +50,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -90,7 +90,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -172,7 +172,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = InferredAuthImplicitClient(
@@ -214,7 +214,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = InferredAuthImplicitClient(
@@ -254,7 +254,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = InferredAuthImplicitClient(

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -40,11 +40,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -74,11 +74,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -108,10 +108,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -143,7 +143,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -176,7 +176,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -290,11 +290,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,11 +334,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -374,27 +374,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,7 +424,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = InferredAuthImplicitClient(
@@ -456,7 +456,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import InferredAuthImplicit
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -42,7 +42,7 @@ import InferredAuthImplicit
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/license/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/license/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/license/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = LicenseClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = LicenseClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = LicenseClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = LicenseClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = LicenseClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = LicenseClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = LicenseClient(

--- a/seed/swift-sdk/license/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/license/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = LicenseClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/license/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/license/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/literal-user-agent/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal-user-agent/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/literal-user-agent/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/literal-user-agent/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = LiteralUserAgentClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = LiteralUserAgentClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = LiteralUserAgentClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = LiteralUserAgentClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = LiteralUserAgentClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = LiteralUserAgentClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = LiteralUserAgentClient(

--- a/seed/swift-sdk/literal-user-agent/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/literal-user-agent/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = LiteralUserAgentClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/literal-user-agent/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/literal-user-agent/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literal/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/literal/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/literal/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = LiteralClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = LiteralClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = LiteralClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = LiteralClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = LiteralClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = LiteralClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = LiteralClient(

--- a/seed/swift-sdk/literal/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/literal/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = LiteralClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/literal/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/literal/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Headers/HeadersClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Headers/HeadersClientWireTests.swift
@@ -6,7 +6,7 @@ import Literal
     @Test func send1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "The weather is sunny",
@@ -35,7 +35,7 @@ import Literal
     @Test func send2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "message",

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Inlined/InlinedClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Inlined/InlinedClientWireTests.swift
@@ -6,7 +6,7 @@ import Literal
     @Test func send1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "The weather is sunny",
@@ -48,7 +48,7 @@ import Literal
     @Test func send2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "message",

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Path/PathClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Path/PathClientWireTests.swift
@@ -6,7 +6,7 @@ import Literal
     @Test func send1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "The weather is sunny",
@@ -35,7 +35,7 @@ import Literal
     @Test func send2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "message",

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Query/QueryClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Query/QueryClientWireTests.swift
@@ -6,7 +6,7 @@ import Literal
     @Test func send1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "The weather is sunny",
@@ -43,7 +43,7 @@ import Literal
     @Test func send2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "message",

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Reference/ReferenceClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Reference/ReferenceClientWireTests.swift
@@ -6,7 +6,7 @@ import Literal
     @Test func send1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "The weather is sunny",
@@ -50,7 +50,7 @@ import Literal
     @Test func send2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "message": "message",

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/literals-unions/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/literals-unions/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/mixed-case/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/mixed-case/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = MixedCaseClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = MixedCaseClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = MixedCaseClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = MixedCaseClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = MixedCaseClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = MixedCaseClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = MixedCaseClient(

--- a/seed/swift-sdk/mixed-case/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/mixed-case/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = MixedCaseClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/mixed-case/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/mixed-case/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/mixed-case/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/mixed-case/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import MixedCase
     @Test func getResource1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "status": "ACTIVE",
@@ -55,7 +55,7 @@ import MixedCase
     @Test func getResource2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "resource_type": "user",
@@ -102,7 +102,7 @@ import MixedCase
     @Test func listResources1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -156,7 +156,7 @@ import MixedCase
     @Test func listResources2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/mixed-file-directory/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = MixedFileDirectoryClient(
@@ -45,7 +45,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = MixedFileDirectoryClient(
@@ -80,7 +80,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = MixedFileDirectoryClient(
@@ -117,7 +117,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = MixedFileDirectoryClient(
@@ -152,7 +152,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = MixedFileDirectoryClient(
@@ -189,7 +189,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = MixedFileDirectoryClient(
@@ -224,7 +224,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = MixedFileDirectoryClient(

--- a/seed/swift-sdk/mixed-file-directory/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -35,11 +35,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -64,11 +64,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -93,10 +93,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,7 +123,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -151,7 +151,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -207,11 +207,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -250,11 +250,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -289,11 +289,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -324,27 +324,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -369,7 +369,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = MixedFileDirectoryClient(
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/mixed-file-directory/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/Organization/OrganizationClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/Organization/OrganizationClientWireTests.swift
@@ -6,7 +6,7 @@ import MixedFileDirectory
     @Test func create1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/EventsClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/EventsClientWireTests.swift
@@ -6,7 +6,7 @@ import MixedFileDirectory
     @Test func listEvents1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/Metadata/MetadataClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/Metadata/MetadataClientWireTests.swift
@@ -6,7 +6,7 @@ import MixedFileDirectory
     @Test func getMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import MixedFileDirectory
     @Test func list1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/multi-line-docs/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/multi-line-docs/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = MultiLineDocsClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = MultiLineDocsClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = MultiLineDocsClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = MultiLineDocsClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = MultiLineDocsClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = MultiLineDocsClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = MultiLineDocsClient(

--- a/seed/swift-sdk/multi-line-docs/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/multi-line-docs/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = MultiLineDocsClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/multi-line-docs/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-line-docs/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/multi-line-docs/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/multi-line-docs/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import MultiLineDocs
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/multi-url-environment-no-default/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = MultiUrlEnvironmentNoDefaultClient(

--- a/seed/swift-sdk/multi-url-environment-no-default/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = MultiUrlEnvironmentNoDefaultClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/multi-url-environment-no-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/multi-url-environment-no-default/Tests/Wire/Resources/S3/S3ClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Tests/Wire/Resources/S3/S3ClientWireTests.swift
@@ -6,7 +6,7 @@ import MultiUrlEnvironmentNoDefault
     @Test func getPresignedUrl1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/multi-url-environment-reference/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func gettoken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token"
@@ -34,7 +34,7 @@ import Api
     @Test func gettoken2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token"

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Files/FilesClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Files/FilesClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func upload1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -30,7 +30,7 @@ import Api
     @Test func upload2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Items/ItemsClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Items/ItemsClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func listItems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -24,7 +24,7 @@ import Api
     @Test func listItems2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/multi-url-environment/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/multi-url-environment/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = MultiUrlEnvironmentClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = MultiUrlEnvironmentClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = MultiUrlEnvironmentClient(

--- a/seed/swift-sdk/multi-url-environment/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/multi-url-environment/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = MultiUrlEnvironmentClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/multi-url-environment/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multi-url-environment/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/multi-url-environment/Tests/Wire/Resources/S3/S3ClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment/Tests/Wire/Resources/S3/S3ClientWireTests.swift
@@ -6,7 +6,7 @@ import MultiUrlEnvironment
     @Test func getPresignedUrl1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/multiple-request-bodies/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/multiple-request-bodies/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/multiple-request-bodies/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/no-content-response/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-content-response/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/no-content-response/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/no-content-response/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/no-content-response/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/no-content-response/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/no-content-response/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/no-content-response/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/no-content-response/Tests/Wire/Resources/Contacts/ContactsClientWireTests.swift
+++ b/seed/swift-sdk/no-content-response/Tests/Wire/Resources/Contacts/ContactsClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func create1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -35,7 +35,7 @@ import Api
     @Test func create2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -67,7 +67,7 @@ import Api
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -96,7 +96,7 @@ import Api
     @Test func get2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-environment/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/no-environment/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/no-environment/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NoEnvironmentClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NoEnvironmentClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NoEnvironmentClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NoEnvironmentClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NoEnvironmentClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NoEnvironmentClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NoEnvironmentClient(

--- a/seed/swift-sdk/no-environment/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/no-environment/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NoEnvironmentClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/no-environment/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/no-environment/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/no-environment/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/no-environment/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -6,7 +6,7 @@ import NoEnvironment
     @Test func getDummy1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/no-retries/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/no-retries/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/no-retries/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/no-retries/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NoRetriesClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NoRetriesClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NoRetriesClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NoRetriesClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NoRetriesClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NoRetriesClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NoRetriesClient(

--- a/seed/swift-sdk/no-retries/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/no-retries/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NoRetriesClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/no-retries/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/no-retries/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/no-retries/Tests/Wire/Resources/Retries/RetriesClientWireTests.swift
+++ b/seed/swift-sdk/no-retries/Tests/Wire/Resources/Retries/RetriesClientWireTests.swift
@@ -6,7 +6,7 @@ import NoRetries
     @Test func getUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/null-type/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/null-type/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/null-type/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/null-type/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/null-type/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/null-type/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/null-type/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/null-type/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/null-type/Tests/Wire/Resources/Conversations/ConversationsClientWireTests.swift
+++ b/seed/swift-sdk/null-type/Tests/Wire/Resources/Conversations/ConversationsClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func outboundCall1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "conversation_id": {
@@ -39,7 +39,7 @@ import Api
     @Test func outboundCall2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "conversation_id": {

--- a/seed/swift-sdk/null-type/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/null-type/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -41,7 +41,7 @@ import Api
     @Test func get2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/nullable-allof-extends/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-allof-extends/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/nullable-allof-extends/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/nullable-allof-extends/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/nullable-allof-extends/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/nullable-allof-extends/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/nullable-allof-extends/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable-allof-extends/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NullableOptionalClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NullableOptionalClient(

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NullableOptionalClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
@@ -6,7 +6,7 @@ import NullableOptional
     @Test func getUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -59,7 +59,7 @@ import NullableOptional
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -125,7 +125,7 @@ import NullableOptional
     @Test func updateUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -192,7 +192,7 @@ import NullableOptional
     @Test func listUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -286,7 +286,7 @@ import NullableOptional
     @Test func searchUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -380,7 +380,7 @@ import NullableOptional
     @Test func createComplexProfile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -754,7 +754,7 @@ import NullableOptional
     @Test func getComplexProfile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -1015,7 +1015,7 @@ import NullableOptional
     @Test func updateComplexProfile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -1310,7 +1310,7 @@ import NullableOptional
     @Test func testDeserialization1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "echo": {
@@ -1510,7 +1510,7 @@ import NullableOptional
     @Test func filterByRole1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -1603,7 +1603,7 @@ import NullableOptional
     @Test func getNotificationSettings1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "email",
@@ -1638,7 +1638,7 @@ import NullableOptional
     @Test func updateTags1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   "string",
@@ -1679,7 +1679,7 @@ import NullableOptional
     @Test func getSearchResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NullableOptionalClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NullableOptionalClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NullableOptionalClient(

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NullableOptionalClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
@@ -6,7 +6,7 @@ import NullableOptional
     @Test func getUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -59,7 +59,7 @@ import NullableOptional
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -125,7 +125,7 @@ import NullableOptional
     @Test func updateUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -192,7 +192,7 @@ import NullableOptional
     @Test func listUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -286,7 +286,7 @@ import NullableOptional
     @Test func searchUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -380,7 +380,7 @@ import NullableOptional
     @Test func createComplexProfile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -754,7 +754,7 @@ import NullableOptional
     @Test func getComplexProfile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -1015,7 +1015,7 @@ import NullableOptional
     @Test func updateComplexProfile1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -1310,7 +1310,7 @@ import NullableOptional
     @Test func testDeserialization1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "echo": {
@@ -1510,7 +1510,7 @@ import NullableOptional
     @Test func filterByRole1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -1603,7 +1603,7 @@ import NullableOptional
     @Test func getNotificationSettings1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "email",
@@ -1638,7 +1638,7 @@ import NullableOptional
     @Test func updateTags1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   "string",
@@ -1679,7 +1679,7 @@ import NullableOptional
     @Test func getSearchResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/nullable-request-body/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable-request-body/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/nullable-request-body/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/nullable-request-body/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/nullable-request-body/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/nullable-request-body/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/nullable-request-body/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable-request-body/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/nullable-request-body/Tests/Wire/Resources/TestGroup/TestGroupClientWireTests.swift
+++ b/seed/swift-sdk/nullable-request-body/Tests/Wire/Resources/TestGroup/TestGroupClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func testMethodName1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "key": "value"
@@ -36,7 +36,7 @@ import Api
     @Test func testMethodName2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "key": "value"

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/nullable/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NullableClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NullableClient(

--- a/seed/swift-sdk/nullable/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NullableClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/nullable/no-custom-config/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
@@ -6,7 +6,7 @@ import Nullable
     @Test func getUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -158,7 +158,7 @@ import Nullable
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -258,7 +258,7 @@ import Nullable
     @Test func deleteUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/nullable/nullable-as-optional/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NullableClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NullableClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NullableClient(

--- a/seed/swift-sdk/nullable/nullable-as-optional/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NullableClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/nullable/nullable-as-optional/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
@@ -6,7 +6,7 @@ import Nullable
     @Test func getUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -158,7 +158,7 @@ import Nullable
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -258,7 +258,7 @@ import Nullable
     @Test func deleteUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-custom/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -51,7 +51,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -92,7 +92,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -135,7 +135,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -176,7 +176,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -219,7 +219,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsClient(
@@ -260,7 +260,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsClient(

--- a/seed/swift-sdk/oauth-client-credentials-custom/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -41,11 +41,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -76,11 +76,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -111,10 +111,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -147,7 +147,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -181,7 +181,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -249,11 +249,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -343,11 +343,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -384,27 +384,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -435,7 +435,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsClient(
@@ -468,7 +468,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-custom/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-custom/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentials
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -43,7 +43,7 @@ import OauthClientCredentials
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-default/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsDefaultClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsDefaultClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsDefaultClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsDefaultClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsDefaultClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsDefaultClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsDefaultClient(

--- a/seed/swift-sdk/oauth-client-credentials-default/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsDefaultClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-default/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentialsDefault
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentialsEnvironmentVariables
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -41,7 +41,7 @@ import OauthClientCredentialsEnvironmentVariables
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsMandatoryAuthClient(

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentialsMandatoryAuth
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -41,7 +41,7 @@ import OauthClientCredentialsMandatoryAuth
     @Test func getTokenWithClientCredentials2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -76,7 +76,7 @@ import OauthClientCredentialsMandatoryAuth
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -112,7 +112,7 @@ import OauthClientCredentialsMandatoryAuth
     @Test func refreshToken2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsClient(

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentials
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Identity/IdentityClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Identity/IdentityClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -38,7 +38,7 @@ import Api
     @Test func getToken2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Plants/PlantsClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Plants/PlantsClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func list1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -36,7 +36,7 @@ import Api
     @Test func list2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -76,7 +76,7 @@ import Api
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -105,7 +105,7 @@ import Api
     @Test func get2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/oauth-client-credentials-reference/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-reference/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsReferenceClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsReferenceClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsReferenceClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsReferenceClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsReferenceClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsReferenceClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsReferenceClient(

--- a/seed/swift-sdk/oauth-client-credentials-reference/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsReferenceClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-reference/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentialsReference
     @Test func getToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -36,7 +36,7 @@ import OauthClientCredentialsReference
     @Test func getToken2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsWithVariablesClient(

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsWithVariablesClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentialsWithVariables
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -41,7 +41,7 @@ import OauthClientCredentialsWithVariables
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/oauth-client-credentials/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -49,7 +49,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -88,7 +88,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -129,7 +129,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -168,7 +168,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = OauthClientCredentialsClient(
@@ -209,7 +209,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = OauthClientCredentialsClient(
@@ -248,7 +248,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = OauthClientCredentialsClient(

--- a/seed/swift-sdk/oauth-client-credentials/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -39,11 +39,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -72,11 +72,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -105,10 +105,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -139,7 +139,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -235,11 +235,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -282,11 +282,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,11 +325,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -364,27 +364,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -413,7 +413,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = OauthClientCredentialsClient(
@@ -444,7 +444,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/oauth-client-credentials/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/oauth-client-credentials/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import OauthClientCredentials
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -41,7 +41,7 @@ import OauthClientCredentials
     @Test func getTokenWithClientCredentials2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -76,7 +76,7 @@ import OauthClientCredentials
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -112,7 +112,7 @@ import OauthClientCredentials
     @Test func refreshToken2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/object/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/object/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/objects-with-imports/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/objects-with-imports/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/openapi-request-body-ref/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Catalog/CatalogClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Catalog/CatalogClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func createCatalogImage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -48,7 +48,7 @@ import Api
     @Test func getCatalogImage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -85,7 +85,7 @@ import Api
     @Test func getCatalogImage2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/TeamMember/TeamMemberClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/TeamMember/TeamMemberClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func updateTeamMember1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -36,7 +36,7 @@ import Api
     @Test func updateTeamMember2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Vendor/VendorClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Vendor/VendorClientWireTests.swift
@@ -6,7 +6,7 @@ import Api
     @Test func updateVendor1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -46,7 +46,7 @@ import Api
     @Test func updateVendor2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -87,7 +87,7 @@ import Api
     @Test func createVendor1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -124,7 +124,7 @@ import Api
     @Test func createVendor2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/openapi-subtitle/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/openapi-subtitle/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/openapi-subtitle/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/openapi-subtitle/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/openapi-subtitle/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/openapi-subtitle/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/openapi-subtitle/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/openapi-subtitle/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/optional/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/optional/Sources/Resources/Optional/OptionalClient.swift
+++ b/seed/swift-sdk/optional/Sources/Resources/Optional/OptionalClient.swift
@@ -7,7 +7,7 @@ public final class OptionalClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func sendOptionalBody(request: [String: JSONValue]?, requestOptions: RequestOptions? = nil) async throws -> String {
+    public func sendOptionalBody(request: [String: JSONValue]? = nil, requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/send-optional-body",
@@ -17,7 +17,7 @@ public final class OptionalClient: Sendable {
         )
     }
 
-    public func sendOptionalTypedBody(request: SendOptionalBodyRequest?, requestOptions: RequestOptions? = nil) async throws -> String {
+    public func sendOptionalTypedBody(request: SendOptionalBodyRequest? = nil, requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/send-optional-typed-body",
@@ -31,7 +31,7 @@ public final class OptionalClient: Sendable {
     /// This should not generate wire tests expecting {} when Optional.empty() is passed.
     ///
     /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
-    public func sendOptionalNullableWithAllOptionalProperties(actionId: String, id: String, request: Nullable<DeployParams>?, requestOptions: RequestOptions? = nil) async throws -> DeployResponse {
+    public func sendOptionalNullableWithAllOptionalProperties(actionId: String, id: String, request: Nullable<DeployParams>? = nil, requestOptions: RequestOptions? = nil) async throws -> DeployResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/deploy/\(actionId)/versions/\(id)",

--- a/seed/swift-sdk/optional/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/optional/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ObjectsWithImportsClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ObjectsWithImportsClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ObjectsWithImportsClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ObjectsWithImportsClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ObjectsWithImportsClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ObjectsWithImportsClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ObjectsWithImportsClient(

--- a/seed/swift-sdk/optional/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/optional/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ObjectsWithImportsClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/optional/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/optional/Tests/Wire/Resources/Optional/OptionalClientWireTests.swift
+++ b/seed/swift-sdk/optional/Tests/Wire/Resources/Optional/OptionalClientWireTests.swift
@@ -6,7 +6,7 @@ import ObjectsWithImports
     @Test func sendOptionalBody1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -31,7 +31,7 @@ import ObjectsWithImports
     @Test func sendOptionalTypedBody1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -54,7 +54,7 @@ import ObjectsWithImports
     @Test func sendOptionalNullableWithAllOptionalProperties1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "success": true

--- a/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/package-yml/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/package-yml/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/package-yml/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PackageYmlClient(
@@ -47,7 +47,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PackageYmlClient(
@@ -84,7 +84,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PackageYmlClient(
@@ -123,7 +123,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PackageYmlClient(
@@ -160,7 +160,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PackageYmlClient(
@@ -199,7 +199,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PackageYmlClient(
@@ -236,7 +236,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PackageYmlClient(

--- a/seed/swift-sdk/package-yml/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/package-yml/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -37,11 +37,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -68,11 +68,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -99,10 +99,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -161,7 +161,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -266,11 +266,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -307,11 +307,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -344,27 +344,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -391,7 +391,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PackageYmlClient(
@@ -420,7 +420,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/package-yml/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/package-yml/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/pagination-custom/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/pagination-custom/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -45,7 +45,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -80,7 +80,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -117,7 +117,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -152,7 +152,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -189,7 +189,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PaginationClient(
@@ -224,7 +224,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination-custom/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/pagination-custom/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -35,11 +35,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -64,11 +64,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -93,10 +93,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,7 +123,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -151,7 +151,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -207,11 +207,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -250,11 +250,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -289,11 +289,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -324,27 +324,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -369,7 +369,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PaginationClient(
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/pagination-custom/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination-custom/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/pagination-custom/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination-custom/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCustomPager1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "limit": 1,

--- a/seed/swift-sdk/pagination-uri-path/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination-uri-path/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/pagination-uri-path/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/pagination-uri-path/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PaginationUriPathClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PaginationUriPathClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PaginationUriPathClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PaginationUriPathClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PaginationUriPathClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PaginationUriPathClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PaginationUriPathClient(

--- a/seed/swift-sdk/pagination-uri-path/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/pagination-uri-path/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PaginationUriPathClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/pagination-uri-path/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination-uri-path/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/pagination-uri-path/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination-uri-path/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -6,7 +6,7 @@ import PaginationUriPath
     @Test func listWithUriPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": [
@@ -49,7 +49,7 @@ import PaginationUriPath
     @Test func listWithPathPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": [

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -57,7 +57,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -104,7 +104,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -153,7 +153,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -249,7 +249,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PaginationClient(
@@ -296,7 +296,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -47,11 +47,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -88,11 +88,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -129,10 +129,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -211,7 +211,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -291,11 +291,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -346,11 +346,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -397,11 +397,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -444,27 +444,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -501,7 +501,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PaginationClient(
@@ -540,7 +540,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func search1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "conversations": [

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -79,7 +79,7 @@ import Pagination
     @Test func listWithMixedTypeCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next": "next",
@@ -129,7 +129,7 @@ import Pagination
     @Test func listWithBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -201,7 +201,7 @@ import Pagination
     @Test func listWithOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -274,7 +274,7 @@ import Pagination
     @Test func listWithDoubleOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -347,7 +347,7 @@ import Pagination
     @Test func listWithBodyOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -419,7 +419,7 @@ import Pagination
     @Test func listWithOffsetStepPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -491,7 +491,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -563,7 +563,7 @@ import Pagination
     @Test func listWithExtendedResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -615,7 +615,7 @@ import Pagination
     @Test func listWithExtendedResultsAndOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -667,7 +667,7 @@ import Pagination
     @Test func listUsernames1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -705,7 +705,7 @@ import Pagination
     @Test func listWithGlobalConfig1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -75,7 +75,7 @@ import Pagination
     @Test func listWithMixedTypeCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next": "next",
@@ -121,7 +121,7 @@ import Pagination
     @Test func listWithBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -189,7 +189,7 @@ import Pagination
     @Test func listWithTopLevelBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next_cursor": "next_cursor_value",
@@ -238,7 +238,7 @@ import Pagination
     @Test func listWithTopLevelBodyCursorPagination2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next_cursor": "next_cursor",
@@ -287,7 +287,7 @@ import Pagination
     @Test func listWithOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -356,7 +356,7 @@ import Pagination
     @Test func listWithDoubleOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -425,7 +425,7 @@ import Pagination
     @Test func listWithBodyOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -493,7 +493,7 @@ import Pagination
     @Test func listWithOffsetStepPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -561,7 +561,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -629,7 +629,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": false,
@@ -697,7 +697,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -765,7 +765,7 @@ import Pagination
     @Test func listWithExtendedResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -817,7 +817,7 @@ import Pagination
     @Test func listWithExtendedResultsAndOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -869,7 +869,7 @@ import Pagination
     @Test func listUsernames1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -907,7 +907,7 @@ import Pagination
     @Test func listUsernamesWithOptionalResponse1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -945,7 +945,7 @@ import Pagination
     @Test func listWithGlobalConfig1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [
@@ -977,7 +977,7 @@ import Pagination
     @Test func listWithOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -1043,7 +1043,7 @@ import Pagination
     @Test func listWithOptionalData2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": false,
@@ -1089,7 +1089,7 @@ import Pagination
     @Test func listWithOptionalData3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -1155,7 +1155,7 @@ import Pagination
     @Test func listWithAliasedData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -57,7 +57,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -104,7 +104,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -153,7 +153,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -249,7 +249,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PaginationClient(
@@ -296,7 +296,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -47,11 +47,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -88,11 +88,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -129,10 +129,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -211,7 +211,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -291,11 +291,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -346,11 +346,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -397,11 +397,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -444,27 +444,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -501,7 +501,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PaginationClient(
@@ -540,7 +540,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func search1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "conversations": [

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -79,7 +79,7 @@ import Pagination
     @Test func listWithMixedTypeCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next": "next",
@@ -129,7 +129,7 @@ import Pagination
     @Test func listWithBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -201,7 +201,7 @@ import Pagination
     @Test func listWithOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -274,7 +274,7 @@ import Pagination
     @Test func listWithDoubleOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -347,7 +347,7 @@ import Pagination
     @Test func listWithBodyOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -419,7 +419,7 @@ import Pagination
     @Test func listWithOffsetStepPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -491,7 +491,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -563,7 +563,7 @@ import Pagination
     @Test func listWithExtendedResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -615,7 +615,7 @@ import Pagination
     @Test func listWithExtendedResultsAndOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -667,7 +667,7 @@ import Pagination
     @Test func listUsernames1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -705,7 +705,7 @@ import Pagination
     @Test func listWithGlobalConfig1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -75,7 +75,7 @@ import Pagination
     @Test func listWithMixedTypeCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next": "next",
@@ -121,7 +121,7 @@ import Pagination
     @Test func listWithBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -189,7 +189,7 @@ import Pagination
     @Test func listWithTopLevelBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next_cursor": "next_cursor_value",
@@ -238,7 +238,7 @@ import Pagination
     @Test func listWithTopLevelBodyCursorPagination2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next_cursor": "next_cursor",
@@ -287,7 +287,7 @@ import Pagination
     @Test func listWithOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -356,7 +356,7 @@ import Pagination
     @Test func listWithDoubleOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -425,7 +425,7 @@ import Pagination
     @Test func listWithBodyOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -493,7 +493,7 @@ import Pagination
     @Test func listWithOffsetStepPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -561,7 +561,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -629,7 +629,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": false,
@@ -697,7 +697,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -765,7 +765,7 @@ import Pagination
     @Test func listWithExtendedResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -817,7 +817,7 @@ import Pagination
     @Test func listWithExtendedResultsAndOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -869,7 +869,7 @@ import Pagination
     @Test func listUsernames1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -907,7 +907,7 @@ import Pagination
     @Test func listUsernamesWithOptionalResponse1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -945,7 +945,7 @@ import Pagination
     @Test func listWithGlobalConfig1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [
@@ -977,7 +977,7 @@ import Pagination
     @Test func listWithOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -1043,7 +1043,7 @@ import Pagination
     @Test func listWithOptionalData2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": false,
@@ -1089,7 +1089,7 @@ import Pagination
     @Test func listWithOptionalData3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -1155,7 +1155,7 @@ import Pagination
     @Test func listWithAliasedData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -57,7 +57,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -104,7 +104,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -153,7 +153,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PaginationClient(
@@ -249,7 +249,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PaginationClient(
@@ -296,7 +296,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -47,11 +47,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -88,11 +88,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -129,10 +129,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -171,7 +171,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -211,7 +211,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -291,11 +291,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -346,11 +346,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -397,11 +397,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -444,27 +444,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -501,7 +501,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PaginationClient(
@@ -540,7 +540,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func search1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "conversations": [

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -79,7 +79,7 @@ import Pagination
     @Test func listWithMixedTypeCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next": "next",
@@ -129,7 +129,7 @@ import Pagination
     @Test func listWithBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -201,7 +201,7 @@ import Pagination
     @Test func listWithOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -274,7 +274,7 @@ import Pagination
     @Test func listWithDoubleOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -347,7 +347,7 @@ import Pagination
     @Test func listWithBodyOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -419,7 +419,7 @@ import Pagination
     @Test func listWithOffsetStepPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -491,7 +491,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -563,7 +563,7 @@ import Pagination
     @Test func listWithExtendedResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -615,7 +615,7 @@ import Pagination
     @Test func listWithExtendedResultsAndOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -667,7 +667,7 @@ import Pagination
     @Test func listUsernames1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -705,7 +705,7 @@ import Pagination
     @Test func listWithGlobalConfig1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -6,7 +6,7 @@ import Pagination
     @Test func listWithCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -75,7 +75,7 @@ import Pagination
     @Test func listWithMixedTypeCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next": "next",
@@ -121,7 +121,7 @@ import Pagination
     @Test func listWithBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -189,7 +189,7 @@ import Pagination
     @Test func listWithTopLevelBodyCursorPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next_cursor": "next_cursor_value",
@@ -238,7 +238,7 @@ import Pagination
     @Test func listWithTopLevelBodyCursorPagination2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "next_cursor": "next_cursor",
@@ -287,7 +287,7 @@ import Pagination
     @Test func listWithOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -356,7 +356,7 @@ import Pagination
     @Test func listWithDoubleOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -425,7 +425,7 @@ import Pagination
     @Test func listWithBodyOffsetPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -493,7 +493,7 @@ import Pagination
     @Test func listWithOffsetStepPagination1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -561,7 +561,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -629,7 +629,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": false,
@@ -697,7 +697,7 @@ import Pagination
     @Test func listWithOffsetPaginationHasNextPage3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -765,7 +765,7 @@ import Pagination
     @Test func listWithExtendedResults1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -817,7 +817,7 @@ import Pagination
     @Test func listWithExtendedResultsAndOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "total_count": 1,
@@ -869,7 +869,7 @@ import Pagination
     @Test func listUsernames1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -907,7 +907,7 @@ import Pagination
     @Test func listUsernamesWithOptionalResponse1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "cursor": {
@@ -945,7 +945,7 @@ import Pagination
     @Test func listWithGlobalConfig1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "results": [
@@ -977,7 +977,7 @@ import Pagination
     @Test func listWithOptionalData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -1043,7 +1043,7 @@ import Pagination
     @Test func listWithOptionalData2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": false,
@@ -1089,7 +1089,7 @@ import Pagination
     @Test func listWithOptionalData3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,
@@ -1155,7 +1155,7 @@ import Pagination
     @Test func listWithAliasedData1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "hasNextPage": true,

--- a/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/path-parameters/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PathParametersClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PathParametersClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PathParametersClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PathParametersClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PathParametersClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PathParametersClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PathParametersClient(

--- a/seed/swift-sdk/path-parameters/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PathParametersClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/path-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/path-parameters/Tests/Wire/Resources/Organizations/OrganizationsClientWireTests.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Wire/Resources/Organizations/OrganizationsClientWireTests.swift
@@ -6,7 +6,7 @@ import PathParameters
     @Test func getOrganization1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -40,7 +40,7 @@ import PathParameters
     @Test func getOrganizationUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -75,7 +75,7 @@ import PathParameters
     @Test func searchOrganizations1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/path-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import PathParameters
     @Test func getUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -40,7 +40,7 @@ import PathParameters
     @Test func createUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -80,7 +80,7 @@ import PathParameters
     @Test func updateUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -121,7 +121,7 @@ import PathParameters
     @Test func searchUsers1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -174,7 +174,7 @@ import PathParameters
     @Test func getUserMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -209,7 +209,7 @@ import PathParameters
     @Test func getUserSpecifics1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",

--- a/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/plain-text/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/plain-text/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PlainTextClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PlainTextClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PlainTextClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PlainTextClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PlainTextClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PlainTextClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PlainTextClient(

--- a/seed/swift-sdk/plain-text/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/plain-text/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PlainTextClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/plain-text/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/plain-text/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/plain-text/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/plain-text/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import PlainText
     @Test func getText1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -24,7 +24,7 @@ import PlainText
     @Test func getCsv1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -42,7 +42,7 @@ import PlainText
     @Test func getXml1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/property-access/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/property-access/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/property-access/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/property-access/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = PropertyAccessClient(
@@ -54,7 +54,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = PropertyAccessClient(
@@ -98,7 +98,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = PropertyAccessClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = PropertyAccessClient(
@@ -188,7 +188,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = PropertyAccessClient(
@@ -234,7 +234,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = PropertyAccessClient(
@@ -278,7 +278,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = PropertyAccessClient(

--- a/seed/swift-sdk/property-access/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/property-access/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -44,11 +44,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -82,11 +82,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -120,10 +120,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -159,7 +159,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -196,7 +196,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -270,11 +270,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -322,11 +322,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -370,11 +370,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -414,27 +414,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -468,7 +468,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = PropertyAccessClient(
@@ -504,7 +504,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/property-access/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/property-access/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/public-object/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/public-object/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/query-param-name-conflict/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-param-name-conflict/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/query-param-name-conflict/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/query-param-name-conflict/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/query-param-name-conflict/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/query-param-name-conflict/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/query-param-name-conflict/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-param-name-conflict/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -94,7 +94,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -178,7 +178,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -264,7 +264,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -434,7 +434,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -518,7 +518,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,11 +84,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -162,11 +162,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -240,10 +240,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -319,7 +319,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -550,11 +550,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -642,11 +642,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -730,11 +730,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -814,27 +814,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -908,7 +908,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -984,7 +984,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/query-parameters-openapi/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -94,7 +94,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -178,7 +178,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -264,7 +264,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -434,7 +434,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -518,7 +518,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/query-parameters-openapi/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,11 +84,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -162,11 +162,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -240,10 +240,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -319,7 +319,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -550,11 +550,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -642,11 +642,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -730,11 +730,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -814,27 +814,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -908,7 +908,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -984,7 +984,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/query-parameters-openapi/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/query-parameters/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/query-parameters/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = QueryParametersClient(
@@ -92,7 +92,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = QueryParametersClient(
@@ -174,7 +174,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = QueryParametersClient(
@@ -258,7 +258,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = QueryParametersClient(
@@ -340,7 +340,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = QueryParametersClient(
@@ -424,7 +424,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = QueryParametersClient(
@@ -506,7 +506,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = QueryParametersClient(

--- a/seed/swift-sdk/query-parameters/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/query-parameters/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -82,11 +82,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -158,11 +158,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,10 +234,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -311,7 +311,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -386,7 +386,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -536,11 +536,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -626,11 +626,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -712,11 +712,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -794,27 +794,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -886,7 +886,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = QueryParametersClient(
@@ -960,7 +960,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/query-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/query-parameters/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/query-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/query-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import QueryParameters
     @Test func getUsername1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",

--- a/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/request-parameters/Sources/Resources/User/UserClient.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Resources/User/UserClient.swift
@@ -31,7 +31,7 @@ public final class UserClient: Sendable {
         )
     }
 
-    public func createUsernameOptional(request: Nullable<CreateUsernameBodyOptionalProperties>?, requestOptions: RequestOptions? = nil) async throws -> Void {
+    public func createUsernameOptional(request: Nullable<CreateUsernameBodyOptionalProperties>? = nil, requestOptions: RequestOptions? = nil) async throws -> Void {
         return try await httpClient.performRequest(
             method: .post,
             path: "/user/username-optional",

--- a/seed/swift-sdk/request-parameters/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/request-parameters/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = RequestParametersClient(
@@ -51,7 +51,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = RequestParametersClient(
@@ -92,7 +92,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = RequestParametersClient(
@@ -135,7 +135,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = RequestParametersClient(
@@ -176,7 +176,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = RequestParametersClient(
@@ -219,7 +219,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = RequestParametersClient(
@@ -260,7 +260,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = RequestParametersClient(

--- a/seed/swift-sdk/request-parameters/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/request-parameters/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -41,11 +41,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -76,11 +76,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -111,10 +111,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -147,7 +147,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -181,7 +181,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -249,11 +249,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -343,11 +343,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -384,27 +384,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -435,7 +435,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = RequestParametersClient(
@@ -468,7 +468,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/request-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/request-parameters/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/request-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/request-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import RequestParameters
     @Test func getUsername1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/required-nullable/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/required-nullable/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/required-nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/reserved-keywords/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/reserved-keywords/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = NurseryApiClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = NurseryApiClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = NurseryApiClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = NurseryApiClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = NurseryApiClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = NurseryApiClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = NurseryApiClient(

--- a/seed/swift-sdk/reserved-keywords/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/reserved-keywords/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = NurseryApiClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/reserved-keywords/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/reserved-keywords/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/response-property/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/response-property/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/response-property/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ResponsePropertyClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ResponsePropertyClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ResponsePropertyClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ResponsePropertyClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ResponsePropertyClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ResponsePropertyClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ResponsePropertyClient(

--- a/seed/swift-sdk/response-property/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/response-property/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ResponsePropertyClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/response-property/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/response-property/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/response-property/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/response-property/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -6,7 +6,7 @@ import ResponseProperty
     @Test func getMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": {
@@ -45,7 +45,7 @@ import ResponseProperty
     @Test func getMovieDocs1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": {
@@ -84,7 +84,7 @@ import ResponseProperty
     @Test func getMovieName1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": "data"
@@ -109,7 +109,7 @@ import ResponseProperty
     @Test func getMovieMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": {
@@ -148,7 +148,7 @@ import ResponseProperty
     @Test func getOptionalMovie1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": {
@@ -187,7 +187,7 @@ import ResponseProperty
     @Test func getOptionalMovieDocs1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "docs": "docs"
@@ -212,7 +212,7 @@ import ResponseProperty
     @Test func getOptionalMovieName1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "data": "data"

--- a/seed/swift-sdk/schemaless-request-body-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/schemaless-request-body-examples/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/schemaless-request-body-examples/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/schemaless-request-body-examples/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -55,7 +55,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -100,7 +100,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -147,7 +147,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -192,7 +192,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -239,7 +239,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -284,7 +284,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/schemaless-request-body-examples/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/schemaless-request-body-examples/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -45,11 +45,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -84,11 +84,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,10 +123,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -163,7 +163,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -201,7 +201,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -277,11 +277,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -330,11 +330,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -379,11 +379,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,27 +424,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -479,7 +479,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -516,7 +516,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/schemaless-request-body-examples/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/schemaless-request-body-examples/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -130,8 +130,6 @@ fixtures:
 allowedFailures:
   - audiences
   - enum
-  - examples:no-custom-config
-  - examples:readme-config
   - exhaustive
   - multi-url-environment
   - multi-url-environment-no-default

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/server-sent-event-examples/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ServerSentEventsClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ServerSentEventsClient(

--- a/seed/swift-sdk/server-sent-event-examples/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ServerSentEventsClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/server-sent-event-examples/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/server-sent-events-openapi/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -45,7 +45,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -80,7 +80,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -117,7 +117,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -152,7 +152,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -189,7 +189,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -224,7 +224,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/server-sent-events-openapi/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -35,11 +35,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -64,11 +64,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -93,10 +93,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,7 +123,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -151,7 +151,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -207,11 +207,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -250,11 +250,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -289,11 +289,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -324,27 +324,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -369,7 +369,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/server-sent-events-openapi/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/server-sent-events-resumable/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events-resumable/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/server-sent-events-resumable/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/server-sent-events-resumable/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ServerSentEventsResumableClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ServerSentEventsResumableClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ServerSentEventsResumableClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ServerSentEventsResumableClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ServerSentEventsResumableClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ServerSentEventsResumableClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ServerSentEventsResumableClient(

--- a/seed/swift-sdk/server-sent-events-resumable/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/server-sent-events-resumable/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ServerSentEventsResumableClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/server-sent-events-resumable/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-sent-events-resumable/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/server-sent-events/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/server-sent-events/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ServerSentEventsClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ServerSentEventsClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ServerSentEventsClient(

--- a/seed/swift-sdk/server-sent-events/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/server-sent-events/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ServerSentEventsClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/server-sent-events/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-sent-events/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/server-url-templating/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/server-url-templating/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/server-url-templating/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/server-url-templating/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -37,7 +37,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -64,7 +64,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -93,7 +93,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -149,7 +149,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -176,7 +176,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(urlSession: stub.urlSession)

--- a/seed/swift-sdk/server-url-templating/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/server-url-templating/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -27,11 +27,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -48,11 +48,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -69,10 +69,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -91,7 +91,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -111,7 +111,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -151,11 +151,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -186,11 +186,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -217,11 +217,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,27 +244,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -281,7 +281,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(urlSession: stub.urlSession)
@@ -300,7 +300,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/server-url-templating/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/server-url-templating/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-api/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/simple-api/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/simple-api/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = SimpleApiClient(
@@ -44,7 +44,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = SimpleApiClient(
@@ -78,7 +78,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = SimpleApiClient(
@@ -114,7 +114,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = SimpleApiClient(
@@ -148,7 +148,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = SimpleApiClient(
@@ -184,7 +184,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = SimpleApiClient(
@@ -218,7 +218,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = SimpleApiClient(

--- a/seed/swift-sdk/simple-api/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/simple-api/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -34,11 +34,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -62,11 +62,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -90,10 +90,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -119,7 +119,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -146,7 +146,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -200,11 +200,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -280,11 +280,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,27 +314,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -358,7 +358,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = SimpleApiClient(
@@ -384,7 +384,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/simple-api/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/simple-api/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/simple-api/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/simple-api/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import SimpleApi
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/simple-fhir/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/simple-fhir/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/simple-fhir/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/simple-fhir/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/simple-fhir/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/simple-fhir/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -182,11 +182,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -221,11 +221,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -256,11 +256,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -287,27 +287,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -328,7 +328,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -351,7 +351,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -6,7 +6,7 @@ import SingleUrlEnvironmentDefault
     @Test func getDummy1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = SingleUrlEnvironmentDefaultClient(

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -6,7 +6,7 @@ import SingleUrlEnvironmentDefault
     @Test func getDummy1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/single-url-environment-no-default/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = SingleUrlEnvironmentNoDefaultClient(

--- a/seed/swift-sdk/single-url-environment-no-default/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = SingleUrlEnvironmentNoDefaultClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/single-url-environment-no-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/single-url-environment-no-default/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -6,7 +6,7 @@ import SingleUrlEnvironmentNoDefault
     @Test func getDummy1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/streaming-parameter/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/streaming-parameter/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = StreamingClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = StreamingClient(

--- a/seed/swift-sdk/streaming-parameter/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/streaming-parameter/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = StreamingClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/streaming-parameter/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/streaming-parameter/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/streaming-parameter/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/streaming-parameter/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -6,7 +6,7 @@ import Streaming
     @Test func generate1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -36,7 +36,7 @@ import Streaming
     @Test func generate2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/streaming/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/streaming/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/streaming/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = StreamingClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = StreamingClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = StreamingClient(

--- a/seed/swift-sdk/streaming/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/streaming/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = StreamingClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/streaming/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/streaming/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/streaming/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/streaming/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -6,7 +6,7 @@ import Streaming
     @Test func generate1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",
@@ -36,7 +36,7 @@ import Streaming
     @Test func generate2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/trace/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/trace/Sources/Resources/Playlist/PlaylistClient.swift
+++ b/seed/swift-sdk/trace/Sources/Resources/Playlist/PlaylistClient.swift
@@ -61,7 +61,7 @@ public final class PlaylistClient: Sendable {
     /// Updates a playlist
     ///
     /// - Parameter requestOptions: Additional options for configuring the request, such as custom headers or timeout settings.
-    public func updatePlaylist(serviceParam: String, playlistId: String, request: UpdatePlaylistRequest?, requestOptions: RequestOptions? = nil) async throws -> Playlist? {
+    public func updatePlaylist(serviceParam: String, playlistId: String, request: UpdatePlaylistRequest? = nil, requestOptions: RequestOptions? = nil) async throws -> Playlist? {
         return try await httpClient.performRequest(
             method: .put,
             path: "/v2/playlist/\(serviceParam)/\(playlistId)",

--- a/seed/swift-sdk/trace/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/trace/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = TraceClient(
@@ -41,7 +41,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = TraceClient(
@@ -72,7 +72,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = TraceClient(
@@ -105,7 +105,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = TraceClient(
@@ -136,7 +136,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = TraceClient(
@@ -169,7 +169,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = TraceClient(
@@ -200,7 +200,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/trace/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -31,11 +31,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -56,11 +56,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -81,10 +81,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -107,7 +107,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -131,7 +131,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -179,11 +179,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -218,11 +218,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -253,11 +253,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -284,27 +284,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -325,7 +325,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = TraceClient(
@@ -348,7 +348,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/trace/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/trace/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Homepage/HomepageClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Homepage/HomepageClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func getHomepageProblems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   "string",

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Migration/MigrationClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Migration/MigrationClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func getAttemptedMigrations1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Playlist/PlaylistClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Playlist/PlaylistClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func createPlaylist1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "playlist_id": "playlist_id",
@@ -53,7 +53,7 @@ import Trace
     @Test func getPlaylists1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -116,7 +116,7 @@ import Trace
     @Test func getPlaylist1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "playlist_id": "playlist_id",
@@ -155,7 +155,7 @@ import Trace
     @Test func updatePlaylist1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "playlist_id": "playlist_id",

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Problem/ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Problem/ProblemClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func createProblem1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "success",
@@ -107,7 +107,7 @@ import Trace
     @Test func updateProblem1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "problemVersion": 1
@@ -210,7 +210,7 @@ import Trace
     @Test func getDefaultStarterFiles1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "files": {

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Submission/SubmissionClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Submission/SubmissionClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func createExecutionSession1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "sessionId": "sessionId",
@@ -38,7 +38,7 @@ import Trace
     @Test func getExecutionSession1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "sessionId": "sessionId",
@@ -70,7 +70,7 @@ import Trace
     @Test func getExecutionSessionsState1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "states": {

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Sysprop/SyspropClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Sysprop/SyspropClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func getNumWarmInstances1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "JAVA": 1

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/V2/Problem/V2ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/V2/Problem/V2ProblemClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func getLightweightProblems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -59,7 +59,7 @@ import Trace
     @Test func getProblems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -1172,7 +1172,7 @@ import Trace
     @Test func getLatestProblem1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "problemId": "problemId",
@@ -1742,7 +1742,7 @@ import Trace
     @Test func getProblemVersion1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "problemId": "problemId",

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/V2/V3/Problem/V3ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/V2/V3/Problem/V3ProblemClientWireTests.swift
@@ -6,7 +6,7 @@ import Trace
     @Test func getLightweightProblems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -59,7 +59,7 @@ import Trace
     @Test func getProblems1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -1172,7 +1172,7 @@ import Trace
     @Test func getLatestProblem1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "problemId": "problemId",
@@ -1742,7 +1742,7 @@ import Trace
     @Test func getProblemVersion1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "problemId": "problemId",

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = UndiscriminatedUnionWithResponsePropertyClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionsClient(
@@ -45,7 +45,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionsClient(
@@ -80,7 +80,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionsClient(
@@ -117,7 +117,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionsClient(
@@ -152,7 +152,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = UndiscriminatedUnionsClient(
@@ -189,7 +189,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = UndiscriminatedUnionsClient(
@@ -224,7 +224,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = UndiscriminatedUnionsClient(

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -35,11 +35,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -64,11 +64,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -93,10 +93,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,7 +123,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -151,7 +151,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -207,11 +207,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -250,11 +250,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -289,11 +289,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -324,27 +324,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -369,7 +369,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = UndiscriminatedUnionsClient(
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -6,7 +6,7 @@ import UndiscriminatedUnions
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "string"
                 """#.utf8
@@ -31,7 +31,7 @@ import UndiscriminatedUnions
     @Test func getMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "exampleName",
@@ -63,7 +63,7 @@ import UndiscriminatedUnions
     @Test func getMetadata2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "string"
@@ -87,7 +87,7 @@ import UndiscriminatedUnions
     @Test func updateMetadata1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -114,7 +114,7 @@ import UndiscriminatedUnions
     @Test func updateMetadata2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -141,7 +141,7 @@ import UndiscriminatedUnions
     @Test func call1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -170,7 +170,7 @@ import UndiscriminatedUnions
     @Test func call2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -199,7 +199,7 @@ import UndiscriminatedUnions
     @Test func duplicateTypesUnion1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 "string"
                 """#.utf8
@@ -224,7 +224,7 @@ import UndiscriminatedUnions
     @Test func nestedUnions1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -247,7 +247,7 @@ import UndiscriminatedUnions
     @Test func nestedObjectUnions1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -270,7 +270,7 @@ import UndiscriminatedUnions
     @Test func aliasedObjectUnion1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8
@@ -296,7 +296,7 @@ import UndiscriminatedUnions
     @Test func getWithBaseProperties1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "name": "name",
@@ -344,7 +344,7 @@ import UndiscriminatedUnions
     @Test func testCamelCaseProperties1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 success
                 """#.utf8
@@ -370,7 +370,7 @@ import UndiscriminatedUnions
     @Test func testCamelCaseProperties2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/union-query-parameters/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/union-query-parameters/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/union-query-parameters/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/union-query-parameters/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = UnionQueryParametersClient(
@@ -48,7 +48,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = UnionQueryParametersClient(
@@ -86,7 +86,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = UnionQueryParametersClient(
@@ -126,7 +126,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = UnionQueryParametersClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = UnionQueryParametersClient(
@@ -204,7 +204,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = UnionQueryParametersClient(
@@ -242,7 +242,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = UnionQueryParametersClient(

--- a/seed/swift-sdk/union-query-parameters/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/union-query-parameters/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -38,11 +38,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -70,11 +70,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -102,10 +102,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -135,7 +135,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -166,7 +166,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -228,11 +228,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,11 +274,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -316,11 +316,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -354,27 +354,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -402,7 +402,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = UnionQueryParametersClient(
@@ -432,7 +432,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/union-query-parameters/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/union-query-parameters/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/union-query-parameters/Tests/Wire/Resources/Events/EventsClientWireTests.swift
+++ b/seed/swift-sdk/union-query-parameters/Tests/Wire/Resources/Events/EventsClientWireTests.swift
@@ -6,7 +6,7 @@ import UnionQueryParameters
     @Test func subscribe1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 string
                 """#.utf8

--- a/seed/swift-sdk/unions-with-local-date/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions-with-local-date/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/unions-with-local-date/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = UnionsClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = UnionsClient(

--- a/seed/swift-sdk/unions-with-local-date/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = UnionsClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/unions-with-local-date/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
@@ -6,7 +6,7 @@ import Unions
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "normalSweet",
@@ -43,7 +43,7 @@ import Unions
     @Test func update1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -68,7 +68,7 @@ import Unions
     @Test func updateMany1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": true

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Types/TypesClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Types/TypesClientWireTests.swift
@@ -6,7 +6,7 @@ import Unions
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "date",
@@ -30,7 +30,7 @@ import Unions
     @Test func get2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "datetime",
@@ -54,7 +54,7 @@ import Unions
     @Test func get3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "value",
@@ -78,7 +78,7 @@ import Unions
     @Test func update1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -101,7 +101,7 @@ import Unions
     @Test func update2() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -124,7 +124,7 @@ import Unions
     @Test func update3() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -6,7 +6,7 @@ import Unions
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "circle",
@@ -39,7 +39,7 @@ import Unions
     @Test func update1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unions/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/unions/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/unions/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = UnionsClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = UnionsClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = UnionsClient(

--- a/seed/swift-sdk/unions/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/unions/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = UnionsClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/unions/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/unions/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/unions/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
+++ b/seed/swift-sdk/unions/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
@@ -6,7 +6,7 @@ import Unions
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "normalSweet",
@@ -43,7 +43,7 @@ import Unions
     @Test func update1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8
@@ -68,7 +68,7 @@ import Unions
     @Test func updateMany1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "string": true

--- a/seed/swift-sdk/unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -6,7 +6,7 @@ import Unions
     @Test func get1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "type": "circle",
@@ -39,7 +39,7 @@ import Unions
     @Test func update1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 true
                 """#.utf8

--- a/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/unknown/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/unknown/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/unknown/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = UnknownAsAnyClient(
@@ -45,7 +45,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = UnknownAsAnyClient(
@@ -80,7 +80,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = UnknownAsAnyClient(
@@ -117,7 +117,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = UnknownAsAnyClient(
@@ -152,7 +152,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = UnknownAsAnyClient(
@@ -189,7 +189,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = UnknownAsAnyClient(
@@ -224,7 +224,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = UnknownAsAnyClient(

--- a/seed/swift-sdk/unknown/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/unknown/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -35,11 +35,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -64,11 +64,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -93,10 +93,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -123,7 +123,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -151,7 +151,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -207,11 +207,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -250,11 +250,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -289,11 +289,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -324,27 +324,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -369,7 +369,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = UnknownAsAnyClient(
@@ -396,7 +396,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/unknown/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/unknown/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/unknown/Tests/Wire/Resources/Unknown/UnknownClientWireTests.swift
+++ b/seed/swift-sdk/unknown/Tests/Wire/Resources/Unknown/UnknownClientWireTests.swift
@@ -6,7 +6,7 @@ import UnknownAsAny
     @Test func post1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {
@@ -47,7 +47,7 @@ import UnknownAsAny
     @Test func postObject1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 [
                   {

--- a/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/url-form-encoded/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/url-form-encoded/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -46,7 +46,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -82,7 +82,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -120,7 +120,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -156,7 +156,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -230,7 +230,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/url-form-encoded/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/url-form-encoded/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -36,11 +36,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -66,11 +66,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -96,10 +96,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -127,7 +127,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -156,7 +156,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -214,11 +214,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -258,11 +258,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -298,11 +298,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,27 +334,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -380,7 +380,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -408,7 +408,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/url-form-encoded/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/url-form-encoded/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/validation/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/validation/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/validation/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ValidationClient(
@@ -48,7 +48,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ValidationClient(
@@ -86,7 +86,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ValidationClient(
@@ -126,7 +126,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ValidationClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ValidationClient(
@@ -204,7 +204,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ValidationClient(
@@ -242,7 +242,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ValidationClient(

--- a/seed/swift-sdk/validation/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/validation/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -38,11 +38,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -70,11 +70,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -102,10 +102,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -135,7 +135,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -166,7 +166,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -228,11 +228,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,11 +274,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -316,11 +316,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -354,27 +354,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -402,7 +402,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ValidationClient(
@@ -432,7 +432,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/validation/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/validation/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/variables/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/variables/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/variables/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = VariablesClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = VariablesClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = VariablesClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = VariablesClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = VariablesClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = VariablesClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = VariablesClient(

--- a/seed/swift-sdk/variables/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/variables/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = VariablesClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/variables/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/variables/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/version-no-default/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/version-no-default/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = VersionClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = VersionClient(

--- a/seed/swift-sdk/version-no-default/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/version-no-default/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = VersionClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/version-no-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/version-no-default/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/version-no-default/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/version-no-default/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import Version
     @Test func getUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/version/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/version/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/version/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = VersionClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = VersionClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = VersionClient(

--- a/seed/swift-sdk/version/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/version/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = VersionClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/version/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/version/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/version/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/version/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -6,7 +6,7 @@ import Version
     @Test func getUser1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "id": "id",

--- a/seed/swift-sdk/webhook-audience/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/webhook-audience/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/webhook-audience/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/webhook-audience/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/webhooks/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/webhooks/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/webhooks/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/webhooks/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/websocket-bearer-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = WebsocketAuthClient(
@@ -50,7 +50,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = WebsocketAuthClient(
@@ -90,7 +90,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = WebsocketAuthClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = WebsocketAuthClient(
@@ -172,7 +172,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = WebsocketAuthClient(
@@ -214,7 +214,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = WebsocketAuthClient(
@@ -254,7 +254,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = WebsocketAuthClient(

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -40,11 +40,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -74,11 +74,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -108,10 +108,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -143,7 +143,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -176,7 +176,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -242,11 +242,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -290,11 +290,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -334,11 +334,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -374,27 +374,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -424,7 +424,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = WebsocketAuthClient(
@@ -456,7 +456,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -6,7 +6,7 @@ import WebsocketAuth
     @Test func getTokenWithClientCredentials1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",
@@ -40,7 +40,7 @@ import WebsocketAuth
     @Test func refreshToken1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "access_token": "access_token",

--- a/seed/swift-sdk/websocket-multi-url/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket-multi-url/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/websocket-multi-url/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket-multi-url/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/websocket/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/websocket/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = WebsocketClient(
@@ -40,7 +40,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = WebsocketClient(
@@ -70,7 +70,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = WebsocketClient(
@@ -102,7 +102,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = WebsocketClient(
@@ -132,7 +132,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = WebsocketClient(
@@ -164,7 +164,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = WebsocketClient(
@@ -194,7 +194,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = WebsocketClient(

--- a/seed/swift-sdk/websocket/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/websocket/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -30,11 +30,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -54,11 +54,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -78,10 +78,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -103,7 +103,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -126,7 +126,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -172,11 +172,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -210,11 +210,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -244,11 +244,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -274,27 +274,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -314,7 +314,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = WebsocketClient(
@@ -336,7 +336,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/websocket/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/websocket/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {

--- a/seed/swift-sdk/websocket/Tests/Wire/Resources/Status/StatusClientWireTests.swift
+++ b/seed/swift-sdk/websocket/Tests/Wire/Resources/Status/StatusClientWireTests.swift
@@ -6,7 +6,7 @@ import Websocket
     @Test func getStatus1() async throws -> Void {
         let stub = HTTPStub()
         stub.setResponse(
-            body: Data(
+            body: Foundation.Data(
                 #"""
                 {
                   "status": "status"

--- a/seed/swift-sdk/x-fern-default/Sources/Core/Networking/HTTPClient.swift
+++ b/seed/swift-sdk/x-fern-default/Sources/Core/Networking/HTTPClient.swift
@@ -246,7 +246,7 @@ final class HTTPClient: Swift.Sendable {
     private func buildRequestBody(
         requestBody: HTTP.RequestBody,
         requestOptions: RequestOptions? = nil
-    ) -> Data {
+    ) -> Foundation.Data {
         switch requestBody {
         case .jsonEncodable(let encodableBody):
             do {

--- a/seed/swift-sdk/x-fern-default/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/x-fern-default/Tests/Core/ClientErrorTests.swift
@@ -10,7 +10,7 @@ import Testing
         stub.setResponse(
             statusCode: 400,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Bad request"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Bad request"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -43,7 +43,7 @@ import Testing
         stub.setResponse(
             statusCode: 404,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Not found"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Not found"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -76,7 +76,7 @@ import Testing
         stub.setResponse(
             statusCode: 422,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Validation failed"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Validation failed"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -111,7 +111,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Internal error"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Internal error"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -144,7 +144,7 @@ import Testing
         stub.setResponse(
             statusCode: 503,
             headers: ["Content-Type": "application/json"],
-            body: Data(#"{"message":"Unavailable"}"#.utf8)
+            body: Foundation.Data(#"{"message":"Unavailable"}"#.utf8)
         )
 
         let client = ApiClient(
@@ -179,7 +179,7 @@ import Testing
         stub.setResponse(
             statusCode: 302,
             headers: ["Location": "https://example.com"],
-            body: Data()
+            body: Foundation.Data()
         )
 
         let client = ApiClient(
@@ -212,7 +212,7 @@ import Testing
         stub.setResponse(
             statusCode: 500,
             headers: ["Content-Type": "text/plain"],
-            body: Data("Plain text error".utf8)
+            body: Foundation.Data("Plain text error".utf8)
         )
 
         let client = ApiClient(

--- a/seed/swift-sdk/x-fern-default/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/x-fern-default/Tests/Core/ClientRetryTests.swift
@@ -6,11 +6,11 @@ import Testing
     @Test func testRetryOn408RequestTimeout() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 408, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -33,11 +33,11 @@ import Testing
     @Test func testRetryOn429TooManyRequests() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 429, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -60,11 +60,11 @@ import Testing
     @Test func testRetryOn500InternalServerError() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -87,10 +87,10 @@ import Testing
     @Test func testRetryOn503ServiceUnavailable() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 503, headers: ["Content-Type": "application/json"], body: Foundation.Data()),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -115,7 +115,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 400, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"BadRequest\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"BadRequest\"}".utf8)
             )
         ])
 
@@ -141,7 +141,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 404, headers: ["Content-Type": "application/json"],
-                body: Data("{\"errorName\":\"NotFound\"}".utf8)
+                body: Foundation.Data("{\"errorName\":\"NotFound\"}".utf8)
             )
         ])
 
@@ -193,11 +193,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429, headers: ["Content-Type": "application/json", "Retry-After": "1"],
-                body: Data()
+                body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -234,11 +234,11 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 429,
-                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": httpDate], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -271,11 +271,11 @@ import Testing
                 statusCode: 429,
                 headers: [
                     "Content-Type": "application/json", "X-RateLimit-Reset": "\(futureTimestamp)",
-                ], body: Data()
+                ], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -304,27 +304,27 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 500,
-                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Data()
+                headers: ["Content-Type": "application/json", "Retry-After": "0.1"], body: Foundation.Data()
             ),
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             ),
         ])
 
@@ -347,7 +347,7 @@ import Testing
     @Test func testEndpointLevelMaxRetriesZero() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data())
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Foundation.Data())
         ])
 
         let client = ApiClient(
@@ -372,7 +372,7 @@ import Testing
         stub.setResponseSequence([
             (
                 statusCode: 200, headers: ["Content-Type": "application/json"],
-                body: Data("true".utf8)
+                body: Foundation.Data("true".utf8)
             )
         ])
 

--- a/seed/swift-sdk/x-fern-default/Tests/Utilities/HTTPStub.swift
+++ b/seed/swift-sdk/x-fern-default/Tests/Utilities/HTTPStub.swift
@@ -55,7 +55,7 @@ final class HTTPStub {
     func setResponse(
         statusCode: Int = 200,
         headers: [String: String] = ["Content-Type": "application/json"],
-        body: Data
+        body: Foundation.Data
     ) {
         StubURLProtocol.configure(
             id: identifier,
@@ -66,7 +66,7 @@ final class HTTPStub {
     }
 
     func setResponseSequence(
-        _ responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        _ responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         StubURLProtocol.configureSequence(id: identifier, responses: responses)
     }
@@ -92,7 +92,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
     struct Response {
         let statusCode: Int
         let headers: [String: String]
-        let body: Data
+        let body: Foundation.Data
         var lastRequest: Networking.URLRequest?
     }
 
@@ -122,7 +122,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
         id: UUID,
         statusCode: Int,
         headers: [String: String],
-        body: Data
+        body: Foundation.Data
     ) {
         lock.lock()
         responses[id] = Response(
@@ -133,7 +133,7 @@ private final class StubURLProtocol: Networking.URLProtocol {
 
     static func configureSequence(
         id: UUID,
-        responses: [(statusCode: Int, headers: [String: String], body: Data)]
+        responses: [(statusCode: Int, headers: [String: String], body: Foundation.Data)]
     ) {
         lock.lock()
         let responseList = responses.map {


### PR DESCRIPTION
## Description

Unblocks the `examples` fixtures (`no-custom-config`, `readme-config`) and removes them from the swift-sdk seed `allowedFailures`. They were failing to compile due to two distinct bugs that surface in this fixture.

This is the final slice of the swift-sdk `allowedFailures` cleanup effort. The rest of the stack has already landed in `main` (most recently via #16552 "emit header args and additional properties"), so this PR now targets `main` directly and was rebased + regenerated against the current generator.

### 1. A user-defined type named `Data` shadowed `Foundation.Data`

The `examples` API defines a type literally named `Data`, emitted as a top-level `public enum Data`. The generated HTTP client and test stubs still referenced `Data` bare in a few spots, so they resolved to the user's `Examples.Data` instead of `Foundation.Data` and failed to compile:

```
HTTPClient.swift:135: cannot assign value of type 'Examples.Data' to type 'Foundation.Data'
HTTPClient.swift:253: cannot convert return expression of type 'Foundation.Data' to return type 'Examples.Data'
```

Every other reference already used `Foundation.Data`; this makes the remaining bare references consistent. Affected:
- `HTTPClient.Template.swift` (request-body builder return type) and the `HTTPStub` / `ClientRetryTests` / `ClientErrorTests` test templates (`Data(...)` body literals).
- `WireTestFunctionGenerator.ts` — wire-test response-body stubs also emitted bare `Data(...)`; now qualified to `Foundation.Data(...)`.

### 2. Optional request bodies didn't compile when the example omitted the body

`refreshToken` has `request: optional<RefreshTokenRequest>` with an empty example (`{}`). Two problems:

- The generated method declared `request: RefreshTokenRequest?` with **no default**, so a call omitting it wouldn't compile.
- The snippet/wire-test for the empty example emitted `RefreshTokenRequest()` (an empty initializer for a type with a required `ttl`), instead of omitting the argument.

Fixes:
- `EndpointMethodGenerator`: optional referenced request bodies now default to `nil` (matching headers/query params), e.g. `refreshToken(request: RefreshTokenRequest? = nil, ...)`.
- `EndpointSnippetGenerator`: when the request body's type reference is `optional` and the example provides no value, the `request` argument is omitted entirely rather than emitting an empty initializer. Scoped to the request-body argument only (does **not** touch general optional-literal mapping, so explicit `null` values inside lists/objects — e.g. nullable query params — still render as before).

```swift
// example {}            -> before: refreshToken(request: RefreshTokenRequest())  (does not compile)
//                       -> after:  refreshToken()
// example { ttl: 420 }  -> refreshToken(request: RefreshTokenRequest(ttl: 420))
```

## Changes Made
- Qualify remaining bare `Data` references as `Foundation.Data` in the HTTP client, test templates, and wire-test response bodies.
- Default optional referenced request bodies to `nil` in generated client methods.
- Omit absent optional request bodies from snippets and wire tests instead of emitting an empty initializer.
- Removed `examples:no-custom-config` and `examples:readme-config` from swift-sdk seed `allowedFailures`; regenerated all fixtures.
- Added changelog entries (`fix-data-type-name-shadowing.yml`, `fix-optional-request-body.yml`).
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] `swift test -c release` (Docker `swift:6.1.2`): `examples/no-custom-config` 32/32, `examples/readme-config` 32/32.
- [x] Full swift-sdk seed regeneration against current `main` — only expected deltas: mechanical `Foundation.Data` qualification across fixtures, `= nil` defaults on optional request bodies, and the two examples fixtures; no source regressions.
- [x] CI `seed-test-results (swift-sdk)` matrix green (validates regenerated snapshots match generation).
- [x] Biome clean on changed TypeScript.
- [ ] Unit tests added/updated — N/A (covered by seed fixtures)
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/24c6efc2110b4c8ead19d72f7fe013b2
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->