### PR TITLE
fix(rust): escape reserved keywords in union variant constructor names

### DIFF
--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -540,13 +540,20 @@ export class UnionGenerator {
             // callers can wrap a raw JSON payload (the `#[non_exhaustive]` enum attribute
             // prevents direct construction outside the crate).
             if (this.isForwardCompatible()) {
-                if (needsNewline) {
-                    writer.newLine();
-                }
-                writer.writeBlock(`pub fn ${UNKNOWN_CONSTRUCTOR_NAME}(value: serde_json::Value) -> Self`, () => {
-                    writer.writeLine(`Self::${UNKNOWN_VARIANT_NAME}(value)`);
+                // Check if any user-defined variant already produces a constructor named "unknown"
+                // to avoid duplicate method definitions.
+                const hasUnknownVariant = this.unionTypeDeclaration.types.some((ut) => {
+                    return this.context.case.snakeUnsafe(ut.discriminantValue) === UNKNOWN_CONSTRUCTOR_NAME;
                 });
-                needsNewline = true;
+                if (!hasUnknownVariant) {
+                    if (needsNewline) {
+                        writer.newLine();
+                    }
+                    writer.writeBlock(`pub fn ${UNKNOWN_CONSTRUCTOR_NAME}(value: serde_json::Value) -> Self`, () => {
+                        writer.writeLine(`Self::${UNKNOWN_VARIANT_NAME}(value)`);
+                    });
+                    needsNewline = true;
+                }
             }
 
             // Generate getter methods for base properties
@@ -587,7 +594,7 @@ export class UnionGenerator {
     private generateVariantConstructor(writer: rust.Writer, unionType: FernIr.SingleUnionType): void {
         const rawVariantName = this.context.case.pascalUnsafe(unionType.discriminantValue);
         const variantName = this.context.escapeRustReservedType(rawVariantName);
-        const constructorName = this.context.case.snakeUnsafe(unionType.discriminantValue);
+        const constructorName = this.context.escapeRustKeyword(this.context.case.snakeUnsafe(unionType.discriminantValue));
         const typeId = Object.entries(this.context.ir.types).find(([_, type]) => type === this.typeDeclaration)?.[0];
 
         unionType.shape._visit({

--- a/generators/rust/sdk/changes/unreleased/fix-keyword-union-constructors.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-keyword-union-constructors.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Escape Rust reserved keywords (`static`, `override`, etc.) in generated
+    union variant constructor function names using `r#` raw identifier syntax.
+    Also skip generating the catch-all `unknown()` constructor when a union
+    already has a variant named "unknown" to avoid duplicate definitions.
+  type: fix

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_BackupConfig.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_BackupConfig.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "override",
+        "fallback"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "const": "override"
+        },
+        "model": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "model"
+      ]
+    },
+    {
+      "properties": {
+        "type": {
+          "const": "fallback"
+        },
+        "model": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "model"
+      ]
+    }
+  ],
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_BackupOverride.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_BackupOverride.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "model"
+  ],
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_CustomSipHeader.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_CustomSipHeader.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "key",
+    "value"
+  ],
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_DependencyItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_DependencyItem.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "known",
+        "unknown"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "const": "known"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    },
+    {
+      "properties": {
+        "type": {
+          "const": "unknown"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    }
+  ],
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_KnownDependency.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_KnownDependency.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_SipHeaderAction.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/reserved-keywords/type_package_SipHeaderAction.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "static",
+        "dynamic"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "const": "static"
+        },
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "value"
+      ]
+    },
+    {
+      "properties": {
+        "type": {
+          "const": "dynamic"
+        },
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "value"
+      ]
+    }
+  ],
+  "definitions": {}
+}

--- a/seed/rust-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/rust-sdk/reserved-keywords/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/reserved-keywords/src/api/types/mod.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/mod.rs
@@ -1,7 +1,19 @@
+pub mod package_backup_config;
+pub mod package_backup_override;
+pub mod package_custom_sip_header;
+pub mod package_dependency_item;
+pub mod package_known_dependency;
 pub mod package_package;
 pub mod package_record;
+pub mod package_sip_header_action;
 pub mod test_query_request;
 
+pub use package_backup_config::BackupConfig;
+pub use package_backup_override::BackupOverride;
+pub use package_custom_sip_header::CustomSipHeader;
+pub use package_dependency_item::DependencyItem;
+pub use package_known_dependency::KnownDependency;
 pub use package_package::Package;
 pub use package_record::Record;
+pub use package_sip_header_action::SipHeaderAction;
 pub use test_query_request::TestQueryRequest;

--- a/seed/rust-sdk/reserved-keywords/src/api/types/package_backup_config.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/package_backup_config.rs
@@ -1,0 +1,40 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub enum BackupConfig {
+    #[serde(rename = "override")]
+    #[non_exhaustive]
+    Override {
+        #[serde(flatten)]
+        data: BackupOverride,
+    },
+
+    #[serde(rename = "fallback")]
+    #[non_exhaustive]
+    Fallback {
+        #[serde(flatten)]
+        data: BackupOverride,
+    },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
+}
+
+impl BackupConfig {
+    pub fn r#override(data: BackupOverride) -> Self {
+        Self::Override { data }
+    }
+
+    pub fn fallback(data: BackupOverride) -> Self {
+        Self::Fallback { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+}

--- a/seed/rust-sdk/reserved-keywords/src/api/types/package_backup_override.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/package_backup_override.rs
@@ -1,0 +1,37 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+pub struct BackupOverride {
+    #[serde(default)]
+    pub model: String,
+}
+
+impl BackupOverride {
+    pub fn builder() -> BackupOverrideBuilder {
+        <BackupOverrideBuilder as Default>::default()
+    }
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+#[non_exhaustive]
+pub struct BackupOverrideBuilder {
+    model: Option<String>,
+}
+
+impl BackupOverrideBuilder {
+    pub fn model(mut self, value: impl Into<String>) -> Self {
+        self.model = Some(value.into());
+        self
+    }
+
+    /// Consumes the builder and constructs a [`BackupOverride`].
+    /// This method will fail if any of the following fields are not set:
+    /// - [`model`](BackupOverrideBuilder::model)
+    pub fn build(self) -> Result<BackupOverride, BuildError> {
+        Ok(BackupOverride {
+            model: self
+                .model
+                .ok_or_else(|| BuildError::missing_field("model"))?,
+        })
+    }
+}

--- a/seed/rust-sdk/reserved-keywords/src/api/types/package_custom_sip_header.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/package_custom_sip_header.rs
@@ -1,0 +1,47 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+pub struct CustomSipHeader {
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub value: String,
+}
+
+impl CustomSipHeader {
+    pub fn builder() -> CustomSipHeaderBuilder {
+        <CustomSipHeaderBuilder as Default>::default()
+    }
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+#[non_exhaustive]
+pub struct CustomSipHeaderBuilder {
+    key: Option<String>,
+    value: Option<String>,
+}
+
+impl CustomSipHeaderBuilder {
+    pub fn key(mut self, value: impl Into<String>) -> Self {
+        self.key = Some(value.into());
+        self
+    }
+
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Consumes the builder and constructs a [`CustomSipHeader`].
+    /// This method will fail if any of the following fields are not set:
+    /// - [`key`](CustomSipHeaderBuilder::key)
+    /// - [`value`](CustomSipHeaderBuilder::value)
+    pub fn build(self) -> Result<CustomSipHeader, BuildError> {
+        Ok(CustomSipHeader {
+            key: self.key.ok_or_else(|| BuildError::missing_field("key"))?,
+            value: self
+                .value
+                .ok_or_else(|| BuildError::missing_field("value"))?,
+        })
+    }
+}

--- a/seed/rust-sdk/reserved-keywords/src/api/types/package_dependency_item.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/package_dependency_item.rs
@@ -1,0 +1,36 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub enum DependencyItem {
+    #[serde(rename = "known")]
+    #[non_exhaustive]
+    Known {
+        #[serde(flatten)]
+        data: KnownDependency,
+    },
+
+    #[serde(rename = "unknown")]
+    #[non_exhaustive]
+    Unknown {
+        #[serde(flatten)]
+        data: KnownDependency,
+    },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
+}
+
+impl DependencyItem {
+    pub fn known(data: KnownDependency) -> Self {
+        Self::Known { data }
+    }
+
+    pub fn unknown(data: KnownDependency) -> Self {
+        Self::Unknown { data }
+    }
+}

--- a/seed/rust-sdk/reserved-keywords/src/api/types/package_known_dependency.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/package_known_dependency.rs
@@ -1,0 +1,35 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+pub struct KnownDependency {
+    #[serde(default)]
+    pub name: String,
+}
+
+impl KnownDependency {
+    pub fn builder() -> KnownDependencyBuilder {
+        <KnownDependencyBuilder as Default>::default()
+    }
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+#[non_exhaustive]
+pub struct KnownDependencyBuilder {
+    name: Option<String>,
+}
+
+impl KnownDependencyBuilder {
+    pub fn name(mut self, value: impl Into<String>) -> Self {
+        self.name = Some(value.into());
+        self
+    }
+
+    /// Consumes the builder and constructs a [`KnownDependency`].
+    /// This method will fail if any of the following fields are not set:
+    /// - [`name`](KnownDependencyBuilder::name)
+    pub fn build(self) -> Result<KnownDependency, BuildError> {
+        Ok(KnownDependency {
+            name: self.name.ok_or_else(|| BuildError::missing_field("name"))?,
+        })
+    }
+}

--- a/seed/rust-sdk/reserved-keywords/src/api/types/package_sip_header_action.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/types/package_sip_header_action.rs
@@ -1,0 +1,40 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub enum SipHeaderAction {
+    #[serde(rename = "static")]
+    #[non_exhaustive]
+    Static {
+        #[serde(flatten)]
+        data: CustomSipHeader,
+    },
+
+    #[serde(rename = "dynamic")]
+    #[non_exhaustive]
+    Dynamic {
+        #[serde(flatten)]
+        data: CustomSipHeader,
+    },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
+}
+
+impl SipHeaderAction {
+    pub fn r#static(data: CustomSipHeader) -> Self {
+        Self::Static { data }
+    }
+
+    pub fn dynamic(data: CustomSipHeader) -> Self {
+        Self::Dynamic { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+}

--- a/seed/rust-sdk/unions/.fern/metadata.json
+++ b/seed/rust-sdk/unions/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/test-definitions/fern/apis/reserved-keywords/definition/package.yml
+++ b/test-definitions/fern/apis/reserved-keywords/definition/package.yml
@@ -7,6 +7,32 @@ types:
       foo: map<string, string>
       3d: integer
 
+  # Union with keyword-named variants to test escaping in generated constructors
+  SipHeaderAction:
+    union:
+      static: CustomSipHeader
+      dynamic: CustomSipHeader
+  CustomSipHeader:
+    properties:
+      key: string
+      value: string
+
+  BackupConfig:
+    union:
+      override: BackupOverride
+      fallback: BackupOverride
+  BackupOverride:
+    properties:
+      model: string
+
+  DependencyItem:
+    union:
+      known: KnownDependency
+      unknown: KnownDependency
+  KnownDependency:
+    properties:
+      name: string
+
 service:
   base-path: /
   auth: false


### PR DESCRIPTION
## Description

The Rust SDK generator produces invalid code when a discriminated union has variants whose names are Rust reserved keywords (e.g. `static`, `override`) or when a variant is literally named `unknown` (colliding with the forward-compatible catch-all constructor).

This was reported from ElevenLabs CLI generation: `cargo build` fails with 22 errors on the generated `elevenlabs_types` crate.

## Changes Made

**`generators/rust/model/src/union/UnionGenerator.ts`:**
- Escape the constructor function name via `escapeRustKeyword()` so keywords like `static` → `r#static`, `override` → `r#override`
- Skip emitting the catch-all `unknown()` constructor when a user-defined variant already maps to that name, avoiding `E0592` duplicate definitions

**`test-definitions/fern/apis/reserved-keywords/definition/package.yml`:**
- Added three discriminated unions to the existing `reserved-keywords` fixture:
  - `SipHeaderAction` with a `static` variant (strict keyword)
  - `BackupConfig` with an `override` variant (reserved keyword)
  - `DependencyItem` with an `unknown` variant (catch-all collision)

**`seed/rust-sdk/reserved-keywords/`:**
- Updated seed output showing correct `pub fn r#static(...)`, `pub fn r#override(...)`, and no duplicate `unknown()` constructors

- [x] Updated seed test fixture for `reserved-keywords`

## Testing
- [x] Seed test `rust-sdk:reserved-keywords` passes with correct escaping
- [x] Regression: existing `rust-sdk:unions` fixture unchanged


Link to Devin session: https://app.devin.ai/sessions/97903482e5d9476d8befc7c7344754c1
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->