### PR TITLE
fix(parser): lift discriminated-union props inherited via shared $ref parent

### DIFF
--- a/generators/typescript/model/type-schema-generator/src/__test__/TypeSchemaGenerator.test.ts
+++ b/generators/typescript/model/type-schema-generator/src/__test__/TypeSchemaGenerator.test.ts
@@ -184,22 +184,28 @@ function createMockGeneratedAliasType(opts?: { isBranded?: boolean }): Generated
 }
 
 /**
- * Creates a mock GeneratedType for union schemas.
+ * Creates a mock GeneratedType for union schemas. Optionally accepts the union's
+ * base properties so callers exercising `_Base` can have them returned from
+ * `getEffectiveBaseProperties`. The mock skips the real suppression logic
+ * (which requires variant type lookups via context) and just passes them
+ * through — adequate for these snapshot tests.
  */
-function createMockGeneratedUnionType(): GeneratedType<unknown> {
-    return {
-        type: "union",
-        getGeneratedUnion: () => ({
-            discriminant: "type",
-            visitPropertyName: "_visit",
-            getReferenceTo: () => ts.factory.createTypeReferenceNode("ParsedUnion"),
-            buildUnknown: ({ existingValue }: { existingValue: ts.Expression }) => existingValue,
-            buildFromExistingValue: ({ existingValue }: { existingValue: ts.Expression }) => existingValue,
-            getBasePropertyKey: (wireValue: string) => wireValue
-        }),
-        getSinglePropertyKey: ({ name }: { name: FernIr.NameAndWireValue }) => name.wireValue
-        // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal GeneratedType interface
-    } as any;
+function createMockGeneratedUnionType(baseProperties: FernIr.ObjectProperty[] = []): () => GeneratedType<unknown> {
+    return () =>
+        ({
+            type: "union",
+            getGeneratedUnion: () => ({
+                discriminant: "type",
+                visitPropertyName: "_visit",
+                getReferenceTo: () => ts.factory.createTypeReferenceNode("ParsedUnion"),
+                getEffectiveBaseProperties: () => baseProperties,
+                buildUnknown: ({ existingValue }: { existingValue: ts.Expression }) => existingValue,
+                buildFromExistingValue: ({ existingValue }: { existingValue: ts.Expression }) => existingValue,
+                getBasePropertyKey: (wireValue: string) => wireValue
+            }),
+            getSinglePropertyKey: ({ name }: { name: FernIr.NameAndWireValue }) => name.wireValue
+            // biome-ignore lint/suspicious/noExplicitAny: test mock with minimal GeneratedType interface
+        }) as any;
 }
 
 /**
@@ -365,7 +371,7 @@ describe("TypeSchemaGenerator", () => {
         const schema = generator.generateTypeSchema({
             typeName: "Shape",
             shape,
-            getGeneratedType: createMockGeneratedUnionType,
+            getGeneratedType: createMockGeneratedUnionType(),
             getReferenceToGeneratedType: () => ts.factory.createTypeReferenceNode("Shape"),
             getReferenceToGeneratedTypeSchema: () => createMockReference("ShapeSchema")
         });
@@ -444,7 +450,7 @@ describe("TypeSchemaGenerator", () => {
         const schema = generator.generateTypeSchema({
             typeName: "Shape",
             shape,
-            getGeneratedType: createMockGeneratedUnionType,
+            getGeneratedType: createMockGeneratedUnionType(),
             getReferenceToGeneratedType: () => ts.factory.createTypeReferenceNode("Shape"),
             getReferenceToGeneratedTypeSchema: () => createMockReference("ShapeSchema")
         });
@@ -925,7 +931,7 @@ describe("GeneratedUnionTypeSchemaImpl", () => {
                 default: undefined,
                 discriminatorContext: undefined
             },
-            getGeneratedType: createMockGeneratedUnionType,
+            getGeneratedType: createMockGeneratedUnionType(opts.baseProperties ?? []),
             getReferenceToGeneratedType: () => ts.factory.createTypeReferenceNode(opts.typeName),
             getReferenceToGeneratedTypeSchema: () => createMockReference(`${opts.typeName}Schema`),
             noOptionalProperties: opts.noOptionalProperties ?? false,

--- a/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
+++ b/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
@@ -908,7 +908,7 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         return [...this.parsedSingleUnionTypes, this.unknownSingleUnionType];
     }
 
-    private getEffectiveBaseProperties(context: Context): FernIr.ObjectProperty[] {
+    public getEffectiveBaseProperties(context: Context): FernIr.ObjectProperty[] {
         const suppressed = this.getInheritedPropertyNamesSharedByAllVariants(context);
         if (suppressed.size === 0) {
             return this.baseProperties;

--- a/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
+++ b/generators/typescript/model/union-generator/src/GeneratedUnionImpl.ts
@@ -388,7 +388,7 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         if (this.includeUtilsOnUnionMembers || this.includeConstBuilders) {
             statements.push(this.getVisitorInterface(context));
         }
-        if (this.hasBaseInterface()) {
+        if (this.hasBaseInterface(context)) {
             const baseInterface = this.getBaseInterface(context);
             statements.push(baseInterface.normal);
             if (baseInterface.request || baseInterface.response) {
@@ -564,12 +564,50 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         };
     }
 
+    /**
+     * Property names that every variant already inherits via its `extends` chain.
+     * The OpenAPI parser lifts these onto the union's `baseProperties` so that
+     * generators without structural typing (Go, C#) can expose them directly, but
+     * for TypeScript re-emitting them on `_Base` would conflict with the real
+     * parent interface — TS2320 if optionality disagrees. Suppress them here.
+     */
+    private getInheritedPropertyNamesSharedByAllVariants(context: Context): Set<string> {
+        if (this.shape == null || this.shape.types.length === 0) {
+            return new Set();
+        }
+        let intersection: Set<string> | undefined;
+        for (const variant of this.shape.types) {
+            const variantInherited = new Set<string>();
+            if (variant.shape.propertiesType === "samePropertiesAsObject") {
+                const declaration = context.type.getTypeDeclaration(variant.shape);
+                if (declaration.shape.type === "object") {
+                    for (const property of declaration.shape.extendedProperties ?? []) {
+                        variantInherited.add(getWireValue(property.name));
+                    }
+                }
+            }
+            if (intersection == null) {
+                intersection = variantInherited;
+            } else {
+                for (const name of intersection) {
+                    if (!variantInherited.has(name)) {
+                        intersection.delete(name);
+                    }
+                }
+            }
+            if (intersection.size === 0) {
+                return intersection;
+            }
+        }
+        return intersection ?? new Set();
+    }
+
     private getBaseInterface(context: Context): {
         normal: InterfaceDeclarationStructure;
         request: InterfaceDeclarationStructure | undefined;
         response: InterfaceDeclarationStructure | undefined;
     } {
-        const properties = this.baseProperties.map((p) => {
+        const properties = this.getEffectiveBaseProperties(context).map((p) => {
             const type = context.type.getReferenceToType(p.valueType);
             const property = {
                 name: getPropertyKey(this._getBasePropertyKey(p)),
@@ -739,7 +777,7 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
     }
 
     private addBuilderProperties(context: Context, writer: ObjectWriter) {
-        if (this.hasBaseInterface()) {
+        if (this.hasBaseInterface(context)) {
             throw new Error("Cannot create builders because union has base properties");
         }
 
@@ -870,8 +908,16 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         return [...this.parsedSingleUnionTypes, this.unknownSingleUnionType];
     }
 
-    private hasBaseInterface(): boolean {
-        return this.baseProperties.length > 0 || (this.shape?.extends ?? []).length > 0;
+    private getEffectiveBaseProperties(context: Context): FernIr.ObjectProperty[] {
+        const suppressed = this.getInheritedPropertyNamesSharedByAllVariants(context);
+        if (suppressed.size === 0) {
+            return this.baseProperties;
+        }
+        return this.baseProperties.filter((p) => !suppressed.has(getWireValue(p.name)));
+    }
+
+    private hasBaseInterface(context: Context): boolean {
+        return this.getEffectiveBaseProperties(context).length > 0 || (this.shape?.extends ?? []).length > 0;
     }
 
     private hasBaseInterfaces(context: Context): {
@@ -879,7 +925,8 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         request: boolean;
         response: boolean;
     } {
-        const hasNormal = this.baseProperties.length > 0 || (this.shape?.extends ?? []).length > 0;
+        const effectiveBaseProperties = this.getEffectiveBaseProperties(context);
+        const hasNormal = effectiveBaseProperties.length > 0 || (this.shape?.extends ?? []).length > 0;
         if (!this.generateReadWriteOnlyTypes) {
             return {
                 normal: hasNormal,
@@ -891,7 +938,7 @@ export class GeneratedUnionImpl<Context extends ModelContext> implements Generat
         let hasRequest = false;
         let hasResponse = false;
         if (hasNormal && this.shape) {
-            const properties = this.baseProperties.map((p) => {
+            const properties = effectiveBaseProperties.map((p) => {
                 const type = context.type.getReferenceToType(p.valueType);
                 return {
                     requestProperty: type.requestTypeNode ? true : false,

--- a/generators/typescript/model/union-schema-generator/src/GeneratedUnionSchema.ts
+++ b/generators/typescript/model/union-schema-generator/src/GeneratedUnionSchema.ts
@@ -61,6 +61,7 @@ export class GeneratedUnionSchema<Context extends ModelContext> extends Abstract
 
     public override generateRawTypeDeclaration(context: Context, module: ModuleDeclaration): void {
         const interfaces = this.singleUnionTypes.map((singleUnionType) => singleUnionType.generateInterface(context));
+        const effectiveBaseProperties = this.getEffectiveBaseProperties(context);
 
         module.addTypeAlias({
             name: AbstractGeneratedSchema.RAW_TYPE_NAME,
@@ -81,15 +82,15 @@ export class GeneratedUnionSchema<Context extends ModelContext> extends Abstract
 
         for (const interfaceStructure of interfaces) {
             const interface_ = module.addInterface(interfaceStructure);
-            if (this.hasBaseInterface()) {
+            if (this.hasBaseInterface(context)) {
                 interface_.insertExtends(0, GeneratedUnionSchema.BASE_SCHEMA_NAME);
             }
         }
 
-        if (this.hasBaseInterface()) {
+        if (this.hasBaseInterface(context)) {
             module.addInterface({
                 name: GeneratedUnionSchema.BASE_SCHEMA_NAME,
-                properties: this.baseProperties.map((property) => {
+                properties: effectiveBaseProperties.map((property) => {
                     const type = context.typeSchema.getReferenceToRawType(property.valueType);
                     return {
                         name: getPropertyKey(getWireValue(property.name)),
@@ -116,7 +117,7 @@ export class GeneratedUnionSchema<Context extends ModelContext> extends Abstract
             rawDiscriminant: getWireValue(this.discriminant),
             singleUnionTypes: this.singleUnionTypes.map((singleUnionType) => {
                 const singleUnionTypeSchema = singleUnionType.getSchema(context);
-                if (this.hasBaseInterface()) {
+                if (this.hasBaseInterface(context)) {
                     singleUnionTypeSchema.nonDiscriminantProperties =
                         singleUnionTypeSchema.nonDiscriminantProperties.extend(
                             context.coreUtilities.zurg.Schema._fromExpression(
@@ -205,7 +206,7 @@ export class GeneratedUnionSchema<Context extends ModelContext> extends Abstract
             return;
         }
 
-        if (this.hasBaseInterface()) {
+        if (this.hasBaseInterface(context)) {
             context.sourceFile.addVariableStatement({
                 declarationKind: VariableDeclarationKind.Const,
                 declarations: [
@@ -214,7 +215,7 @@ export class GeneratedUnionSchema<Context extends ModelContext> extends Abstract
                         initializer: getTextOfTsNode(
                             context.coreUtilities.zurg
                                 .object(
-                                    this.baseProperties.map((baseProperty) => ({
+                                    this.getEffectiveBaseProperties(context).map((baseProperty) => ({
                                         key: {
                                             raw: getWireValue(baseProperty.name),
                                             parsed: this.getGeneratedUnion(context).getBasePropertyKey(
@@ -316,7 +317,11 @@ export class GeneratedUnionSchema<Context extends ModelContext> extends Abstract
         });
     }
 
-    private hasBaseInterface(): boolean {
-        return this.baseProperties.length > 0 || (this.shape?.extends ?? []).length > 0;
+    private getEffectiveBaseProperties(context: Context): FernIr.ObjectProperty[] {
+        return this.getGeneratedUnion(context).getEffectiveBaseProperties(context);
+    }
+
+    private hasBaseInterface(context: Context): boolean {
+        return this.getEffectiveBaseProperties(context).length > 0 || (this.shape?.extends ?? []).length > 0;
     }
 }

--- a/generators/typescript/sdk/changes/unreleased/suppress-inherited-base-props-on-discriminated-union.yml
+++ b/generators/typescript/sdk/changes/unreleased/suppress-inherited-base-props-on-discriminated-union.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    The TypeScript SDK generator now suppresses lifted base properties from a discriminated union's synthesized `_Base` interface when every variant already inherits them via its `extends` chain. Pairs with the parser change that lifts shared-parent properties so non-structural-typing SDKs (Go, C#) can expose them; keeps the TypeScript output stable and avoids TS2320 collisions on optionality.
+  type: fix

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/src/__test__/SdkEndpointTypeSchemasGenerator.test.ts
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/src/__test__/SdkEndpointTypeSchemasGenerator.test.ts
@@ -86,6 +86,7 @@ function createMockFileContext() {
                         getReferenceTo: () => ts.factory.createTypeReferenceNode("ErrorUnion"),
                         discriminant: "errorName",
                         visitPropertyName: "_visit",
+                        getEffectiveBaseProperties: () => [],
                         getBasePropertyKey: (key: string) => key,
                         buildFromExistingValue: ({ existingValue }: { existingValue: ts.Expression }) => existingValue,
                         buildUnknown: ({ existingValue }: { existingValue: ts.Expression }) => existingValue

--- a/generators/typescript/utils/contexts/src/commons/GeneratedUnion.ts
+++ b/generators/typescript/utils/contexts/src/commons/GeneratedUnion.ts
@@ -1,9 +1,18 @@
+import { FernIr } from "@fern-fern/ir-sdk";
 import { ts } from "ts-morph";
 
 export interface GeneratedUnion<Context> {
     discriminant: string;
     visitPropertyName: string;
     getReferenceTo: (context: Context) => ts.TypeNode;
+    /**
+     * Returns base properties that should be emitted on the union, with any
+     * properties already inherited via every variant's `extends` chain
+     * suppressed. Lets sibling generators (e.g. the schema layer) stay in
+     * sync with the type layer so the synthesized `_Base` never collides
+     * with a real parent interface (TS2320).
+     */
+    getEffectiveBaseProperties: (context: Context) => FernIr.ObjectProperty[];
     build: (args: {
         discriminantValueToBuild: string | number;
         builderArgument: ts.Expression | undefined;

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/inferDiscriminatedUnionBaseProperties.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/inferDiscriminatedUnionBaseProperties.test.ts
@@ -44,7 +44,7 @@ function commonPropertyOptionalityOf(schema: Schema | undefined, key: string): "
 }
 
 describe("infer-discriminated-union-base-properties", () => {
-    it("does NOT infer properties already inherited via a shared allOf $ref parent", () => {
+    it("infers properties inherited via a shared allOf $ref parent so non-structural-typing SDKs can expose them", () => {
         const doc: OpenAPIV3.Document = {
             openapi: "3.0.0",
             info: { title: "Test API", version: "1.0" },
@@ -135,9 +135,12 @@ describe("infer-discriminated-union-base-properties", () => {
         const keys = commonPropertyKeysOf(union);
 
         // `sharedField` and `anotherShared` come from Common, which every variant inherits
-        // via `allOf: $ref`. They should NOT be re-emitted as union commonProperties.
-        expect(keys).not.toContain("sharedField");
-        expect(keys).not.toContain("anotherShared");
+        // via `allOf: $ref`. They are lifted onto the union so SDKs without structural
+        // typing (Go, C#, etc.) can expose them at the top level. Generators that
+        // synthesize a duplicate base interface (e.g. TypeScript) are responsible for
+        // suppressing the redeclaration to avoid TS2320 collisions.
+        expect(keys).toContain("sharedField");
+        expect(keys).toContain("anotherShared");
     });
 
     it("still infers properties that variants declare inline (not inherited from a shared parent)", () => {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertDiscriminatedOneOf.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertDiscriminatedOneOf.ts
@@ -354,11 +354,12 @@ export function wrapDiscriminatedOneOf({
  * union's top level are excluded. This lets SDKs expose shared fields directly on
  * the union type instead of forcing a cast to a concrete variant.
  *
- * Properties that every variant already inherits through a shared `allOf $ref` parent
- * are also excluded: the parent schema is the single source of truth, and re-emitting
- * those properties on the union forces some generators (e.g. TypeScript) to declare a
- * synthesized base interface alongside the real parent, which can collide when the two
- * disagree on optionality.
+ * Properties that every variant inherits via a shared `allOf $ref` parent are also
+ * lifted: SDKs without structural typing (Go, C#, etc.) can only expose what the IR
+ * declares on the union itself, so omitting them would force a cast even when every
+ * variant truly has the property. Generators that synthesize a base interface
+ * alongside the real parent (e.g. TypeScript) are responsible for suppressing the
+ * duplicate at generation time to avoid TS2320 collisions.
  */
 function inferCommonPropertiesFromVariants({
     variants,
@@ -387,13 +388,6 @@ function inferCommonPropertiesFromVariants({
     if (firstVariantProps == null) {
         return [];
     }
-    const inheritedFromSharedParent = getPropertyNamesInheritedFromSharedAllOfRefParents({
-        variants,
-        context,
-        breadcrumbs,
-        source,
-        namespace
-    });
     const variantRequiredSets = variants.map((variant) =>
         getAllRequiredPropertyNames({ schema: variant, context, visited: new Set() })
     );
@@ -403,9 +397,6 @@ function inferCommonPropertiesFromVariants({
             continue;
         }
         if (existingPropertyNames.has(propertyName)) {
-            continue;
-        }
-        if (inheritedFromSharedParent.has(propertyName)) {
             continue;
         }
         let presentInAll = true;
@@ -473,103 +464,6 @@ function getAllRequiredPropertyNames({
         const childRequired = getAllRequiredPropertyNames({ schema: allOfElement, context, visited });
         for (const name of childRequired) {
             result.add(name);
-        }
-    }
-    return result;
-}
-
-/**
- * Walks each variant's `allOf` chain (following `$ref`s transitively) and returns the set
- * of property names that come from `$ref` parents shared by *every* variant. These are the
- * properties each variant already inherits from a common ancestor — re-declaring them on
- * the union would cause the structural duplication described above.
- */
-function getPropertyNamesInheritedFromSharedAllOfRefParents({
-    variants,
-    context,
-    breadcrumbs,
-    source,
-    namespace
-}: {
-    variants: Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject>;
-    context: SchemaParserContext;
-    breadcrumbs: string[];
-    source: Source;
-    namespace: string | undefined;
-}): Set<string> {
-    if (variants.length === 0) {
-        return new Set();
-    }
-    const refsPerVariant = variants.map((variant) =>
-        collectTransitiveAllOfRefs({ schema: variant, context, visited: new Set() })
-    );
-    const firstSet = refsPerVariant[0];
-    if (firstSet == null || firstSet.size === 0) {
-        return new Set();
-    }
-    const inherited = new Set<string>();
-    for (const [refKey, refObject] of firstSet) {
-        const sharedAcrossAllVariants = refsPerVariant.every((s) => s.has(refKey));
-        if (!sharedAcrossAllVariants) {
-            continue;
-        }
-        const parentProperties = getAllProperties({
-            schema: refObject,
-            context,
-            breadcrumbs,
-            source,
-            namespace
-        });
-        for (const propertyName of Object.keys(parentProperties)) {
-            inherited.add(propertyName);
-        }
-    }
-    return inherited;
-}
-
-/**
- * Returns a map of `$ref` URI -> the `ReferenceObject` that points to it, for every
- * `$ref` reachable via `allOf` from the given schema (transitively). Inline `allOf`
- * elements are recursed into so a deeply-nested `$ref` still surfaces.
- */
-function collectTransitiveAllOfRefs({
-    schema,
-    context,
-    visited
-}: {
-    schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject;
-    context: SchemaParserContext;
-    visited: Set<string>;
-}): Map<string, OpenAPIV3.ReferenceObject> {
-    const result = new Map<string, OpenAPIV3.ReferenceObject>();
-    let resolved: OpenAPIV3.SchemaObject;
-    if (isReferenceObject(schema)) {
-        if (visited.has(schema.$ref)) {
-            return result;
-        }
-        visited.add(schema.$ref);
-        resolved = context.resolveSchemaReference(schema);
-    } else {
-        resolved = schema;
-    }
-    for (const allOfElement of resolved.allOf ?? []) {
-        if (isReferenceObject(allOfElement)) {
-            if (!result.has(allOfElement.$ref)) {
-                result.set(allOfElement.$ref, allOfElement);
-            }
-            const nested = collectTransitiveAllOfRefs({ schema: allOfElement, context, visited });
-            for (const [k, v] of nested) {
-                if (!result.has(k)) {
-                    result.set(k, v);
-                }
-            }
-        } else {
-            const nested = collectTransitiveAllOfRefs({ schema: allOfElement, context, visited });
-            for (const [k, v] of nested) {
-                if (!result.has(k)) {
-                    result.set(k, v);
-                }
-            }
         }
     }
     return result;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oneof-shared-allof-properties.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oneof-shared-allof-properties.json
@@ -77,21 +77,21 @@
                 "value": {
                   "id": {
                     "value": {
-                      "value": "id",
+                      "value": "string",
                       "type": "string"
                     },
                     "type": "primitive"
                   },
                   "name": {
                     "value": {
-                      "value": "name",
+                      "value": "string",
                       "type": "string"
                     },
                     "type": "primitive"
                   },
                   "display_name": {
                     "value": {
-                      "value": "display_name",
+                      "value": "string",
                       "type": "string"
                     },
                     "type": "primitive"
@@ -204,7 +204,48 @@
       },
       "ConnectionResponse": {
         "value": {
-          "commonProperties": [],
+          "commonProperties": [
+            {
+              "key": "id",
+              "schema": {
+                "description": "The connection's identifier.",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ConnectionCommonId",
+                "groupName": [],
+                "type": "primitive"
+              }
+            },
+            {
+              "key": "name",
+              "schema": {
+                "description": "The connection's display name.",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ConnectionCommonName",
+                "groupName": [],
+                "type": "primitive"
+              }
+            },
+            {
+              "key": "display_name",
+              "schema": {
+                "generatedName": "",
+                "value": {
+                  "description": "Connection name shown in the login screen.",
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "ConnectionCommonDisplayName",
+                  "groupName": [],
+                  "type": "primitive"
+                },
+                "type": "optional"
+              }
+            }
+          ],
           "description": "Discriminated union of connection strategies.",
           "discriminantProperty": "strategy",
           "discriminatorContext": "data",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oneof-shared-allof-properties.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oneof-shared-allof-properties.json
@@ -19,9 +19,9 @@
                   },
                   "response": {
                     "body": {
-                      "display_name": "display_name",
-                      "id": "id",
-                      "name": "name",
+                      "display_name": "string",
+                      "id": "string",
+                      "name": "string",
                       "options_auth0": {
                         "tenant": "tenant",
                       },
@@ -77,7 +77,20 @@
           },
           "ConnectionResponse": {
             "availability": undefined,
-            "base-properties": {},
+            "base-properties": {
+              "display_name": {
+                "docs": "Connection name shown in the login screen.",
+                "type": "optional<string>",
+              },
+              "id": {
+                "docs": "The connection's identifier.",
+                "type": "string",
+              },
+              "name": {
+                "docs": "The connection's display name.",
+                "type": "string",
+              },
+            },
             "default-variant": undefined,
             "discriminant": {
               "context": "data",
@@ -187,9 +200,9 @@
             id: id
           response:
             body:
-              id: id
-              name: name
-              display_name: display_name
+              id: string
+              name: string
+              display_name: string
               options_auth0:
                 tenant: tenant
               strategy: auth0
@@ -214,7 +227,16 @@ types:
     discriminant:
       value: strategy
       context: data
-    base-properties: {}
+    base-properties:
+      id:
+        type: string
+        docs: The connection's identifier.
+      name:
+        type: string
+        docs: The connection's display name.
+      display_name:
+        type: optional<string>
+        docs: Connection name shown in the login screen.
     docs: Discriminated union of connection strategies.
     union:
       auth0: ConnectionResponseAuth0

--- a/packages/cli/cli/changes/unreleased/lift-discriminated-union-inherited-base-properties.yml
+++ b/packages/cli/cli/changes/unreleased/lift-discriminated-union-inherited-base-properties.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    `infer-discriminated-union-base-properties` now lifts properties that every variant inherits via a shared `allOf $ref` parent. Previously these were dropped to protect TypeScript's `_Base` from colliding with the real parent interface, which left Go and C# unions missing common fields like `id`, `name`, and `display_name`.
+  type: fix


### PR DESCRIPTION
Closes FER-11350

## Summary

- `infer-discriminated-union-base-properties` was excluding properties that every variant inherited from a shared `allOf $ref` parent. That kept TypeScript's synthesized `_Base` from colliding with the real parent (TS2320), but it silently broke Go and C# unions, which don't have structural typing — common fields like `id`, `name`, `display_name` weren't reachable without first switching on the variant pointer.
- The parser now lifts all properties common to every variant, regardless of whether they came via a shared `$ref` parent.
- The TypeScript generator suppresses any of those lifted properties that every variant already inherits via its IR `extends` chain. TS output stays identical; Go and C# unions now expose the common fields.

## Example: Auth0 `ConnectionResponseContent`

Each of the 55 variants is `allOf: [inline, $ref ConnectionPurposes, $ref ConnectionResponseCommon]`, where `ConnectionResponseCommon` provides `id`, `realms`, plus everything inherited from `CreateConnectionCommon` → `ConnectionCommon` (`name`, `display_name`, `enabled_clients`, `is_domain_connection`, `metadata`).

**Before — Go:**
```go
type ConnectionResponseContent struct {
    Strategy       string
    Authentication *ConnectionAuthenticationPurpose
    Ad             *ConnectionResponseContentAd
    // ... 54 more variant pointers, no common fields
}
```

**After — Go:**
```go
type ConnectionResponseContent struct {
    Strategy            string
    Authentication      *ConnectionAuthenticationPurpose
    ID                  ConnectionID
    Realms              *ConnectionRealms
    DisplayName         ConnectionDisplayName
    EnabledClients      []string
    IsDomainConnection  *ConnectionIsDomainConnection
    Metadata            *ConnectionsMetadata
    Name                ConnectionName
    Ad                  *ConnectionResponseContentAd
    // ...
}
```

**TypeScript — unchanged:**
```ts
export interface _Base {
    authentication?: Management.ConnectionAuthenticationPurpose;
}
export interface Ad extends Management.ConnectionResponseContentAd, _Base { strategy: "ad" }
```
`id`/`name`/`display_name`/... continue to come via the real `extends ConnectionResponseCommon` chain — the new suppression keeps them out of `_Base` so TS2320 doesn't fire.

## Test plan

- [x] `pnpm vitest run` for `@fern-api/openapi-ir-parser` (parser tests, including updated `inferDiscriminatedUnionBaseProperties` test)
- [x] `pnpm vitest run` for `@fern-api/openapi-ir-to-fern-tests` (updated snapshots for `oneof-shared-allof-properties` fixture)
- [x] `pnpm vitest run` for `@fern-typescript/type-generator` (no snapshot changes)
- [x] Seed-run Auth0 config locally for `ts-sdk`, `go-sdk`, `csharp-sdk` — confirmed `ConnectionResponseContent` now exposes the full set of common properties at the top level in Go and C# while TS output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->