### PR TITLE
fix(ci): use PAT for PR creation so workflows run without approval

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -53,41 +53,11 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "fix(lint): auto-fix lint issues"
           title: "fix(lint): auto-fix lint issues"
           branch: automated-lint-fixes
           delete-branch: true
-
-      # GITHUB_TOKEN pushes queue pull_request workflow runs that require
-      # manual approval.  Approve them automatically so required PR checks
-      # can run and the auto-merge proceeds.
-      - name: Approve pending workflow runs
-        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
-        run: |
-          BRANCH="automated-lint-fixes"
-          echo "Waiting for pull_request workflow runs to be queued..."
-          for attempt in 1 2 3 4 5 6; do
-            sleep 10
-            PENDING_RUNS=$(gh api \
-              "/repos/${{ github.repository }}/actions/runs?branch=${BRANCH}&event=pull_request&status=action_required&per_page=20" \
-              --jq '.workflow_runs[].id')
-            if [ -n "$PENDING_RUNS" ]; then
-              echo "Found pending workflow runs, approving..."
-              for RUN_ID in $PENDING_RUNS; do
-                echo "Approving workflow run $RUN_ID"
-                gh api --method POST \
-                  "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/approve" 2>&1 \
-                  || echo "Warning: failed to approve run $RUN_ID"
-              done
-              echo "All pending runs approved."
-              break
-            fi
-            echo "Attempt $attempt: no pending runs yet, retrying..."
-          done
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
@@ -101,7 +71,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: ./.github/actions/auto-approve
         with:
-          approver-gh-token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+          approver-gh-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           enforced-checks: lint
           enforce-checks: "true"

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1109,7 +1109,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "chore(seed): update all seed snapshots"
           title: "chore(seed): update all seed snapshots"
           branch: update-all-seed
@@ -1132,37 +1132,6 @@ jobs:
         run: |
           echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
 
-      # GITHUB_TOKEN pushes queue pull_request workflow runs that require
-      # manual approval.  Approve them automatically so required PR checks
-      # can run and the auto-merge proceeds.
-      - name: Approve pending workflow runs
-        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
-        run: |
-          BRANCH="update-all-seed"
-          echo "Waiting for pull_request workflow runs to be queued..."
-          for attempt in 1 2 3 4 5 6; do
-            sleep 10
-            PENDING_RUNS=$(gh api \
-              "/repos/${{ github.repository }}/actions/runs?branch=${BRANCH}&event=pull_request&status=action_required&per_page=20" \
-              --jq '.workflow_runs[].id')
-            if [ -n "$PENDING_RUNS" ]; then
-              echo "Found pending workflow runs, approving..."
-              for RUN_ID in $PENDING_RUNS; do
-                echo "Approving workflow run $RUN_ID"
-                gh api --method POST \
-                  "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/approve" 2>&1 \
-                  || echo "Warning: failed to approve run $RUN_ID"
-              done
-              echo "All pending runs approved."
-              exit 0
-            fi
-            echo "Attempt $attempt: no pending runs yet, retrying..."
-          done
-          echo "No action-required workflow runs found after retries."
-
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: peter-evans/enable-pull-request-automerge@v3
@@ -1175,5 +1144,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: ./.github/actions/auto-approve
         with:
-          approver-gh-token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+          approver-gh-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Description

Fixes automated seed-update and lint-fix PRs getting stuck with "5 workflows awaiting approval" — preventing auto-merge.

## Changes Made

Swap token roles in `update-seed.yml` and `fix-lint.yml`:

| Action | Before (#16433 / #16545) | After |
|--------|-------------------------|-------|
| Create PR | `GITHUB_TOKEN` | `FERN_SUPPORT_GH_ACTIONS_PAT` |
| Approve PR | `FERN_SUPPORT_GH_ACTIONS_PAT` | `GITHUB_TOKEN` |
| Auto-merge | `FERN_SUPPORT_GH_ACTIONS_PAT` | `FERN_SUPPORT_GH_ACTIONS_PAT` (unchanged) |

- Remove the broken \"Approve pending workflow runs\" step from #16545 — the `/actions/runs/{id}/approve` API only works for fork PRs (`HTTP 403: This run is not from a fork pull request`)

### Why this works

- PAT pushes trigger `pull_request` events that run **without** needing approval (real user, not bot)
- `GITHUB_TOKEN` (`github-actions[bot]`) is a different identity from the PAT user, so it can approve the PR
- No classic PATs used (satisfies the org policy that banned `FERN_GITHUB_TOKEN`)

### Why the previous approaches failed

1. **#16433**: Switched to `GITHUB_TOKEN` for PR creation → `github-actions[bot]` push requires workflow approval
2. **#16545**: Tried approving runs via API → `POST /actions/runs/{id}/approve` only works for fork PRs

## Testing

- Will be validated end-to-end on the next seed update run after merge
- Confirmed via job logs that the API approach returned `403: This run is not from a fork pull request`

Link to Devin session: https://app.devin.ai/sessions/9cd19f775add4a25b3c5131b9f949b96
Requested by: @davidkonigsberg