### PR TITLE
fix(cli): guard undefined discriminant in IR-to-FDR union conversion

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-wirevalue-crash-union-discriminant.yml
+++ b/packages/cli/cli/changes/unreleased/fix-wirevalue-crash-union-discriminant.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix crash in `fern docs dev` when an IR union type has an undefined discriminant.
+    The IR-to-FDR type converter now gracefully falls back to an undiscriminated union
+    representation instead of throwing `Cannot read properties of undefined (reading 'wireValue')`.
+  type: fix

--- a/packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts
@@ -75,17 +75,15 @@ export function convertTypeShape(irType: Ir.types.Type): FdrCjsSdk.api.v1.regist
             }
             const baseProperties: FdrCjsSdk.api.v1.register.ObjectProperty[] = union.baseProperties
                 .filter((baseProperty) => baseProperty.name != null)
-                .map(
-                    (baseProperty): FdrCjsSdk.api.v1.register.ObjectProperty => {
-                        return {
-                            key: FdrCjsSdk.PropertyKey(getWireValue(baseProperty.name)),
-                            valueType: convertTypeReference(baseProperty.valueType, baseProperty.defaultValue),
-                            availability: convertIrAvailability(baseProperty.availability),
-                            description: baseProperty.docs,
-                            propertyAccess: baseProperty.propertyAccess
-                        };
-                    }
-                );
+                .map((baseProperty): FdrCjsSdk.api.v1.register.ObjectProperty => {
+                    return {
+                        key: FdrCjsSdk.PropertyKey(getWireValue(baseProperty.name)),
+                        valueType: convertTypeReference(baseProperty.valueType, baseProperty.defaultValue),
+                        availability: convertIrAvailability(baseProperty.availability),
+                        description: baseProperty.docs,
+                        propertyAccess: baseProperty.propertyAccess
+                    };
+                });
             return {
                 type: "discriminatedUnion",
                 discriminant: getWireValue(union.discriminant),
@@ -97,9 +95,7 @@ export function convertTypeShape(irType: Ir.types.Type): FdrCjsSdk.api.v1.regist
                             discriminantValue: getWireValue(variant.discriminantValue),
                             displayName: variant.displayName,
                             availability:
-                                variant.availability != null
-                                    ? convertIrAvailability(variant.availability)
-                                    : undefined,
+                                variant.availability != null ? convertIrAvailability(variant.availability) : undefined,
                             additionalProperties:
                                 Ir.types.SingleUnionTypeProperties._visit<FdrCjsSdk.api.v1.register.ObjectType>(
                                     variant.shape,

--- a/packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts
@@ -42,69 +42,113 @@ export function convertTypeShape(irType: Ir.types.Type): FdrCjsSdk.api.v1.regist
             };
         },
         union: (union) => {
-            const baseProperties: FdrCjsSdk.api.v1.register.ObjectProperty[] = union.baseProperties.map(
-                (baseProperty): FdrCjsSdk.api.v1.register.ObjectProperty => {
-                    return {
-                        key: FdrCjsSdk.PropertyKey(getWireValue(baseProperty.name)),
-                        valueType: convertTypeReference(baseProperty.valueType, baseProperty.defaultValue),
-                        availability: convertIrAvailability(baseProperty.availability),
-                        description: baseProperty.docs,
-                        propertyAccess: baseProperty.propertyAccess
-                    };
-                }
-            );
+            if (union.discriminant == null) {
+                return {
+                    type: "undiscriminatedUnion",
+                    variants: union.types
+                        .map((variant): FdrCjsSdk.api.v1.register.UndiscriminatedUnionVariant | undefined => {
+                            const typeRef = Ir.types.SingleUnionTypeProperties._visit<
+                                FdrCjsSdk.api.v1.register.TypeReference | undefined
+                            >(variant.shape, {
+                                samePropertiesAsObject: (extension) => ({
+                                    type: "id",
+                                    value: FdrCjsSdk.TypeId(extension.typeId),
+                                    default: undefined
+                                }),
+                                singleProperty: (singleProperty) => convertTypeReference(singleProperty.type),
+                                noProperties: () => undefined,
+                                _other: () => undefined
+                            });
+                            if (typeRef == null) {
+                                return undefined;
+                            }
+                            return {
+                                typeName: undefined,
+                                description: variant.docs ?? undefined,
+                                type: typeRef,
+                                availability: undefined,
+                                displayName: variant.displayName
+                            };
+                        })
+                        .filter((v): v is FdrCjsSdk.api.v1.register.UndiscriminatedUnionVariant => v != null)
+                };
+            }
+            const baseProperties: FdrCjsSdk.api.v1.register.ObjectProperty[] = union.baseProperties
+                .filter((baseProperty) => baseProperty.name != null)
+                .map(
+                    (baseProperty): FdrCjsSdk.api.v1.register.ObjectProperty => {
+                        return {
+                            key: FdrCjsSdk.PropertyKey(getWireValue(baseProperty.name)),
+                            valueType: convertTypeReference(baseProperty.valueType, baseProperty.defaultValue),
+                            availability: convertIrAvailability(baseProperty.availability),
+                            description: baseProperty.docs,
+                            propertyAccess: baseProperty.propertyAccess
+                        };
+                    }
+                );
             return {
                 type: "discriminatedUnion",
                 discriminant: getWireValue(union.discriminant),
-                variants: union.types.map((variant): FdrCjsSdk.api.v1.register.DiscriminatedUnionVariant => {
-                    return {
-                        description: variant.docs ?? undefined,
-                        discriminantValue: getWireValue(variant.discriminantValue),
-                        displayName: variant.displayName,
-                        availability:
-                            variant.availability != null ? convertIrAvailability(variant.availability) : undefined,
-                        additionalProperties:
-                            Ir.types.SingleUnionTypeProperties._visit<FdrCjsSdk.api.v1.register.ObjectType>(
-                                variant.shape,
-                                {
-                                    samePropertiesAsObject: (extension) => ({
-                                        extends: [FdrCjsSdk.TypeId(extension.typeId)],
-                                        properties: baseProperties,
-                                        // TODO: add support for extra properties in discriminated union
-                                        extraProperties: undefined
-                                    }),
-                                    singleProperty: (singleProperty) => ({
-                                        extends: [],
-                                        properties: [
-                                            {
-                                                key: FdrCjsSdk.PropertyKey(getWireValue(singleProperty.name)),
-                                                valueType: convertTypeReference(singleProperty.type),
-                                                description: undefined,
-                                                availability: undefined,
-                                                propertyAccess: undefined
-                                            },
-                                            ...baseProperties
-                                        ],
-                                        // TODO: add support for extra properties in discriminated union
-                                        extraProperties: undefined
-                                    }),
-                                    noProperties: () => ({
-                                        extends: [],
-                                        properties: baseProperties,
-                                        // TODO: add support for extra properties in discriminated union
-                                        extraProperties: undefined
-                                    }),
-                                    _other: () => {
-                                        throw new CliError({
-                                            message:
-                                                "Unknown SingleUnionTypeProperties: " + variant.shape.propertiesType,
-                                            code: CliError.Code.InternalError
-                                        });
+                variants: union.types
+                    .filter((variant) => variant.discriminantValue != null)
+                    .map((variant): FdrCjsSdk.api.v1.register.DiscriminatedUnionVariant => {
+                        return {
+                            description: variant.docs ?? undefined,
+                            discriminantValue: getWireValue(variant.discriminantValue),
+                            displayName: variant.displayName,
+                            availability:
+                                variant.availability != null
+                                    ? convertIrAvailability(variant.availability)
+                                    : undefined,
+                            additionalProperties:
+                                Ir.types.SingleUnionTypeProperties._visit<FdrCjsSdk.api.v1.register.ObjectType>(
+                                    variant.shape,
+                                    {
+                                        samePropertiesAsObject: (extension) => ({
+                                            extends: [FdrCjsSdk.TypeId(extension.typeId)],
+                                            properties: baseProperties,
+                                            // TODO: add support for extra properties in discriminated union
+                                            extraProperties: undefined
+                                        }),
+                                        singleProperty: (singleProperty) => ({
+                                            extends: [],
+                                            properties: [
+                                                ...(singleProperty.name != null
+                                                    ? [
+                                                          {
+                                                              key: FdrCjsSdk.PropertyKey(
+                                                                  getWireValue(singleProperty.name)
+                                                              ),
+                                                              valueType: convertTypeReference(singleProperty.type),
+                                                              description: undefined,
+                                                              availability: undefined,
+                                                              propertyAccess: undefined
+                                                          }
+                                                      ]
+                                                    : []),
+                                                ...baseProperties
+                                            ],
+                                            // TODO: add support for extra properties in discriminated union
+                                            extraProperties: undefined
+                                        }),
+                                        noProperties: () => ({
+                                            extends: [],
+                                            properties: baseProperties,
+                                            // TODO: add support for extra properties in discriminated union
+                                            extraProperties: undefined
+                                        }),
+                                        _other: () => {
+                                            throw new CliError({
+                                                message:
+                                                    "Unknown SingleUnionTypeProperties: " +
+                                                    variant.shape.propertiesType,
+                                                code: CliError.Code.InternalError
+                                            });
+                                        }
                                     }
-                                }
-                            )
-                    };
-                })
+                                )
+                        };
+                    })
             };
         },
         undiscriminatedUnion: (union) => {


### PR DESCRIPTION
## Description

Fix crash in `fern docs dev` when an IR union type has an undefined discriminant. The crash manifests as `TypeError: Cannot read properties of undefined (reading 'wireValue')` during "Building navigation tree" when an OpenAPI spec produces a discriminated union IR type with an undefined discriminant field. Reported after upgrading from CLI 4.43.1 → 5.49.2.

## Changes Made

In `packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts`, the `union:` handler:

- **Null-guard on `union.discriminant`**: When `undefined`, falls back to an `undiscriminatedUnion` shape instead of crashing. Uses `SingleUnionTypeProperties._visit` to extract type references from each variant (`samePropertiesAsObject` → named type id, `singleProperty` → its type ref, `noProperties`/`_other` → skipped).
- **Filter `baseProperties`** with `.filter((bp) => bp.name != null)` before mapping, preventing `getWireValue(undefined)`.
- **Filter `union.types`** with `.filter((v) => v.discriminantValue != null)` before mapping, preventing `getWireValue(undefined)`.
- **Guard `singleProperty.name`** inside the `singleProperty` visitor — conditionally spreads the property only when `name != null`.

Changelog entry added at `packages/cli/cli/changes/unreleased/fix-wirevalue-crash-union-discriminant.yml`.

## Testing

- [x] `pnpm turbo run compile --filter @fern-api/register` — passes
- [x] `pnpm turbo run test --filter @fern-api/register` — 230 passed, 1 skipped (pre-existing)
- [x] Biome lint — clean

Link to Devin session: https://app.devin.ai/sessions/f6154f102a2c4360b65e51450e1cf471
Requested by: @ctondreau
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->