### PR TITLE
fix(python): remove vestigial [project] table from generated pyproject.toml

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-pep621-pyproject-toml.yml
+++ b/generators/python/sdk/changes/unreleased/fix-pep621-pyproject-toml.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Remove the vestigial `[project]` table from the generated `pyproject.toml`.
+    The partial PEP 621 table (containing only `name` and `dynamic`) caused
+    source/git installs to fail with PEP 621-aware build frontends (uv, recent
+    pip) on older generator versions that lacked `dynamic = ["version"]`.
+    Removing `[project]` entirely lets `poetry-core` fully own all metadata via
+    `[tool.poetry]`, which is compatible with all build tools.
+  type: fix

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -48,7 +48,6 @@ class PyProjectToml:
         user_defined_toml: Optional[str] = None,
         mypy_exclude: Optional[List[str]] = None,
     ):
-        self._name = name
         self._poetry_block = PyProjectToml.PoetryBlock(
             name=name,
             version=version,
@@ -81,11 +80,7 @@ class PyProjectToml:
             PyProjectToml.PluginConfigurationBlock(mypy_exclude=self._mypy_exclude),
             PyProjectToml.BuildSystemBlock(),
         ]
-        content = f"""[project]
-name = "{self._name}"
-dynamic = ["version"]
-
-"""
+        content = ""
 
         for block in blocks:
             content += block.to_string()

--- a/seed/python-sdk/accept-header/pyproject.toml
+++ b/seed/python-sdk/accept-header/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_accept-header"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_accept-header"
 version = "0.0.1"

--- a/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_alias-extends"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_alias-extends"
 version = "0.0.1"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_alias-extends"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_alias-extends"
 version = "0.0.1"

--- a/seed/python-sdk/alias/pyproject.toml
+++ b/seed/python-sdk/alias/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_alias"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_alias"
 version = "0.0.1"

--- a/seed/python-sdk/allof-inline/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/allof-inline/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_allof-inline"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_allof-inline"
 version = "0.0.1"

--- a/seed/python-sdk/allof/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/allof/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_allof"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_allof"
 version = "0.0.1"

--- a/seed/python-sdk/any-auth/pyproject.toml
+++ b/seed/python-sdk/any-auth/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_any-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_any-auth"
 version = "0.0.1"

--- a/seed/python-sdk/api-wide-base-path-with-default/pyproject.toml
+++ b/seed/python-sdk/api-wide-base-path-with-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_api-wide-base-path-with-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_api-wide-base-path-with-default"
 version = "0.0.1"

--- a/seed/python-sdk/api-wide-base-path/pyproject.toml
+++ b/seed/python-sdk/api-wide-base-path/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_api-wide-base-path"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_api-wide-base-path"
 version = "0.0.1"

--- a/seed/python-sdk/audiences/pyproject.toml
+++ b/seed/python-sdk/audiences/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_audiences"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_audiences"
 version = "0.0.1"

--- a/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
+++ b/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_basic-auth-environment-variables"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_basic-auth-environment-variables"
 version = "0.0.1"

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_basic-auth-pw-omitted"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_basic-auth-pw-omitted"
 version = "0.0.1"

--- a/seed/python-sdk/basic-auth/pyproject.toml
+++ b/seed/python-sdk/basic-auth/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_basic-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_basic-auth"
 version = "0.0.1"

--- a/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
+++ b/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_bearer-token-environment-variable"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_bearer-token-environment-variable"
 version = "0.0.1"

--- a/seed/python-sdk/bytes-download/pyproject.toml
+++ b/seed/python-sdk/bytes-download/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_bytes-download"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_bytes-download"
 version = "0.0.1"

--- a/seed/python-sdk/bytes-upload/pyproject.toml
+++ b/seed/python-sdk/bytes-upload/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_bytes-upload"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_bytes-upload"
 version = "0.0.1"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_circular-references-advanced"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_circular-references-advanced"
 version = "0.0.1"

--- a/seed/python-sdk/circular-references-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_circular-references-extends"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_circular-references-extends"
 version = "0.0.1"

--- a/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_circular-references"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_circular-references"
 version = "0.0.1"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_circular-references"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_circular-references"
 version = "0.0.1"

--- a/seed/python-sdk/cli-multi-spec-namespaced/pyproject.toml
+++ b/seed/python-sdk/cli-multi-spec-namespaced/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_cli-multi-spec-namespaced"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_cli-multi-spec-namespaced"
 version = "0.0.1"

--- a/seed/python-sdk/cli-multi-spec/pyproject.toml
+++ b/seed/python-sdk/cli-multi-spec/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_cli-multi-spec"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_cli-multi-spec"
 version = "0.0.1"

--- a/seed/python-sdk/client-side-params/pyproject.toml
+++ b/seed/python-sdk/client-side-params/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_client-side-params"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_client-side-params"
 version = "0.0.1"

--- a/seed/python-sdk/content-type/pyproject.toml
+++ b/seed/python-sdk/content-type/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_content-type"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_content-type"
 version = "0.0.1"

--- a/seed/python-sdk/cross-package-type-names/pyproject.toml
+++ b/seed/python-sdk/cross-package-type-names/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_cross-package-type-names"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_cross-package-type-names"
 version = "0.0.1"

--- a/seed/python-sdk/dollar-string-examples/pyproject.toml
+++ b/seed/python-sdk/dollar-string-examples/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_dollar-string-examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_dollar-string-examples"
 version = "0.0.1"

--- a/seed/python-sdk/empty-clients/pyproject.toml
+++ b/seed/python-sdk/empty-clients/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_empty-clients"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_empty-clients"
 version = "0.0.1"

--- a/seed/python-sdk/endpoint-security-auth/pyproject.toml
+++ b/seed/python-sdk/endpoint-security-auth/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_endpoint-security-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_endpoint-security-auth"
 version = "0.0.1"

--- a/seed/python-sdk/enum/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/enum/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_enum"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_enum"
 version = "0.0.1"

--- a/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_enum"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_enum"
 version = "0.0.1"

--- a/seed/python-sdk/enum/real-enum/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_enum"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_enum"
 version = "0.0.1"

--- a/seed/python-sdk/enum/strenum/pyproject.toml
+++ b/seed/python-sdk/enum/strenum/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_enum"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_enum"
 version = "0.0.1"

--- a/seed/python-sdk/error-property/pyproject.toml
+++ b/seed/python-sdk/error-property/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_error-property"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_error-property"
 version = "0.0.1"

--- a/seed/python-sdk/errors/pyproject.toml
+++ b/seed/python-sdk/errors/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_errors"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_errors"
 version = "0.0.1"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_examples"
 version = "0.0.1"

--- a/seed/python-sdk/examples/client-filename/pyproject.toml
+++ b/seed/python-sdk/examples/client-filename/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_examples"
 version = "0.0.1"

--- a/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
+++ b/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_examples"
 version = "0.0.1"

--- a/seed/python-sdk/examples/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/examples/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_examples"
 version = "0.0.1"

--- a/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
+++ b/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_examples"
 version = "0.0.1"

--- a/seed/python-sdk/examples/readme/pyproject.toml
+++ b/seed/python-sdk/examples/readme/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_examples"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
+++ b/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/import-paths/pyproject.toml
+++ b/seed/python-sdk/exhaustive/import-paths/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/output-directory-project-root/pyproject.toml
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/package-path/pyproject.toml
+++ b/seed/python-sdk/exhaustive/package-path/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/union-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/union-utils/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_exhaustive"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_exhaustive"
 version = "0.0.1"

--- a/seed/python-sdk/extends/pyproject.toml
+++ b/seed/python-sdk/extends/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_extends"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_extends"
 version = "0.0.1"

--- a/seed/python-sdk/extra-properties/pyproject.toml
+++ b/seed/python-sdk/extra-properties/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_extra-properties"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_extra-properties"
 version = "0.0.1"

--- a/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
+++ b/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_file-download"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_file-download"
 version = "0.0.1"

--- a/seed/python-sdk/file-download/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-download/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_file-download"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_file-download"
 version = "0.0.1"

--- a/seed/python-sdk/file-upload-openapi/pyproject.toml
+++ b/seed/python-sdk/file-upload-openapi/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_file-upload-openapi"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_file-upload-openapi"
 version = "0.0.1"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_file-upload"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_file-upload"
 version = "0.0.1"

--- a/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_file-upload"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_file-upload"
 version = "0.0.1"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_file-upload"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_file-upload"
 version = "0.0.1"

--- a/seed/python-sdk/folders/pyproject.toml
+++ b/seed/python-sdk/folders/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_folders"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_folders"
 version = "0.0.1"

--- a/seed/python-sdk/header-auth-environment-variable/pyproject.toml
+++ b/seed/python-sdk/header-auth-environment-variable/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_header-auth-environment-variable"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_header-auth-environment-variable"
 version = "0.0.1"

--- a/seed/python-sdk/header-auth/pyproject.toml
+++ b/seed/python-sdk/header-auth/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_header-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_header-auth"
 version = "0.0.1"

--- a/seed/python-sdk/http-head/pyproject.toml
+++ b/seed/python-sdk/http-head/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_http-head"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_http-head"
 version = "0.0.1"

--- a/seed/python-sdk/idempotency-headers/pyproject.toml
+++ b/seed/python-sdk/idempotency-headers/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_idempotency-headers"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_idempotency-headers"
 version = "0.0.1"

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_imdb"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_imdb"
 version = "0.0.1"

--- a/seed/python-sdk/inferred-auth-explicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-explicit/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_inferred-auth-explicit"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_inferred-auth-explicit"
 version = "0.0.1"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_inferred-auth-implicit-api-key"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_inferred-auth-implicit-api-key"
 version = "0.0.1"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_inferred-auth-implicit-no-expiry"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_inferred-auth-implicit-no-expiry"
 version = "0.0.1"

--- a/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_inferred-auth-implicit-reference"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_inferred-auth-implicit-reference"
 version = "0.0.1"

--- a/seed/python-sdk/inferred-auth-implicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_inferred-auth-implicit"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_inferred-auth-implicit"
 version = "0.0.1"

--- a/seed/python-sdk/license/pyproject.toml
+++ b/seed/python-sdk/license/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_license"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_license"
 version = "0.0.1"

--- a/seed/python-sdk/literal-user-agent/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_literal-user-agent"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_literal-user-agent"
 version = "0.0.1"

--- a/seed/python-sdk/literal/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/literal/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_literal"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_literal"
 version = "0.0.1"

--- a/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_literal"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_literal"
 version = "0.0.1"

--- a/seed/python-sdk/literals-unions/pyproject.toml
+++ b/seed/python-sdk/literals-unions/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_literals-unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_literals-unions"
 version = "0.0.1"

--- a/seed/python-sdk/mixed-case/pyproject.toml
+++ b/seed/python-sdk/mixed-case/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_mixed-case"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_mixed-case"
 version = "0.0.1"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_mixed-file-directory"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_mixed-file-directory"
 version = "0.0.1"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_mixed-file-directory"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_mixed-file-directory"
 version = "0.0.1"

--- a/seed/python-sdk/multi-line-docs/pyproject.toml
+++ b/seed/python-sdk/multi-line-docs/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_multi-line-docs"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_multi-line-docs"
 version = "0.0.1"

--- a/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_multi-url-environment-no-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_multi-url-environment-no-default"
 version = "0.0.1"

--- a/seed/python-sdk/multi-url-environment-reference/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-reference/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_multi-url-environment-reference"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_multi-url-environment-reference"
 version = "0.0.1"

--- a/seed/python-sdk/multi-url-environment/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_multi-url-environment"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_multi-url-environment"
 version = "0.0.1"

--- a/seed/python-sdk/multiple-request-bodies/pyproject.toml
+++ b/seed/python-sdk/multiple-request-bodies/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_multiple-request-bodies"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_multiple-request-bodies"
 version = "0.0.1"

--- a/seed/python-sdk/no-content-response/pyproject.toml
+++ b/seed/python-sdk/no-content-response/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_no-content-response"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_no-content-response"
 version = "0.0.1"

--- a/seed/python-sdk/no-environment/pyproject.toml
+++ b/seed/python-sdk/no-environment/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_no-environment"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_no-environment"
 version = "0.0.1"

--- a/seed/python-sdk/no-retries/pyproject.toml
+++ b/seed/python-sdk/no-retries/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_no-retries"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_no-retries"
 version = "0.0.1"

--- a/seed/python-sdk/null-type/pyproject.toml
+++ b/seed/python-sdk/null-type/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_null-type"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_null-type"
 version = "0.0.1"

--- a/seed/python-sdk/nullable-allof-extends/pyproject.toml
+++ b/seed/python-sdk/nullable-allof-extends/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_nullable-allof-extends"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_nullable-allof-extends"
 version = "0.0.1"

--- a/seed/python-sdk/nullable-optional/pyproject.toml
+++ b/seed/python-sdk/nullable-optional/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_nullable-optional"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_nullable-optional"
 version = "0.0.1"

--- a/seed/python-sdk/nullable-request-body/pyproject.toml
+++ b/seed/python-sdk/nullable-request-body/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_nullable-request-body"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_nullable-request-body"
 version = "0.0.1"

--- a/seed/python-sdk/nullable/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/nullable/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_nullable"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_nullable"
 version = "0.0.1"

--- a/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
+++ b/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_nullable"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_nullable"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-custom"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-custom"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-default"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-environment-variables"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-environment-variables"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-mandatory-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-mandatory-auth"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-nested-root"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-nested-root"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-openapi/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-openapi/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-openapi"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-openapi"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-reference"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-reference"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials-with-variables"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials-with-variables"
 version = "0.0.1"

--- a/seed/python-sdk/oauth-client-credentials/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_oauth-client-credentials"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_oauth-client-credentials"
 version = "0.0.1"

--- a/seed/python-sdk/object/pyproject.toml
+++ b/seed/python-sdk/object/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_object"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_object"
 version = "0.0.1"

--- a/seed/python-sdk/objects-with-imports/pyproject.toml
+++ b/seed/python-sdk/objects-with-imports/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_objects-with-imports"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_objects-with-imports"
 version = "0.0.1"

--- a/seed/python-sdk/openapi-request-body-ref/pyproject.toml
+++ b/seed/python-sdk/openapi-request-body-ref/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_openapi-request-body-ref"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_openapi-request-body-ref"
 version = "0.0.1"

--- a/seed/python-sdk/openapi-subtitle/pyproject.toml
+++ b/seed/python-sdk/openapi-subtitle/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_openapi-subtitle"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_openapi-subtitle"
 version = "0.0.1"

--- a/seed/python-sdk/optional/pyproject.toml
+++ b/seed/python-sdk/optional/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_optional"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_optional"
 version = "0.0.1"

--- a/seed/python-sdk/package-yml/pyproject.toml
+++ b/seed/python-sdk/package-yml/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_package-yml"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_package-yml"
 version = "0.0.1"

--- a/seed/python-sdk/pagination-custom/pyproject.toml
+++ b/seed/python-sdk/pagination-custom/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_pagination-custom"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_pagination-custom"
 version = "0.0.1"

--- a/seed/python-sdk/pagination-uri-path/pyproject.toml
+++ b/seed/python-sdk/pagination-uri-path/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_pagination-uri-path"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_pagination-uri-path"
 version = "0.0.1"

--- a/seed/python-sdk/pagination/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/pagination/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_pagination"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_pagination"
 version = "0.0.1"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_pagination"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_pagination"
 version = "0.0.1"

--- a/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
+++ b/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_pagination"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_pagination"
 version = "0.0.1"

--- a/seed/python-sdk/path-parameters/pyproject.toml
+++ b/seed/python-sdk/path-parameters/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_path-parameters"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_path-parameters"
 version = "0.0.1"

--- a/seed/python-sdk/plain-text/pyproject.toml
+++ b/seed/python-sdk/plain-text/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_plain-text"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_plain-text"
 version = "0.0.1"

--- a/seed/python-sdk/property-access/pyproject.toml
+++ b/seed/python-sdk/property-access/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_property-access"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_property-access"
 version = "0.0.1"

--- a/seed/python-sdk/public-object/pyproject.toml
+++ b/seed/python-sdk/public-object/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_public-object"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_public-object"
 version = "0.0.1"

--- a/seed/python-sdk/python-backslash-escape/pyproject.toml
+++ b/seed/python-sdk/python-backslash-escape/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-backslash-escape"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-backslash-escape"
 version = "0.0.1"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-mypy-exclude"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-mypy-exclude"
 version = "0.0.1"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-mypy-exclude"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-mypy-exclude"
 version = "0.0.1"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-positional-single-property"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-positional-single-property"
 version = "0.0.1"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-positional-single-property"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-positional-single-property"
 version = "0.0.1"

--- a/seed/python-sdk/python-reserved-keyword-subpackages/pyproject.toml
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-reserved-keyword-subpackages"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-reserved-keyword-subpackages"
 version = "0.0.1"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_python-streaming-parameter-openapi"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_python-streaming-parameter-openapi"
 version = "0.0.1"

--- a/seed/python-sdk/query-param-name-conflict/pyproject.toml
+++ b/seed/python-sdk/query-param-name-conflict/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_query-param-name-conflict"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_query-param-name-conflict"
 version = "0.0.1"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_query-parameters-openapi-as-objects"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_query-parameters-openapi-as-objects"
 version = "0.0.1"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_query-parameters-openapi"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_query-parameters-openapi"
 version = "0.0.1"

--- a/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_query-parameters"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_query-parameters"
 version = "0.0.1"

--- a/seed/python-sdk/request-parameters/pyproject.toml
+++ b/seed/python-sdk/request-parameters/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_request-parameters"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_request-parameters"
 version = "0.0.1"

--- a/seed/python-sdk/required-nullable/pyproject.toml
+++ b/seed/python-sdk/required-nullable/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_required-nullable"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_required-nullable"
 version = "0.0.1"

--- a/seed/python-sdk/reserved-keywords/pyproject.toml
+++ b/seed/python-sdk/reserved-keywords/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_reserved-keywords"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_reserved-keywords"
 version = "0.0.1"

--- a/seed/python-sdk/response-property/pyproject.toml
+++ b/seed/python-sdk/response-property/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_response-property"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_response-property"
 version = "0.0.1"

--- a/seed/python-sdk/schemaless-request-body-examples/pyproject.toml
+++ b/seed/python-sdk/schemaless-request-body-examples/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_schemaless-request-body-examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_schemaless-request-body-examples"
 version = "0.0.1"

--- a/seed/python-sdk/server-sent-event-examples/pyproject.toml
+++ b/seed/python-sdk/server-sent-event-examples/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_server-sent-event-examples"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_server-sent-event-examples"
 version = "0.0.1"

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_server-sent-events-openapi"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_server-sent-events-openapi"
 version = "0.0.1"

--- a/seed/python-sdk/server-sent-events-resumable/pyproject.toml
+++ b/seed/python-sdk/server-sent-events-resumable/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_server-sent-events-resumable"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_server-sent-events-resumable"
 version = "0.0.1"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_server-sent-events"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_server-sent-events"
 version = "0.0.1"

--- a/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_server-url-templating"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_server-url-templating"
 version = "0.0.1"

--- a/seed/python-sdk/simple-api/pyproject.toml
+++ b/seed/python-sdk/simple-api/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_simple-api"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_simple-api"
 version = "0.0.1"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_simple-fhir"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_simple-fhir"
 version = "0.0.1"

--- a/seed/python-sdk/single-url-environment-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_single-url-environment-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_single-url-environment-default"
 version = "0.0.1"

--- a/seed/python-sdk/single-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-no-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_single-url-environment-no-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_single-url-environment-no-default"
 version = "0.0.1"

--- a/seed/python-sdk/streaming-parameter/pyproject.toml
+++ b/seed/python-sdk/streaming-parameter/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_streaming-parameter"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_streaming-parameter"
 version = "0.0.1"

--- a/seed/python-sdk/streaming/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/streaming/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_streaming"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_streaming"
 version = "0.0.1"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_streaming"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_streaming"
 version = "0.0.1"

--- a/seed/python-sdk/trace/pyproject.toml
+++ b/seed/python-sdk/trace/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_trace"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_trace"
 version = "0.0.1"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_undiscriminated-union-with-response-property"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_undiscriminated-union-with-response-property"
 version = "0.0.1"

--- a/seed/python-sdk/undiscriminated-unions/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-unions/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_undiscriminated-unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_undiscriminated-unions"
 version = "0.0.1"

--- a/seed/python-sdk/union-query-parameters/pyproject.toml
+++ b/seed/python-sdk/union-query-parameters/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_union-query-parameters"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_union-query-parameters"
 version = "0.0.1"

--- a/seed/python-sdk/unions-with-local-date/pyproject.toml
+++ b/seed/python-sdk/unions-with-local-date/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unions-with-local-date"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unions-with-local-date"
 version = "0.0.1"

--- a/seed/python-sdk/unions/flatten-union-request-bodies/pyproject.toml
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unions"
 version = "0.0.1"

--- a/seed/python-sdk/unions/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/unions/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unions"
 version = "0.0.1"

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unions"
 version = "0.0.1"

--- a/seed/python-sdk/unions/union-naming-v1/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unions"
 version = "0.0.1"

--- a/seed/python-sdk/unions/union-utils/pyproject.toml
+++ b/seed/python-sdk/unions/union-utils/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unions"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unions"
 version = "0.0.1"

--- a/seed/python-sdk/unknown/pyproject.toml
+++ b/seed/python-sdk/unknown/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_unknown"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_unknown"
 version = "0.0.1"

--- a/seed/python-sdk/url-form-encoded/pyproject.toml
+++ b/seed/python-sdk/url-form-encoded/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_url-form-encoded"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_url-form-encoded"
 version = "0.0.1"

--- a/seed/python-sdk/validation/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/validation/no-custom-config/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_validation"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_validation"
 version = "0.0.1"

--- a/seed/python-sdk/validation/with-defaults-parameters/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults-parameters/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_validation"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_validation"
 version = "0.0.1"

--- a/seed/python-sdk/validation/with-defaults/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_validation"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_validation"
 version = "0.0.1"

--- a/seed/python-sdk/variables/pyproject.toml
+++ b/seed/python-sdk/variables/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_variables"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_variables"
 version = "0.0.1"

--- a/seed/python-sdk/version-no-default/pyproject.toml
+++ b/seed/python-sdk/version-no-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_version-no-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_version-no-default"
 version = "0.0.1"

--- a/seed/python-sdk/version/pyproject.toml
+++ b/seed/python-sdk/version/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_version"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_version"
 version = "0.0.1"

--- a/seed/python-sdk/webhook-audience/pyproject.toml
+++ b/seed/python-sdk/webhook-audience/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_webhook-audience"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_webhook-audience"
 version = "0.0.1"

--- a/seed/python-sdk/webhooks/pyproject.toml
+++ b/seed/python-sdk/webhooks/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_webhooks"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_webhooks"
 version = "0.0.1"

--- a/seed/python-sdk/websocket-bearer-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-bearer-auth/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_websocket-bearer-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_websocket-bearer-auth"
 version = "0.0.1"

--- a/seed/python-sdk/websocket-inferred-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-inferred-auth/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_websocket-inferred-auth"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_websocket-inferred-auth"
 version = "0.0.1"

--- a/seed/python-sdk/websocket-multi-url/pyproject.toml
+++ b/seed/python-sdk/websocket-multi-url/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_websocket-multi-url"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_websocket-multi-url"
 version = "0.0.1"

--- a/seed/python-sdk/websocket/websocket-base/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-base/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_websocket"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_websocket"
 version = "0.0.1"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_websocket"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_websocket"
 version = "0.0.1"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_websocket"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_websocket"
 version = "0.0.1"

--- a/seed/python-sdk/x-fern-default/pyproject.toml
+++ b/seed/python-sdk/x-fern-default/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "fern_x-fern-default"
-dynamic = ["version"]
-
 [tool.poetry]
 name = "fern_x-fern-default"
 version = "0.0.1"


### PR DESCRIPTION
## Description
Closes #16555

The Python SDK generator emitted a partial PEP 621 `[project]` table alongside the real `[tool.poetry]` config. PEP 621-aware build frontends (`uv`, recent `pip`, `python -m build`) validate the `[project]` table and reject it when required fields are missing — breaking source/git installs of the generated SDK.

## Changes Made

- Removed the vestigial `[project]` + `dynamic = ["version"]` preamble from `PyProjectToml.write()`, so `poetry-core` fully owns all metadata via `[tool.poetry]`
- Removed the now-unused `self._name` field
- Updated all 189 seed `python-sdk` fixture `pyproject.toml` outputs

## Before/After

**Before** (broken with `uv build` on older versions without `dynamic`):
```toml
[project]
name = "my-sdk"

[tool.poetry]
name = "my-sdk"
version = "1.0.0"
...
```

**After** (works with all build tools):
```toml
[tool.poetry]
name = "my-sdk"
version = "1.0.0"
...
```

## Testing
- [x] Verified `uv build` fails without `[project]` + `dynamic` (reproduces the issue)
- [x] Verified `uv build` succeeds with the fix (no `[project]` table)
- [x] Verified `uv pip install .` succeeds with the fix
- [x] Existing `TestPoetryCoreValidation` unit test passes (already validates without `[project]`)
- [x] Lint (`pnpm run check`) passes

Link to Devin session: https://app.devin.ai/sessions/a6bb9e79d07641b889295441fc67d58f
Requested by: @cade-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->