### PR TITLE
fix(generator-cli): implement FernignoreStep to preserve .fernignore files during pipeline regeneration

### DIFF
--- a/packages/generator-cli/CLAUDE.md
+++ b/packages/generator-cli/CLAUDE.md
@@ -41,7 +41,7 @@ Thin, typed wrappers re-exported from `src/api.ts`. Modules: `generate-readme.ts
 
 Sequential step orchestration. `PostGenerationPipeline` instantiates enabled steps from `PipelineConfig` and runs them in order.
 
-**Step execution order**: ReplayStep → (FernignoreStep, Phase 2 placeholder) → VerificationStep (opt-in) → GithubStep
+**Step execution order**: GenerationCommitStep → AutoVersionStep → ReplayStep → FernignoreStep → VerificationStep (opt-in) → GithubStep
 
 ### Key Files
 
@@ -50,7 +50,7 @@ Pipeline core:
 - `src/pipeline/types.ts` — All pipeline interfaces
 - `src/pipeline/steps/ReplayStep.ts` — Thin wrapper around `replayRun()`
 - `src/pipeline/steps/GithubStep.ts` — Commit/push/PR/conflict visualization
-- `src/pipeline/steps/FernignoreStep.ts` — Phase 2 placeholder (not yet implemented)
+- `src/pipeline/steps/FernignoreStep.ts` — Restores `.fernignore`-protected files after replay commits (or before GithubStep in non-replay mode)
 - `src/pipeline/steps/VerificationStep.ts` — Opt-in step that runs `.fern/verify.sh` inside a `{generatorImage}-validator:{version}` container; failure aborts the pipeline before GithubStep
 - `src/pipeline/replay-summary.ts` — PR body formatting, conflict reason mapping
 

--- a/packages/generator-cli/changes/unreleased/implement-fernignore-step.yml
+++ b/packages/generator-cli/changes/unreleased/implement-fernignore-step.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Implement FernignoreStep in the post-generation pipeline to preserve
+    `.fernignore`-protected files during SDK regeneration. Previously, the
+    pipeline placeholder threw an error, causing files listed in `.fernignore`
+    to be overwritten with duplicate generated code. The step now restores
+    fernignored files to their pre-generation state after replay commits.
+  type: fix

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -4,6 +4,7 @@ import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./github/constants";
 import { consolePipelineLogger, type PipelineLogger } from "./PipelineLogger";
 import { AutoVersionStep } from "./steps/AutoVersionStep";
 import { BaseStep } from "./steps/BaseStep";
+import { FernignoreStep } from "./steps/FernignoreStep";
 import { GenerationCommitStep } from "./steps/GenerationCommitStep";
 import { GithubStep } from "./steps/GithubStep";
 import { ReplayStep } from "./steps/ReplayStep";
@@ -83,10 +84,13 @@ export class PostGenerationPipeline {
             );
         }
 
-        // Phase 2: FernignoreStep (not implemented yet)
-        // if (config.fernignore?.enabled) {
-        //   this.steps.push(new FernignoreStep(config.outputDir, this.logger));
-        // }
+        // FernignoreStep restores .fernignore-protected files after replay
+        // (or before GithubStep's commitAllChanges in non-replay mode).
+        // Always enabled when a GitHub step is present — the step no-ops
+        // when there is no .fernignore file or no matching files.
+        if (config.github?.enabled) {
+            this.steps.push(new FernignoreStep(config.outputDir, this.logger));
+        }
 
         // VerificationStep runs after replay and before GithubStep so a failing
         // verify aborts the pipeline before we open a PR. Wired only when the
@@ -152,6 +156,7 @@ export class PostGenerationPipeline {
                     pipelineContext.previousStepResults.autoVersion = stepResult as AutoVersionStepResult;
                 } else if (step.name === "fernignore") {
                     result.steps.fernignore = stepResult as FernignoreStepResult;
+                    pipelineContext.previousStepResults.fernignore = stepResult as FernignoreStepResult;
                 } else if (step.name === "verify") {
                     const verifyResult = stepResult as VerificationStepResult;
                     result.steps.verify = verifyResult;

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -86,10 +86,11 @@ export class PostGenerationPipeline {
 
         // FernignoreStep restores .fernignore-protected files after replay
         // (or before GithubStep's commitAllChanges in non-replay mode).
-        // Always enabled when a GitHub step is present — the step no-ops
-        // when there is no .fernignore file or no matching files.
-        if (config.github?.enabled) {
-            this.steps.push(new FernignoreStep(config.outputDir, this.logger));
+        // Enabled when a GitHub step is present and not explicitly disabled
+        // via config. The step no-ops when there is no .fernignore file or
+        // no matching files.
+        if (config.github?.enabled && config.fernignore?.enabled !== false) {
+            this.steps.push(new FernignoreStep(config.outputDir, this.logger, config.fernignore));
         }
 
         // VerificationStep runs after replay and before GithubStep so a failing

--- a/packages/generator-cli/src/pipeline/steps/FernignoreStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/FernignoreStep.ts
@@ -1,23 +1,155 @@
+import { expandFernignorePatterns } from "@fern-api/github";
+import { execFileSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
 import type { FernignoreStepResult, PipelineContext } from "../types";
 import { BaseStep } from "./BaseStep";
 
 /**
- * Step that preserves files listed in .fernignore during regeneration.
- * Phase 2: Not implemented yet - this is a placeholder.
+ * Preserves files listed in `.fernignore` during regeneration.
  *
- * Will implement the git rm/reset/restore logic to preserve .fernignore paths.
- * Logic will be extracted from:
- * packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+ * When replay is active, `GenerationCommitStep` commits `[fern-generated]`
+ * which includes ALL generator output — even files the user intended to manage
+ * themselves (listed in `.fernignore`). This step runs after `ReplayStep` and
+ * restores those protected files to their pre-generation state.
+ *
+ * Without replay, the generator's output sits uncommitted in the working tree.
+ * The step restores fernignored files from HEAD so that the subsequent
+ * `GithubStep.commitAllChanges()` does not include them.
+ *
+ * Restoration logic mirrors the git rm/reset/restore flow in
+ * `LocalTaskHandler.copyGeneratedFilesWithFernIgnoreInExistingRepo`, adapted
+ * for the post-commit pipeline context.
  */
 export class FernignoreStep extends BaseStep {
     readonly name = "fernignore";
 
-    async execute(_context: PipelineContext): Promise<FernignoreStepResult> {
-        // TODO: Phase 2 - Implement fernignore preservation
-        // - Read .fernignore file
-        // - Parse glob patterns
-        // - Execute git rm/reset/restore flow
-        // - Return paths that were preserved
-        throw new Error("FernignoreStep not implemented yet - Phase 2");
+    async execute(context: PipelineContext): Promise<FernignoreStepResult> {
+        const fernignorePath = join(this.outputDir, ".fernignore");
+        if (!existsSync(fernignorePath)) {
+            this.logger.debug("No .fernignore file found — skipping");
+            return { executed: true, success: true, pathsPreserved: [] };
+        }
+
+        const fernignoreContent = readFileSync(fernignorePath, "utf-8");
+        const patterns = fernignoreContent
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+        if (patterns.length === 0) {
+            this.logger.debug(".fernignore has no patterns — skipping");
+            return { executed: true, success: true, pathsPreserved: [] };
+        }
+
+        // With replay: the [fern-generated] commit overwrote fernignored files.
+        // Restore from its parent (the pre-generation working tree).
+        // Without replay: generator output is uncommitted. Restore from HEAD.
+        const generationCommitSha = context.previousStepResults.generationCommit?.currentGenerationSha;
+        let restoreSource: string;
+        if (generationCommitSha != null) {
+            const parentSha = this.git(["rev-parse", `${generationCommitSha}^`]);
+            if (parentSha == null) {
+                this.logger.warn("Could not determine pre-generation commit — skipping fernignore preservation");
+                return { executed: true, success: true, pathsPreserved: [] };
+            }
+            restoreSource = parentSha;
+        } else {
+            restoreSource = "HEAD";
+        }
+
+        // List all tracked files at HEAD to match against fernignore patterns.
+        const trackedOutput = this.git(["ls-tree", "-r", "HEAD", "--name-only"]);
+        const trackedFiles = trackedOutput != null ? trackedOutput.split("\n").filter(Boolean) : [];
+
+        const matchingFiles = expandFernignorePatterns(fernignoreContent, trackedFiles);
+        if (matchingFiles.length === 0) {
+            this.logger.debug("No tracked files match .fernignore patterns — skipping");
+            return { executed: true, success: true, pathsPreserved: [] };
+        }
+
+        this.logger.debug(`Found ${matchingFiles.length} file(s) matching .fernignore patterns`);
+
+        // Separate files into those that existed pre-generation (restore) vs
+        // newly generated files that landed in a fernignored path (remove).
+        const filesToRestore: string[] = [];
+        const filesToRemove: string[] = [];
+        for (const file of matchingFiles) {
+            if (this.gitSucceeds(["cat-file", "-e", `${restoreSource}:${file}`])) {
+                filesToRestore.push(file);
+            } else {
+                filesToRemove.push(file);
+            }
+        }
+
+        const preservedPaths: string[] = [];
+
+        if (filesToRestore.length > 0) {
+            if (this.git(["checkout", restoreSource, "--", ...filesToRestore]) != null) {
+                preservedPaths.push(...filesToRestore);
+            } else {
+                // Batch failed — try one by one
+                for (const file of filesToRestore) {
+                    if (this.git(["checkout", restoreSource, "--", file]) != null) {
+                        preservedPaths.push(file);
+                    } else {
+                        this.logger.warn(`Failed to restore fernignored file: ${file}`);
+                    }
+                }
+            }
+        }
+
+        for (const file of filesToRemove) {
+            if (this.git(["rm", "-f", "--", file]) != null) {
+                preservedPaths.push(file);
+            }
+        }
+
+        if (preservedPaths.length === 0) {
+            this.logger.debug("No fernignored files needed restoration");
+            return { executed: true, success: true, pathsPreserved: [] };
+        }
+
+        this.logger.info(
+            `Preserved ${preservedPaths.length} .fernignore-protected file(s): ${preservedPaths.join(", ")}`
+        );
+
+        // When replay committed (generation commit exists), GithubStep won't call
+        // commitAllChanges — commit the restoration so it lands on the branch.
+        if (generationCommitSha != null && this.hasStagedChanges()) {
+            this.git(["commit", "--no-verify", "-m", "[fern-fernignore] Preserve .fernignore-protected files"]);
+        }
+
+        return { executed: true, success: true, pathsPreserved: preservedPaths };
+    }
+
+    private hasStagedChanges(): boolean {
+        return !this.gitSucceeds(["diff", "--cached", "--quiet"]);
+    }
+
+    private gitSucceeds(args: string[]): boolean {
+        try {
+            execFileSync("git", args, {
+                cwd: this.outputDir,
+                encoding: "utf-8",
+                stdio: "pipe"
+            });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private git(args: string[]): string | null {
+        try {
+            return execFileSync("git", args, {
+                cwd: this.outputDir,
+                encoding: "utf-8",
+                stdio: "pipe"
+            }).trim();
+        } catch {
+            return null;
+        }
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/FernignoreStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/FernignoreStep.ts
@@ -3,7 +3,8 @@ import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
-import type { FernignoreStepResult, PipelineContext } from "../types";
+import type { PipelineLogger } from "../PipelineLogger";
+import type { FernignoreStepConfig, FernignoreStepResult, PipelineContext } from "../types";
 import { BaseStep } from "./BaseStep";
 
 /**
@@ -25,14 +26,25 @@ import { BaseStep } from "./BaseStep";
 export class FernignoreStep extends BaseStep {
     readonly name = "fernignore";
 
+    constructor(
+        outputDir: string,
+        logger: PipelineLogger,
+        private readonly config?: FernignoreStepConfig
+    ) {
+        super(outputDir, logger);
+    }
+
     async execute(context: PipelineContext): Promise<FernignoreStepResult> {
-        const fernignorePath = join(this.outputDir, ".fernignore");
-        if (!existsSync(fernignorePath)) {
-            this.logger.debug("No .fernignore file found — skipping");
+        if (this.config?.enabled === false) {
+            this.logger.debug("FernignoreStep disabled via config — skipping");
             return { executed: true, success: true, pathsPreserved: [] };
         }
 
-        const fernignoreContent = readFileSync(fernignorePath, "utf-8");
+        const fernignoreContent = this.resolveFernignoreContent();
+        if (fernignoreContent == null) {
+            return { executed: true, success: true, pathsPreserved: [] };
+        }
+
         const patterns = fernignoreContent
             .split("\n")
             .map((line) => line.trim())
@@ -59,13 +71,20 @@ export class FernignoreStep extends BaseStep {
             restoreSource = "HEAD";
         }
 
-        // List all tracked files at HEAD to match against fernignore patterns.
+        // List tracked files at both HEAD (current state) and restoreSource
+        // (pre-generation state). The union ensures we catch fernignored files
+        // that the generator deleted (absent from HEAD) as well as files it
+        // overwrote (present at HEAD).
         const trackedOutput = this.git(["ls-tree", "-r", "HEAD", "--name-only"]);
         const trackedFiles = trackedOutput != null ? trackedOutput.split("\n").filter(Boolean) : [];
+        const restoreSourceOutput =
+            restoreSource !== "HEAD" ? this.git(["ls-tree", "-r", restoreSource, "--name-only"]) : null;
+        const restoreSourceFiles = restoreSourceOutput != null ? restoreSourceOutput.split("\n").filter(Boolean) : [];
+        const allCandidateFiles = [...new Set([...trackedFiles, ...restoreSourceFiles])];
 
-        const matchingFiles = expandFernignorePatterns(fernignoreContent, trackedFiles);
+        const matchingFiles = expandFernignorePatterns(fernignoreContent, allCandidateFiles);
         if (matchingFiles.length === 0) {
-            this.logger.debug("No tracked files match .fernignore patterns — skipping");
+            this.logger.debug("No files match .fernignore patterns — skipping");
             return { executed: true, success: true, pathsPreserved: [] };
         }
 
@@ -122,6 +141,18 @@ export class FernignoreStep extends BaseStep {
         }
 
         return { executed: true, success: true, pathsPreserved: preservedPaths };
+    }
+
+    private resolveFernignoreContent(): string | null {
+        if (this.config?.customContents != null) {
+            return this.config.customContents;
+        }
+        const fernignorePath = join(this.outputDir, ".fernignore");
+        if (!existsSync(fernignorePath)) {
+            this.logger.debug("No .fernignore file found — skipping");
+            return null;
+        }
+        return readFileSync(fernignorePath, "utf-8");
     }
 
     private hasStagedChanges(): boolean {

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -4,7 +4,7 @@ export interface PipelineConfig {
     // Step configs (optional, modular)
     replay?: ReplayStepConfig;
     autoVersion?: AutoVersionStepConfig;
-    fernignore?: FernignoreStepConfig; // PHASE 2: not implemented yet
+    fernignore?: FernignoreStepConfig;
     verify?: VerifyStepConfig;
     github?: GithubStepConfig;
 


### PR DESCRIPTION
## Description

Implements the previously-placeholder `FernignoreStep` in the post-generation pipeline, fixing a bug where `.fernignore`-protected files get overwritten with duplicate generated code during SDK regeneration.

**Root cause**: When replay is active, `GenerationCommitStep` commits `[fern-generated]` which includes ALL generator output — including files the user manages themselves (listed in `.fernignore`). The `FernignoreStep` was a Phase 2 placeholder that threw `"FernignoreStep not implemented yet"`, so fernignored files were never restored.

## Changes Made

- **`FernignoreStep.ts`**: Full implementation replacing the placeholder:
  - Reads `.fernignore` patterns from the output directory
  - Uses `expandFernignorePatterns` from `@fern-api/github` for glob matching (same logic as `GitHub.ts` and `ClonedRepository`)
  - With replay: restores protected files from `currentGenerationSha^` (pre-generation state)
  - Without replay: restores from `HEAD` so `GithubStep.commitAllChanges()` excludes them
  - Handles both file restoration (existed pre-generation) and removal (newly generated in a fernignored path)
  - Batch restore with per-file fallback for resilience
  - Commits `[fern-fernignore]` when replay has already committed
  - No-ops gracefully when no `.fernignore` exists or no files match

- **`PostGenerationPipeline.ts`**: Wires `FernignoreStep` into the pipeline after `ReplayStep` and before `VerificationStep`. Always enabled when a GitHub step is present (the step self-guards via early returns). Also stores the result in `pipelineContext.previousStepResults`.

- **`types.ts`**: Removed stale "PHASE 2: not implemented yet" comment.

- **`CLAUDE.md`**: Updated step execution order and step description.

## Testing

- [x] `pnpm turbo run compile --filter @fern-api/generator-cli` — passes
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 42 test files passed (416 tests)
- [x] `pnpm biome check` — passes on modified files


Link to Devin session: https://app.devin.ai/sessions/cb8629d93dc54e6e992e163aaa6a0bcf
Requested by: @dvdaruri-art
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->