### PR TITLE
fix(go): avoid double pointer for nullable $ref aliases used as optional properties

### DIFF
--- a/generators/go/internal/generator/model.go
+++ b/generators/go/internal/generator/model.go
@@ -1791,6 +1791,18 @@ func (c *containerTypeVisitor) VisitOptional(optionalOrNullable *ir.TypeReferenc
 		return nil
 	}
 
+	// A named alias whose underlying type is nullable is already rendered as a
+	// pointer in its alias definition (e.g. `type Foo = *string` or
+	// `type Foo = *time.Time`). Wrapping it in any number of optional/nullable
+	// layers must not add a second pointer, otherwise we emit an invalid double
+	// pointer (e.g. **string) that doesn't match the single pointer produced
+	// elsewhere (setters, snippets, and the date marshal/unmarshal helpers). This
+	// also covers nested shapes like optional<nullable<named>>.
+	if resolvesToPointerNamedAlias(optionalOrNullable, c.types, c.scope, c.baseImportPath, c.importPath) {
+		c.value = value
+		return nil
+	}
+
 	// Collapse optional<nullable<...>> or nullable<optional<...>> into a single optional<...>.
 	// We can assume there aren't arbitrary depth nestings. The node being visited is optional or nullable, so we
 	// only need to check if its container is optional or nullable.
@@ -2519,6 +2531,59 @@ func maybeDate(valueType *ir.TypeReference, isOptional bool, types map[common.Ty
 		return maybeDate(optionalOrNullableContainer, true, types)
 	}
 	return nil
+}
+
+// isPointerNamedAlias reports whether the given type reference is a named alias
+// whose Go representation is already a pointer (e.g. `type Foo = *string` or
+// `type Foo = *time.Time`). These arise from nullable component schemas referenced
+// via `$ref`. Because the pointer is baked into the alias definition, callers that
+// wrap such an alias in an optional must not add a second pointer, which would
+// otherwise produce an invalid double pointer (e.g. **string) that doesn't match
+// the single pointer produced elsewhere (setters, snippets, and the date
+// marshal/unmarshal helpers). Alias chains are resolved recursively.
+//
+// Note: this intentionally only covers pointer-bodied aliases. Aliases to nil-able
+// containers (slices/maps) have a separate, pre-existing v1<->v2 disagreement about
+// whether the optional should add a pointer, and are left untouched here.
+func isPointerNamedAlias(
+	typeReference *ir.TypeReference,
+	types map[common.TypeId]*ir.TypeDeclaration,
+	scope *gospec.Scope,
+	baseImportPath string,
+	importPath string,
+) bool {
+	if typeReference == nil || typeReference.Named == nil {
+		return false
+	}
+	typeDeclaration := types[typeReference.Named.TypeId]
+	if typeDeclaration == nil || typeDeclaration.Shape.Alias == nil {
+		return false
+	}
+	aliasOf := typeDeclaration.Shape.Alias.AliasOf
+	if isPointerNamedAlias(aliasOf, types, scope, baseImportPath, importPath) {
+		return true
+	}
+	return strings.HasPrefix(typeReferenceToGoType(aliasOf, types, scope, baseImportPath, importPath, false), "*")
+}
+
+// resolvesToPointerNamedAlias reports whether the given type reference is a
+// pointer-bodied named alias (see isPointerNamedAlias), drilling through any
+// optional/nullable wrapper layers. This handles nested shapes such as
+// optional<nullable<named>> where the named alias is the innermost type.
+func resolvesToPointerNamedAlias(
+	typeReference *ir.TypeReference,
+	types map[common.TypeId]*ir.TypeDeclaration,
+	scope *gospec.Scope,
+	baseImportPath string,
+	importPath string,
+) bool {
+	if isPointerNamedAlias(typeReference, types, scope, baseImportPath, importPath) {
+		return true
+	}
+	if inner := getOptionalOrNullableContainer(typeReference); inner != nil {
+		return resolvesToPointerNamedAlias(inner, types, scope, baseImportPath, importPath)
+	}
+	return false
 }
 
 // maybeFormatStructTag returns the layout struct tag for [optional] date types.

--- a/generators/go/sdk/changes/unreleased/fix-nullable-alias-double-pointer.yml
+++ b/generators/go/sdk/changes/unreleased/fix-nullable-alias-double-pointer.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix generated Go SDKs failing to compile when a nullable type defined via a
+    shared component schema (`$ref`) is used as an optional property. Such a schema
+    is rendered as a pointer alias (e.g. `type Foo = *string` or `type Foo =
+    *time.Time`), and the optional wrapper was adding a second pointer, producing an
+    invalid double pointer (e.g. `**string`) that did not match the single-pointer
+    setters, getters, and date marshal/unmarshal helpers. The optional wrapper now
+    leaves the pointer baked into the alias intact, including for nested shapes like
+    `optional<nullable<named>>`.
+  type: fix

--- a/seed/go-sdk/exhaustive/no-custom-config/types/object.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/types/object.go
@@ -19,7 +19,7 @@ var (
 )
 
 type DoubleOptional struct {
-	OptionalAlias *OptionalAlias `json:"optionalAlias,omitempty" url:"optionalAlias,omitempty"`
+	OptionalAlias OptionalAlias `json:"optionalAlias,omitempty" url:"optionalAlias,omitempty"`
 
 	// Private bitmask of fields set to an explicit value and therefore not to be omitted
 	explicitFields *big.Int `json:"-" url:"-"`
@@ -28,7 +28,7 @@ type DoubleOptional struct {
 	rawJSON         json.RawMessage
 }
 
-func (d *DoubleOptional) GetOptionalAlias() *OptionalAlias {
+func (d *DoubleOptional) GetOptionalAlias() OptionalAlias {
 	if d == nil {
 		return nil
 	}
@@ -51,7 +51,7 @@ func (d *DoubleOptional) require(field *big.Int) {
 
 // SetOptionalAlias sets the OptionalAlias field and marks it as non-optional;
 // this prevents an empty or null value for this field from being omitted during serialization.
-func (d *DoubleOptional) SetOptionalAlias(optionalAlias *OptionalAlias) {
+func (d *DoubleOptional) SetOptionalAlias(optionalAlias OptionalAlias) {
 	d.OptionalAlias = optionalAlias
 	d.require(doubleOptionalFieldOptionalAlias)
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/types/object_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/types/object_test.go
@@ -14,7 +14,7 @@ import (
 func TestSettersDoubleOptional(t *testing.T) {
 	t.Run("SetOptionalAlias", func(t *testing.T) {
 		obj := &DoubleOptional{}
-		var fernTestValueOptionalAlias *OptionalAlias
+		var fernTestValueOptionalAlias OptionalAlias
 		obj.SetOptionalAlias(fernTestValueOptionalAlias)
 		assert.Equal(t, fernTestValueOptionalAlias, obj.OptionalAlias)
 		assert.NotNil(t, obj.explicitFields)
@@ -27,21 +27,11 @@ func TestGettersDoubleOptional(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &DoubleOptional{}
-		var expected *OptionalAlias
+		var expected OptionalAlias
 		obj.OptionalAlias = expected
 
 		// Act & Assert
 		assert.Equal(t, expected, obj.GetOptionalAlias(), "getter should return the property value")
-	})
-
-	t.Run("GetOptionalAlias_NilValue", func(t *testing.T) {
-		t.Parallel()
-		// Arrange
-		obj := &DoubleOptional{}
-		obj.OptionalAlias = nil
-
-		// Act & Assert
-		assert.Nil(t, obj.GetOptionalAlias(), "getter should return nil when property is nil")
 	})
 
 	t.Run("GetOptionalAlias_NilReceiver", func(t *testing.T) {
@@ -63,7 +53,7 @@ func TestSettersMarkExplicitDoubleOptional(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &DoubleOptional{}
-		var fernTestValueOptionalAlias *OptionalAlias
+		var fernTestValueOptionalAlias OptionalAlias
 
 		// Act
 		obj.SetOptionalAlias(fernTestValueOptionalAlias)

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/types/object.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/types/object.go
@@ -19,7 +19,7 @@ var (
 )
 
 type DoubleOptional struct {
-	OptionalAlias *OptionalAlias `json:"optionalAlias,omitempty" url:"optionalAlias,omitempty"`
+	OptionalAlias OptionalAlias `json:"optionalAlias,omitempty" url:"optionalAlias,omitempty"`
 
 	// Private bitmask of fields set to an explicit value and therefore not to be omitted
 	explicitFields *big.Int `json:"-" url:"-"`
@@ -28,7 +28,7 @@ type DoubleOptional struct {
 	rawJSON         json.RawMessage
 }
 
-func (d *DoubleOptional) GetOptionalAlias() *OptionalAlias {
+func (d *DoubleOptional) GetOptionalAlias() OptionalAlias {
 	if d == nil {
 		return nil
 	}
@@ -51,7 +51,7 @@ func (d *DoubleOptional) require(field *big.Int) {
 
 // SetOptionalAlias sets the OptionalAlias field and marks it as non-optional;
 // this prevents an empty or null value for this field from being omitted during serialization.
-func (d *DoubleOptional) SetOptionalAlias(optionalAlias *OptionalAlias) {
+func (d *DoubleOptional) SetOptionalAlias(optionalAlias OptionalAlias) {
 	d.OptionalAlias = optionalAlias
 	d.require(doubleOptionalFieldOptionalAlias)
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/types/object_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/types/object_test.go
@@ -14,7 +14,7 @@ import (
 func TestSettersDoubleOptional(t *testing.T) {
 	t.Run("SetOptionalAlias", func(t *testing.T) {
 		obj := &DoubleOptional{}
-		var fernTestValueOptionalAlias *OptionalAlias
+		var fernTestValueOptionalAlias OptionalAlias
 		obj.SetOptionalAlias(fernTestValueOptionalAlias)
 		assert.Equal(t, fernTestValueOptionalAlias, obj.OptionalAlias)
 		assert.NotNil(t, obj.explicitFields)
@@ -27,21 +27,11 @@ func TestGettersDoubleOptional(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &DoubleOptional{}
-		var expected *OptionalAlias
+		var expected OptionalAlias
 		obj.OptionalAlias = expected
 
 		// Act & Assert
 		assert.Equal(t, expected, obj.GetOptionalAlias(), "getter should return the property value")
-	})
-
-	t.Run("GetOptionalAlias_NilValue", func(t *testing.T) {
-		t.Parallel()
-		// Arrange
-		obj := &DoubleOptional{}
-		obj.OptionalAlias = nil
-
-		// Act & Assert
-		assert.Nil(t, obj.GetOptionalAlias(), "getter should return nil when property is nil")
 	})
 
 	t.Run("GetOptionalAlias_NilReceiver", func(t *testing.T) {
@@ -63,7 +53,7 @@ func TestSettersMarkExplicitDoubleOptional(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &DoubleOptional{}
-		var fernTestValueOptionalAlias *OptionalAlias
+		var fernTestValueOptionalAlias OptionalAlias
 
 		// Act
 		obj.SetOptionalAlias(fernTestValueOptionalAlias)


### PR DESCRIPTION
Closes FER-11384

## Summary

- A customer (Plaid) reported that the generated Go SDK fails to compile when a **nullable type defined via a shared component schema** is referenced with `$ref` and used as an optional property.
- Such a schema becomes a **pointer alias** (`type Iso8601DateNullable = *time.Time`). The optional/nullable wrapper then added a **second** pointer, producing `**time.Time`, which doesn't match the single-pointer marshal/unmarshal, setter, and getter code. Inline definitions worked because they only carry one nullability layer; the `$ref` indirection adds a second.
- The fix (in `VisitOptional`, `generators/go/internal/generator/model.go`) skips the extra pointer when the optional wraps a named alias whose Go body is already a pointer — including nested `optional<nullable<named>>` shapes. Because all field-type rendering (struct field, setter, getter, snippets) flows through this one path, they stay consistent.

## Example

Input (OpenAPI):
```yaml
Report:
  properties:
    fraud_date:
      $ref: "#/components/schemas/ISO8601DateNullable"
ISO8601DateNullable:
  type: [string, "null"]
  format: date
```

Before — does not compile (`cannot use ... (*time.Time) as *Iso8601DateNullable`):
```go
type Iso8601DateNullable = *time.Time
FraudDate *Iso8601DateNullable   // **time.Time
```

After:
```go
type Iso8601DateNullable = *time.Time
FraudDate Iso8601DateNullable    // *time.Time
```

The same fix covers nullable string aliases (`type AccessTokenNullable = *string`, previously `**string`). The only existing-fixture change is `exhaustive`'s aptly named `DoubleOptional.OptionalAlias` going from `**string` to `*string`.

## Scope

Pointer-bodied aliases only. Nullable **container** aliases (map/slice) have a separate, pre-existing v1↔v2 snippet-generator disagreement and are intentionally left untouched here.

## Test plan

- [x] `go build ./...` + `go test ./internal/generator/...` in `generators/go`
- [x] Regenerated the customer's SDK via `seed run` — core SDK compiles
- [x] Regenerated alias/nullable seed fixtures — only `exhaustive` changes; fixture builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)