### PR TITLE
fix(cli): resolve $ref parameters in reference.md generation

### DIFF
--- a/generators/cli/changes/unreleased/fix-ref-params-reference.yml
+++ b/generators/cli/changes/unreleased/fix-ref-params-reference.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix crash in reference.md generation when OpenAPI specs contain `$ref`
+    parameter references (e.g. `$ref: "#/components/parameters/LimitParam"`).
+    The generator now resolves these references from `components.parameters`
+    instead of crashing with "Cannot read properties of undefined".
+  type: fix

--- a/generators/cli/src/__test__/emitReference.test.ts
+++ b/generators/cli/src/__test__/emitReference.test.ts
@@ -322,6 +322,68 @@ describe("emitReference", () => {
         expect(reference).toContain("`my-api store items`");
     });
 
+    // ── $ref parameter resolution ───────────────────────────────────
+
+    it("resolves $ref parameters from components.parameters", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "Close API", version: "1.0.0" },
+            paths: {
+                "/activity/": {
+                    get: {
+                        operationId: "activity_list",
+                        tags: ["Activity"],
+                        summary: "List activities",
+                        parameters: [
+                            { $ref: "#/components/parameters/LimitParam" },
+                            { $ref: "#/components/parameters/SkipParam" },
+                            { $ref: "#/components/parameters/FieldsParam" }
+                        ],
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            },
+            components: {
+                parameters: {
+                    LimitParam: {
+                        in: "query",
+                        name: "_limit",
+                        required: false,
+                        schema: { type: "integer", default: 100 }
+                    },
+                    SkipParam: {
+                        in: "query",
+                        name: "_skip",
+                        required: false,
+                        schema: { type: "integer", default: 0 }
+                    },
+                    FieldsParam: {
+                        description: "Comma-separated list of fields to include in the response.",
+                        in: "query",
+                        name: "_fields",
+                        required: false,
+                        schema: { type: "string" }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "close",
+            apiDisplayName: "Close API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`--limit`");
+        expect(reference).toContain("`--skip`");
+        expect(reference).toContain("`--fields`");
+        expect(reference).toContain("Comma-separated list of fields");
+    });
+
     // ── Fallback to binaryName when no apiDisplayName ────────────────
 
     it("falls back to binaryName in header when apiDisplayName is undefined", async () => {

--- a/generators/cli/src/__test__/emitReference.test.ts
+++ b/generators/cli/src/__test__/emitReference.test.ts
@@ -384,6 +384,125 @@ describe("emitReference", () => {
         expect(reference).toContain("Comma-separated list of fields");
     });
 
+    it("resolves path-level $ref parameters", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/items/{itemId}": {
+                    parameters: [{ $ref: "#/components/parameters/ItemIdParam" }],
+                    get: {
+                        operationId: "items_get",
+                        tags: ["Items"],
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            },
+            components: {
+                parameters: {
+                    ItemIdParam: {
+                        in: "path",
+                        name: "itemId",
+                        required: true,
+                        schema: { type: "string" }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`--item-id`");
+    });
+
+    it("skips unresolvable $ref parameters gracefully", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/things": {
+                    get: {
+                        operationId: "things_list",
+                        tags: ["Things"],
+                        parameters: [
+                            { $ref: "#/components/parameters/DoesNotExist" },
+                            { name: "status", in: "query", schema: { type: "string" } }
+                        ],
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            },
+            components: { parameters: {} }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        // The inline param should still appear; the bad $ref is silently dropped.
+        expect(reference).toContain("`--status`");
+        expect(reference).not.toContain("DoesNotExist");
+    });
+
+    it("handles mixed inline and $ref parameters in the same operation", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/search": {
+                    get: {
+                        operationId: "search",
+                        tags: ["Search"],
+                        parameters: [
+                            { name: "q", in: "query", required: true, schema: { type: "string" } },
+                            { $ref: "#/components/parameters/LimitParam" },
+                            { name: "sort", in: "query", schema: { type: "string" } }
+                        ],
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            },
+            components: {
+                parameters: {
+                    LimitParam: {
+                        in: "query",
+                        name: "_limit",
+                        required: false,
+                        schema: { type: "integer" }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`--q`");
+        expect(reference).toContain("`--limit`");
+        expect(reference).toContain("`--sort`");
+    });
+
     // ── Fallback to binaryName when no apiDisplayName ────────────────
 
     it("falls back to binaryName in header when apiDisplayName is undefined", async () => {

--- a/generators/cli/src/emitReference.ts
+++ b/generators/cli/src/emitReference.ts
@@ -56,7 +56,7 @@ export async function emitReference(args: {
 interface OpenApiDocument {
     info?: { title?: string; version?: string };
     paths?: Record<string, Record<string, OpenApiOperation>>;
-    components?: { schemas?: Record<string, unknown> };
+    components?: { schemas?: Record<string, unknown>; parameters?: Record<string, OpenApiParameter> };
 }
 
 interface OpenApiOperation {
@@ -64,7 +64,7 @@ interface OpenApiOperation {
     summary?: string;
     description?: string;
     tags?: string[];
-    parameters?: OpenApiParameter[];
+    parameters?: (OpenApiParameter | { $ref: string })[];
     requestBody?: OpenApiRequestBody;
     "x-fern-sdk-group-name"?: string | string[];
     "x-fern-sdk-method-name"?: string;
@@ -136,11 +136,15 @@ function collectResources(
     namespace: string | undefined
 ): void {
     const paths = doc.paths ?? {};
+    const componentParams = doc.components?.parameters ?? {};
 
     for (const [pathStr, pathItem] of Object.entries(paths)) {
         // Collect path-level parameters (inherited by all operations)
-        const pathParams: OpenApiParameter[] =
-            ((pathItem as Record<string, unknown>).parameters as OpenApiParameter[] | undefined) ?? [];
+        const pathParams: OpenApiParameter[] = resolveParamRefs(
+            ((pathItem as Record<string, unknown>).parameters as (OpenApiParameter | { $ref: string })[] | undefined) ??
+                [],
+            componentParams
+        );
 
         for (const method of HTTP_METHODS) {
             const operation = pathItem[method] as OpenApiOperation | undefined;
@@ -156,7 +160,7 @@ function collectResources(
             const availability = resolveAvailability(operation);
 
             // Merge path-level + operation-level params (operation wins on conflict).
-            const params = mergeParameters(pathParams, operation.parameters ?? []);
+            const params = mergeParameters(pathParams, resolveParamRefs(operation.parameters ?? [], componentParams));
             const paramEntries = params
                 .filter((p) => p["x-fern-ignore"] !== true && p.in !== "cookie")
                 .map((p) => ({
@@ -288,6 +292,32 @@ function resolveAvailability(op: OpenApiOperation): string | undefined {
         return "deprecated";
     }
     return undefined;
+}
+
+/**
+ * Resolve `$ref` entries in a parameters array by looking them up in
+ * `components.parameters`. Entries that are already inline or whose
+ * `$ref` target cannot be found are passed through / skipped.
+ */
+function resolveParamRefs(
+    params: (OpenApiParameter | { $ref: string })[],
+    componentParams: Record<string, OpenApiParameter>
+): OpenApiParameter[] {
+    const resolved: OpenApiParameter[] = [];
+    for (const p of params) {
+        if ("$ref" in p && typeof (p as { $ref?: string }).$ref === "string") {
+            const refPath = (p as { $ref: string }).$ref;
+            // Expected format: "#/components/parameters/<name>"
+            const refName = refPath.split("/").pop();
+            if (refName != null && componentParams[refName] != null) {
+                resolved.push(componentParams[refName]);
+            }
+            // Skip unresolvable $ref entries rather than crashing.
+        } else if ((p as OpenApiParameter).name != null) {
+            resolved.push(p as OpenApiParameter);
+        }
+    }
+    return resolved;
 }
 
 function mergeParameters(pathLevel: OpenApiParameter[], opLevel: OpenApiParameter[]): OpenApiParameter[] {

--- a/generators/cli/src/emitReference.ts
+++ b/generators/cli/src/emitReference.ts
@@ -295,9 +295,17 @@ function resolveAvailability(op: OpenApiOperation): string | undefined {
 }
 
 /**
+ * Type guard: returns true when `p` is a JSON `$ref` pointer rather than
+ * an inline parameter object.
+ */
+function isRefEntry(p: OpenApiParameter | { $ref: string }): p is { $ref: string } {
+    return "$ref" in p && typeof (p as Record<string, unknown>).$ref === "string";
+}
+
+/**
  * Resolve `$ref` entries in a parameters array by looking them up in
- * `components.parameters`. Entries that are already inline or whose
- * `$ref` target cannot be found are passed through / skipped.
+ * `components.parameters`. Entries that are already inline are passed
+ * through; `$ref` entries whose target cannot be found are skipped.
  */
 function resolveParamRefs(
     params: (OpenApiParameter | { $ref: string })[],
@@ -305,16 +313,15 @@ function resolveParamRefs(
 ): OpenApiParameter[] {
     const resolved: OpenApiParameter[] = [];
     for (const p of params) {
-        if ("$ref" in p && typeof (p as { $ref?: string }).$ref === "string") {
-            const refPath = (p as { $ref: string }).$ref;
+        if (isRefEntry(p)) {
             // Expected format: "#/components/parameters/<name>"
-            const refName = refPath.split("/").pop();
+            const refName = p.$ref.split("/").pop();
             if (refName != null && componentParams[refName] != null) {
                 resolved.push(componentParams[refName]);
             }
             // Skip unresolvable $ref entries rather than crashing.
-        } else if ((p as OpenApiParameter).name != null) {
-            resolved.push(p as OpenApiParameter);
+        } else if (p.name != null) {
+            resolved.push(p);
         }
     }
     return resolved;


### PR DESCRIPTION
## Description

Fix crash in CLI generator when OpenAPI specs use `$ref` parameter references (e.g. `"$ref": "#/components/parameters/LimitParam"`). The `emitReference.ts` module attempted to access `.name` on unresolved `$ref` objects, resulting in:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
 ❯ renderMethod src/emitReference.ts:435:41
 ❯ renderReference src/emitReference.ts:367:17
 ❯ emitReference src/emitReference.ts:48:21
```

Reported when generating the CLI from the Close API spec, which has 135 `$ref` parameter entries.

## Changes Made

- Added `isRefEntry()` type guard to properly narrow `$ref` entries vs inline `OpenApiParameter` objects — no `as` casts needed in the resolution logic
- Added `resolveParamRefs()` that looks up `$ref` entries in `components.parameters`, silently skipping unresolvable refs
- Updated `OpenApiDocument.components` type to include `parameters`
- Updated `OpenApiOperation.parameters` type to accept `$ref` objects alongside inline params
- Both path-level and operation-level parameters now go through `resolveParamRefs` before processing

## Testing

4 new tests covering `$ref` parameter resolution:
- [x] Resolves operation-level `$ref` parameters from `components.parameters`
- [x] Resolves path-level `$ref` parameters
- [x] Skips unresolvable `$ref` parameters gracefully (no crash, inline params still work)
- [x] Handles mixed inline + `$ref` parameters in the same operation
- [x] All 12 `emitReference` tests pass (8 original + 4 new)
- [x] All 143 CLI generator unit tests pass
- [x] Biome lint/format passes

Link to Devin session: https://app.devin.ai/sessions/63716d1a41284c98a360732b0bdec9a7
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->