### PR TITLE
fix(cli): show credential hints for custom auth providers in --help output

### DIFF
--- a/generators/cli/changes/unreleased/show-custom-auth-hints-in-help.yml
+++ b/generators/cli/changes/unreleased/show-custom-auth-hints-in-help.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Show credential hints (env vars, flags) for custom auth providers in
+    `--help` output instead of the opaque "custom auth provider" label.
+  type: fix

--- a/generators/cli/sdk/src/auth/builder.rs
+++ b/generators/cli/sdk/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(p) => {
+            let hints = p.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -896,6 +903,23 @@ mod tests {
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_hints() {
+        let provider: DynAuthProvider = Arc::new(HeaderAuthProvider::new(
+            "apiKey",
+            "X-Api-Key",
+            AuthCredentialSource::from_env("MY_API_KEY"),
+            false,
+        ));
+        let bindings = vec![(
+            "apiKey".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("MY_API_KEY environment variable"));
+        assert!(!out.contains("custom auth provider"));
     }
 
     #[tokio::test]

--- a/generators/cli/sdk/src/openapi/skill_emitter.rs
+++ b/generators/cli/sdk/src/openapi/skill_emitter.rs
@@ -238,7 +238,14 @@ fn describe_binding_source(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(p) => {
+            let hints = p.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" or ")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

When a CLI uses `SchemeBinding::Custom` (e.g. via `.auth_provider()`), the `--help` text previously showed the opaque label "custom auth provider" even when the underlying provider has `credential_hints()` (env var names, flags, etc.). This makes it impossible for users to know which env var to set.

## Changes Made

- `describe_binding_sources()` in `builder.rs` now calls `credential_hints()` on `Custom` providers and displays those hints instead of "custom auth provider" (falls back to the old label when hints are empty)
- Same fix in `skill_emitter.rs`'s `describe_binding_source()`
- Added test `render_auth_help_section_shows_custom_provider_hints` verifying a `HeaderAuthProvider` bound as `Custom` surfaces its env var name
- [x] Unit tests added/updated

## Testing

- All 1297 Rust SDK tests pass
- All 140 TypeScript generator tests pass
- Lint passes (`biome check`)

### Before

```
Authentication: custom auth provider
```

### After (when provider has hints)

```
Authentication: MY_API_KEY environment variable
```


Link to Devin session: https://app.devin.ai/sessions/f0b078168fad4766b469b978d5d80ad9
Requested by: @adidavid014
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->