### PR TITLE
fix(cli): show credential hints in --help for custom auth providers

### DIFF
--- a/generators/cli/changes/unreleased/fix-custom-auth-help-display.yml
+++ b/generators/cli/changes/unreleased/fix-custom-auth-help-display.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Show credential source hints (e.g. env var names) in `--help` for
+    custom auth providers instead of the opaque "custom auth provider" label.
+    Affects basic-auth-with-omit bindings where the env var was not visible.
+  type: fix

--- a/generators/cli/sdk/src/auth/builder.rs
+++ b/generators/cli/sdk/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/generators/cli/sdk/src/auth/builder.rs
+++ b/generators/cli/sdk/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/allof-inline/src/auth/builder.rs
+++ b/seed/cli/allof-inline/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/allof-inline/src/auth/builder.rs
+++ b/seed/cli/allof-inline/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/allof/src/auth/builder.rs
+++ b/seed/cli/allof/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/allof/src/auth/builder.rs
+++ b/seed/cli/allof/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/api-wide-base-path-with-default/src/auth/builder.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/api-wide-base-path-with-default/src/auth/builder.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/builder.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/builder.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/cli-multi-spec/no-custom-config/src/auth/builder.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/cli-multi-spec/no-custom-config/src/auth/builder.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/file-upload-openapi/src/auth/builder.rs
+++ b/seed/cli/file-upload-openapi/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/file-upload-openapi/src/auth/builder.rs
+++ b/seed/cli/file-upload-openapi/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/imdb/src/auth/builder.rs
+++ b/seed/cli/imdb/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/imdb/src/auth/builder.rs
+++ b/seed/cli/imdb/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/multi-url-environment-reference/src/auth/builder.rs
+++ b/seed/cli/multi-url-environment-reference/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/multi-url-environment-reference/src/auth/builder.rs
+++ b/seed/cli/multi-url-environment-reference/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/no-content-response/src/auth/builder.rs
+++ b/seed/cli/no-content-response/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/no-content-response/src/auth/builder.rs
+++ b/seed/cli/no-content-response/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/null-type/src/auth/builder.rs
+++ b/seed/cli/null-type/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/null-type/src/auth/builder.rs
+++ b/seed/cli/null-type/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/nullable-allof-extends/src/auth/builder.rs
+++ b/seed/cli/nullable-allof-extends/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/nullable-allof-extends/src/auth/builder.rs
+++ b/seed/cli/nullable-allof-extends/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/nullable-request-body/src/auth/builder.rs
+++ b/seed/cli/nullable-request-body/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/nullable-request-body/src/auth/builder.rs
+++ b/seed/cli/nullable-request-body/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/oauth-client-credentials-openapi/src/auth/builder.rs
+++ b/seed/cli/oauth-client-credentials-openapi/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/oauth-client-credentials-openapi/src/auth/builder.rs
+++ b/seed/cli/oauth-client-credentials-openapi/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/openapi-request-body-ref/src/auth/builder.rs
+++ b/seed/cli/openapi-request-body-ref/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/openapi-request-body-ref/src/auth/builder.rs
+++ b/seed/cli/openapi-request-body-ref/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/openapi-subtitle/src/auth/builder.rs
+++ b/seed/cli/openapi-subtitle/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/openapi-subtitle/src/auth/builder.rs
+++ b/seed/cli/openapi-subtitle/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/query-param-name-conflict/src/auth/builder.rs
+++ b/seed/cli/query-param-name-conflict/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/query-param-name-conflict/src/auth/builder.rs
+++ b/seed/cli/query-param-name-conflict/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/query-parameters-openapi-as-objects/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/query-parameters-openapi-as-objects/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/query-parameters-openapi/github-npm/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/query-parameters-openapi/github-npm/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/auth/builder.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/schemaless-request-body-examples/src/auth/builder.rs
+++ b/seed/cli/schemaless-request-body-examples/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/schemaless-request-body-examples/src/auth/builder.rs
+++ b/seed/cli/schemaless-request-body-examples/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/server-sent-events-openapi/src/auth/builder.rs
+++ b/seed/cli/server-sent-events-openapi/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/server-sent-events-openapi/src/auth/builder.rs
+++ b/seed/cli/server-sent-events-openapi/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/server-url-templating/src/auth/builder.rs
+++ b/seed/cli/server-url-templating/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/server-url-templating/src/auth/builder.rs
+++ b/seed/cli/server-url-templating/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/url-form-encoded/src/auth/builder.rs
+++ b/seed/cli/url-form-encoded/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/url-form-encoded/src/auth/builder.rs
+++ b/seed/cli/url-form-encoded/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/webhook-audience/src/auth/builder.rs
+++ b/seed/cli/webhook-audience/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/webhook-audience/src/auth/builder.rs
+++ b/seed/cli/webhook-audience/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]

--- a/seed/cli/x-fern-default/src/auth/builder.rs
+++ b/seed/cli/x-fern-default/src/auth/builder.rs
@@ -180,7 +180,13 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
             if hints.is_empty() {
                 "custom auth provider".to_string()
             } else {
-                hints.join(" / ")
+                // credential_hints() uses "environment variable"; normalise
+                // to the shorter "env var" used by describe_credential_source.
+                hints
+                    .iter()
+                    .map(|h| h.replace("environment variable", "env var"))
+                    .collect::<Vec<_>>()
+                    .join(" / ")
             }
         }
     }
@@ -917,7 +923,8 @@ mod tests {
             SchemeBinding::Custom(provider),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
-        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(out.contains("CLOSE_API_KEY env var"), "should show env var name with short label, got: {out}");
+        assert!(!out.contains("environment variable"), "should use 'env var' not 'environment variable', got: {out}");
         assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 

--- a/seed/cli/x-fern-default/src/auth/builder.rs
+++ b/seed/cli/x-fern-default/src/auth/builder.rs
@@ -175,7 +175,14 @@ fn describe_binding_sources(binding: &SchemeBinding) -> String {
                 describe_credential_source(password),
             )
         }
-        SchemeBinding::Custom(_) => "custom auth provider".to_string(),
+        SchemeBinding::Custom(provider) => {
+            let hints = provider.credential_hints();
+            if hints.is_empty() {
+                "custom auth provider".to_string()
+            } else {
+                hints.join(" / ")
+            }
+        }
     }
 }
 
@@ -889,13 +896,29 @@ mod tests {
     }
 
     #[test]
-    fn render_auth_help_section_marks_custom_provider_opaque() {
+    fn render_auth_help_section_marks_hintless_custom_provider_opaque() {
         let bindings = vec![(
             "x".to_string(),
             SchemeBinding::Custom(crate::auth::test_helpers::bearer("x", "tok")),
         )];
         let out = render_auth_help_section(&bindings).unwrap();
         assert!(out.contains("custom auth provider"));
+    }
+
+    #[test]
+    fn render_auth_help_section_shows_custom_provider_credential_hints() {
+        use crate::auth::schemes::BasicAuthProvider;
+        let provider: DynAuthProvider = Arc::new(BasicAuthProvider::username_only(
+            "ApiKeyAuth",
+            AuthCredentialSource::from_env("CLOSE_API_KEY"),
+        ));
+        let bindings = vec![(
+            "ApiKeyAuth".to_string(),
+            SchemeBinding::Custom(provider),
+        )];
+        let out = render_auth_help_section(&bindings).unwrap();
+        assert!(out.contains("CLOSE_API_KEY"), "should show env var name, got: {out}");
+        assert!(!out.contains("custom auth provider"), "should not show opaque label, got: {out}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

When a CLI auth binding uses `SchemeBinding::Custom` (e.g. basic auth with `passwordOmit: true`, which wraps a `BasicAuthProvider::username_only`), the `--help` output showed the opaque label `custom auth provider` instead of the actual env var name. This made it impossible for users to discover which env var to set from `--help` alone.

## Changes Made

- Updated `describe_binding_sources` in `sdk/src/auth/builder.rs` to call `credential_hints()` on the wrapped `DynAuthProvider` for `Custom` bindings. When hints are available (e.g. `CLOSE_API_KEY env var`), they are shown; otherwise falls back to the existing `custom auth provider` label.
- Normalized hint wording: `credential_hints()` returns `"environment variable"` but the help section uses `"env var"` — the Custom path now normalizes to match the rest of the section.

Before:
```
Authentication:
    ApiKeyAuth  custom auth provider
```

After (when the provider has credential hints):
```
Authentication:
    ApiKeyAuth  CLOSE_API_KEY env var
```

- Added a new test `render_auth_help_section_shows_custom_provider_credential_hints` validating the fix with a `BasicAuthProvider::username_only` binding
- Renamed existing test to `render_auth_help_section_marks_hintless_custom_provider_opaque` for clarity
- Regenerated all 26 CLI seed fixtures

## Testing
- [x] Unit tests added/updated — SDK auth builder tests pass (26/26)
- [x] All 129 CLI seed test cases pass

Link to Devin session: https://app.devin.ai/sessions/f8c2843881b94993a6ecddd02654eee8
Requested by: @adidavid014
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->