### PR TITLE
chore(cli): add regression tests for AUTO version string corruption

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.fallback.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.fallback.test.ts
@@ -711,3 +711,76 @@ describe("LocalTaskHandler - normalizeVersionPrefix", () => {
         expect(result?.version).toBe("v3.0.1");
     });
 });
+
+describe("LocalTaskHandler - Regression: version='AUTO' must use magic placeholder for replacement", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockWithOptions.mockReturnValue({
+            AnalyzeSdkDiff: mockAnalyzeSdkDiff
+        });
+        mockChunkDiff.mockReturnValue(["cleaned diff content"]);
+        mockLoggingExeca.mockResolvedValue({ stdout: "", exitCode: 0 });
+    });
+
+    async function createTaskHandler(overrides: Record<string, unknown> = {}) {
+        const { LocalTaskHandler } = await import("../LocalTaskHandler.js");
+        return new LocalTaskHandler({
+            // biome-ignore lint/suspicious/noExplicitAny: mock context for testing
+            context: mockContext as any,
+            // biome-ignore lint/suspicious/noExplicitAny: mock path for testing
+            absolutePathToTmpOutputDirectory: "/tmp/output" as any,
+            absolutePathToTmpSnippetJSON: undefined,
+            absolutePathToLocalSnippetTemplateJSON: undefined,
+            // biome-ignore lint/suspicious/noExplicitAny: mock path for testing
+            absolutePathToLocalOutput: "/tmp/local-output" as any,
+            absolutePathToLocalSnippetJSON: undefined,
+            absolutePathToTmpSnippetTemplatesJSON: undefined,
+            version: "AUTO",
+            ai: { provider: "anthropic", model: "claude-sonnet-4-5-20250929" },
+            isWhitelabel: false,
+            generatorLanguage: "typescript",
+            absolutePathToSpecRepo: undefined,
+            ...overrides
+        });
+    }
+
+    it("uses magic placeholder (not 'AUTO') when calling replaceMagicVersion", async () => {
+        // Setup: extractPreviousVersion works normally (magic version found in diff)
+        mockExtractPreviousVersion.mockReturnValue("1.0.0");
+
+        mockAnalyzeSdkDiff.mockResolvedValue({
+            version_bump: VersionBump.PATCH,
+            message: "fix: minor update",
+            changelog_entry: ""
+        });
+
+        const handler = await createTaskHandler();
+        const result = await callHandleAutoVersioning(handler);
+
+        expect(result).not.toBeNull();
+        expect(result?.version).toBe("1.0.1");
+
+        // Verify that extractPreviousVersion was called with the magic placeholder,
+        // NOT with the literal "AUTO" string
+        expect(mockExtractPreviousVersion).toHaveBeenCalledWith(expect.anything(), "0.0.0-fern-placeholder");
+    });
+
+    it("uses Go v-prefixed magic placeholder when generatorLanguage is 'go'", async () => {
+        mockExtractPreviousVersion.mockReturnValue("v2.0.0");
+
+        mockAnalyzeSdkDiff.mockResolvedValue({
+            version_bump: VersionBump.MINOR,
+            message: "feat: new feature",
+            changelog_entry: "Added new feature."
+        });
+
+        const handler = await createTaskHandler({ generatorLanguage: "go" });
+        const result = await callHandleAutoVersioning(handler);
+
+        expect(result).not.toBeNull();
+        expect(result?.version).toBe("v2.1.0");
+
+        // For Go, the magic version should be "v0.0.0-fern-placeholder"
+        expect(mockExtractPreviousVersion).toHaveBeenCalledWith(expect.anything(), "v0.0.0-fern-placeholder");
+    });
+});

--- a/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
+++ b/packages/generator-cli/src/__test__/AutoVersioningService.test.ts
@@ -812,6 +812,60 @@ describe("AutoVersioningService", () => {
         }
     });
 
+    // --- Regression test: AUTO identifiers must not be corrupted ---
+    // Reproduces the bug from https://github.com/fern-api/fern/pull/16675
+    // When --version AUTO was used, the sed command did `s/AUTO/<version>/g`
+    // which corrupted identifiers like SENSOR_MODE_AUTO and CORRELATION_TYPE_AUTOMATED.
+    // The fix ensures we always replace the magic placeholder, never "AUTO".
+
+    it("testReplaceMagicVersion_doesNotCorruptAutoIdentifiers", async () => {
+        const tempDir = await fs.mkdtemp(path.join(require("os").tmpdir(), "test-"));
+        try {
+            const typesFile = path.join(tempDir, "types.ts");
+            const originalContent = [
+                "export const SensorMode = {",
+                '    SensorModeAuto: "SENSOR_MODE_AUTO",',
+                '    SensorModeManual: "SENSOR_MODE_MANUAL",',
+                "} as const;",
+                "",
+                "export const CorrelationType = {",
+                '    CorrelationTypeAutomated: "CORRELATION_TYPE_AUTOMATED",',
+                '    CorrelationTypeManual: "CORRELATION_TYPE_MANUAL",',
+                "} as const;",
+                "",
+                "export const AutoScaling = {",
+                "    enabled: true,",
+                '    mode: "AUTO_DETECT",',
+                "} as const;",
+                "",
+                'export const VERSION = "0.0.0-fern-placeholder";'
+            ].join("\n");
+            await fs.writeFile(typesFile, originalContent);
+
+            await new AutoVersioningService({ logger: mockLogger }).replaceMagicVersion(
+                tempDir,
+                "0.0.0-fern-placeholder",
+                "4.13.1"
+            );
+
+            const updatedContent = await fs.readFile(typesFile, "utf-8");
+
+            // Version placeholder should be replaced
+            expect(updatedContent).not.toContain("0.0.0-fern-placeholder");
+            expect(updatedContent).toContain('"4.13.1"');
+
+            // AUTO identifiers must be preserved unchanged
+            expect(updatedContent).toContain('"SENSOR_MODE_AUTO"');
+            expect(updatedContent).toContain('"CORRELATION_TYPE_AUTOMATED"');
+            expect(updatedContent).toContain('"AUTO_DETECT"');
+            expect(updatedContent).toContain("SensorModeAuto");
+            expect(updatedContent).toContain("CorrelationTypeAutomated");
+            expect(updatedContent).toContain("AutoScaling");
+        } finally {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
     // --- Tests for extractPreviousVersion: exception path ---
 
     it("testExtractPreviousVersion_noMagicVersionInDiff_throws", () => {


### PR DESCRIPTION
## Description

Follow-up to #16675 — adds regression tests that directly reproduce the reported bug scenario where `--version AUTO` corrupted generated SDK code by replacing all occurrences of "AUTO" with the version number.

## Changes Made

**`AutoVersioningService.test.ts`** — New test `testReplaceMagicVersion_doesNotCorruptAutoIdentifiers`:
- Creates files containing the exact identifiers from the bug report (`SENSOR_MODE_AUTO`, `CORRELATION_TYPE_AUTOMATED`, `AUTO_DETECT`)
- Runs `replaceMagicVersion` with the magic placeholder (`0.0.0-fern-placeholder`)
- Asserts the version placeholder is correctly replaced AND all "AUTO" identifiers survive unchanged

**`LocalTaskHandler.fallback.test.ts`** — New describe block `"version='AUTO' must use magic placeholder for replacement"`:
- Tests that when `version: "AUTO"` is passed, `extractPreviousVersion` is called with the magic placeholder `"0.0.0-fern-placeholder"` (not the literal "AUTO" string)
- Tests the Go variant: `generatorLanguage: "go"` produces the v-prefixed magic placeholder `"v0.0.0-fern-placeholder"`

These tests would have caught the original bug and will prevent regression.

## Testing
- [x] Unit tests added (3 new tests, all passing)
- [x] Lint/typecheck clean (`pnpm run check` passes)
- [x] 580 total tests passing across both packages (417 generator-cli + 163 local-workspace-runner)

Link to Devin session: https://app.devin.ai/sessions/d7363ebb78134b23b785a4750dd9ea06
Requested by: @dvdaruri-art
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->