### PR TITLE
feat(docs): switch mobile-toc default from opt-in to opt-out

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -6053,7 +6053,7 @@
               "type": "null"
             }
           ],
-          "description": "If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages."
+          "description": "A sticky collapsible table of contents bar is shown on mobile viewports for guide and overview layout pages by default. Set `mobile-toc` to false to disable it."
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -969,7 +969,7 @@ types:
         type: optional<boolean>
         availability: in-development
         docs: |
-          If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages.
+          A sticky collapsible table of contents bar is shown on mobile viewports for guide and overview layout pages by default. Set `mobile-toc` to false to disable it.
 
   DocsSettingsConfig:
     properties:

--- a/packages/cli/cli/changes/unreleased/mobile-toc-default-true.yml
+++ b/packages/cli/cli/changes/unreleased/mobile-toc-default-true.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Switch mobile-toc default from opt-in (false) to opt-out (true) so the
+    mobile table of contents is enabled for all documentation sites by default.
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -657,7 +657,7 @@ function convertLayoutConfig(
         disableHeader: layout.disableHeader ?? false,
         hideNavLinks: layout.hideNavLinks ?? false,
         hideFeedback: layout.hideFeedback ?? false,
-        mobileToc: layout.mobileToc ?? false,
+        mobileToc: layout.mobileToc ?? true,
         tabsAlignment: resolvedTabsAlignment
     } as unknown as docsYml.ParsedDocsConfiguration["layout"];
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
@@ -94,6 +94,6 @@ export interface LayoutConfig {
     hideNavLinks?: boolean;
     /** If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter. */
     hideFeedback?: boolean;
-    /** If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages. */
+    /** A sticky collapsible table of contents bar is shown on mobile viewports for guide and overview layout pages by default. Set `mobile-toc` to false to disable it. */
     mobileToc?: boolean;
 }

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -6053,7 +6053,7 @@
               "type": "null"
             }
           ],
-          "description": "If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages."
+          "description": "A sticky collapsible table of contents bar is shown on mobile viewports for guide and overview layout pages by default. Set `mobile-toc` to false to disable it."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Description
<!-- Switch mobile-toc default value from false to true -->

Switch the `mobileToc` default from `false` (opt-in) to `true` (opt-out) so the mobile table of contents is enabled for all documentation sites by default. Users can still disable it by setting `mobile-toc: false` in their `docs.yml`.

## Changes Made
- `parseDocsConfiguration.ts`: `mobileToc: layout.mobileToc ?? true` (was `?? false`)
- `docs.yml` API definition: updated description to reflect opt-out behavior
- `LayoutConfig.ts` SDK type: updated JSDoc comment
- `docs-yml.schema.json` files: updated description text
- Added unreleased changelog entry (`feat`)

## Testing
- [x] Pre-commit hooks pass
- [x] Manual verification of affected code paths

Link to Devin session: https://app.devin.ai/sessions/dc05e99eb0c8464e85d2bf949350adf1
Requested by: @matlegault
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->