### PR TITLE
feat(docs): add hide-related-topics layout option to docs.yml schema

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -6051,6 +6051,17 @@
           ],
           "description": "If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter."
         },
+        "hide-related-topics": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If `hide-related-topics` is set to true, the auto-suggested related topics section will not be rendered at the bottom of pages. This can be overridden for a specific page using the frontmatter."
+        },
         "mobile-toc": {
           "oneOf": [
             {

--- a/fern-yml.schema.json
+++ b/fern-yml.schema.json
@@ -2863,6 +2863,9 @@
             "hide-feedback": {
               "type": "boolean"
             },
+            "hide-related-topics": {
+              "type": "boolean"
+            },
             "mobile-toc": {
               "type": "boolean"
             },

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -965,6 +965,12 @@ types:
         docs: |
           If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter.
 
+      hide-related-topics:
+        type: optional<boolean>
+        availability: in-development
+        docs: |
+          If `hide-related-topics` is set to true, the auto-suggested related topics section will not be rendered at the bottom of pages. This can be overridden for a specific page using the frontmatter.
+
       mobile-toc:
         type: optional<boolean>
         availability: in-development

--- a/packages/cli/cli/changes/unreleased/add-hide-related-topics-layout.yml
+++ b/packages/cli/cli/changes/unreleased/add-hide-related-topics-layout.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Add `hide-related-topics` option to the `layout` config in docs.yml. When set to true, the auto-suggested related topics section will not be rendered at the bottom of documentation pages.
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -657,6 +657,7 @@ function convertLayoutConfig(
         disableHeader: layout.disableHeader ?? false,
         hideNavLinks: layout.hideNavLinks ?? false,
         hideFeedback: layout.hideFeedback ?? false,
+        hideRelatedTopics: layout.hideRelatedTopics ?? false,
         mobileToc: layout.mobileToc ?? false,
         // Passed through as-is (no default): omitted renders the searchable
         // timeline, "classic" renders the legacy stacked layout. Resolved by the

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -305,6 +305,7 @@ export const LayoutConfig = z.object({
     "disable-header": z.boolean().optional(),
     "hide-nav-links": z.boolean().optional(),
     "hide-feedback": z.boolean().optional(),
+    "hide-related-topics": z.boolean().optional(),
     "mobile-toc": z.boolean().optional(),
     "changelog-layout": ChangelogLayout.optional()
 });

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
@@ -94,6 +94,8 @@ export interface LayoutConfig {
     hideNavLinks?: boolean;
     /** If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter. */
     hideFeedback?: boolean;
+    /** If `hide-related-topics` is set to true, the auto-suggested related topics section will not be rendered at the bottom of pages. This can be overridden for a specific page using the frontmatter. */
+    hideRelatedTopics?: boolean;
     /** If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages. */
     mobileToc?: boolean;
     /**

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/LayoutConfig.ts
@@ -24,6 +24,7 @@ export const LayoutConfig: core.serialization.ObjectSchema<serializers.LayoutCon
         disableHeader: core.serialization.property("disable-header", core.serialization.boolean().optional()),
         hideNavLinks: core.serialization.property("hide-nav-links", core.serialization.boolean().optional()),
         hideFeedback: core.serialization.property("hide-feedback", core.serialization.boolean().optional()),
+        hideRelatedTopics: core.serialization.property("hide-related-topics", core.serialization.boolean().optional()),
         mobileToc: core.serialization.property("mobile-toc", core.serialization.boolean().optional()),
         changelogLayout: core.serialization.property("changelog-layout", ChangelogLayout.optional()),
     });
@@ -42,6 +43,7 @@ export declare namespace LayoutConfig {
         "disable-header"?: boolean | null;
         "hide-nav-links"?: boolean | null;
         "hide-feedback"?: boolean | null;
+        "hide-related-topics"?: boolean | null;
         "mobile-toc"?: boolean | null;
         "changelog-layout"?: ChangelogLayout.Raw | null;
     }

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -6051,6 +6051,17 @@
           ],
           "description": "If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter."
         },
+        "hide-related-topics": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If `hide-related-topics` is set to true, the auto-suggested related topics section will not be rendered at the bottom of pages. This can be overridden for a specific page using the frontmatter."
+        },
         "mobile-toc": {
           "oneOf": [
             {


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-11056

Companion PR to [fern-platform#11952](https://github.com/fern-api/fern-platform/pull/11952) which adds a "Related Topics" section at the bottom of docs pages. This PR adds the `hide-related-topics` option to the `layout` config in `docs.yml` so users can globally disable the feature.

```yaml
# docs.yml
layout:
  hide-related-topics: true
```

## Changes Made
- Added `hide-related-topics` boolean property to `LayoutConfig` in the Fern API definition (`fern/apis/docs-yml/definition/docs.yml`)
- Updated Zod schema in `DocsYmlSchemas.ts`
- Updated SDK API type and serialization layer (`LayoutConfig.ts`)
- Updated JSON schema (`docs-yml.schema.json`)
- Updated `convertLayoutConfig` in `parseDocsConfiguration.ts` to pass through the new field (defaults to `false`)

## Testing
- [x] `pnpm compile` passes for affected packages (configuration, configuration-loader, config)
- [x] `pnpm lint:biome --fix` and `pnpm format:fix` pass cleanly

Link to Devin session: https://app.devin.ai/sessions/e76abdb239f24b4fabff33b1a2464956
Requested by: @kgowru
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->