### PR TITLE
chore(generator-cli): bump @fern-api/replay to 0.19.0

### DIFF
--- a/packages/cli/cli-v2/src/commands/replay/forget/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/replay/forget/__test__/command.test.ts
@@ -37,7 +37,7 @@ function baseArgs(overrides: Partial<ForgetCommand.Args> = {}): ForgetCommand.Ar
     } as ForgetCommand.Args;
 }
 
-type ForgetResult = ReturnType<typeof import("@fern-api/generator-cli").replayForget>;
+type ForgetResult = Awaited<ReturnType<typeof import("@fern-api/generator-cli").replayForget>>;
 
 function makePatch(id: string, message: string) {
     return { id, message, files: [], diffstat: { additions: 1, deletions: 0 } };
@@ -67,7 +67,7 @@ describe("ForgetCommand", () => {
     describe("--all mode", () => {
         it("prints removed patches", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(
+            vi.mocked(replayForget).mockResolvedValue(
                 makeForgetResult({ removed: [makePatch("patch-abc", "fix types")], totalPatches: 1 })
             );
 
@@ -80,7 +80,7 @@ describe("ForgetCommand", () => {
 
         it("reports not initialized", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(makeForgetResult({ initialized: false }));
+            vi.mocked(replayForget).mockResolvedValue(makeForgetResult({ initialized: false }));
 
             const context = createMockContext();
             await cmd.handle(context, baseArgs({ all: true }));
@@ -90,7 +90,7 @@ describe("ForgetCommand", () => {
 
         it("reports no patches to remove when list is empty", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(makeForgetResult());
+            vi.mocked(replayForget).mockResolvedValue(makeForgetResult());
 
             const context = createMockContext();
             await cmd.handle(context, baseArgs({ all: true }));
@@ -102,7 +102,7 @@ describe("ForgetCommand", () => {
     describe("patch ID mode", () => {
         it("removes specified patch IDs", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(
+            vi.mocked(replayForget).mockResolvedValue(
                 makeForgetResult({ removed: [makePatch("patch-abc123", "fix")], remaining: 2, totalPatches: 3 })
             );
 
@@ -117,7 +117,7 @@ describe("ForgetCommand", () => {
 
         it("handles already-forgotten IDs", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(makeForgetResult({ alreadyForgotten: ["patch-old"] }));
+            vi.mocked(replayForget).mockResolvedValue(makeForgetResult({ alreadyForgotten: ["patch-old"] }));
 
             const context = createMockContext();
             await cmd.handle(context, baseArgs({ args: ["patch-old"] }));
@@ -139,10 +139,10 @@ describe("ForgetCommand", () => {
         it("lists matched patches and removes after confirmation", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
             vi.mocked(replayForget)
-                .mockReturnValueOnce(
+                .mockResolvedValueOnce(
                     makeForgetResult({ matched: [makePatch("patch-xyz", "add field")], totalPatches: 1 })
                 )
-                .mockReturnValueOnce(makeForgetResult({ removed: [makePatch("patch-xyz", "add field")] }));
+                .mockResolvedValueOnce(makeForgetResult({ removed: [makePatch("patch-xyz", "add field")] }));
 
             const context = createMockContext();
             await cmd.handle(context, baseArgs({ args: ["add field"], yes: true }));
@@ -153,7 +153,7 @@ describe("ForgetCommand", () => {
 
         it("reports no matches for unknown pattern", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(makeForgetResult({ notFound: true }));
+            vi.mocked(replayForget).mockResolvedValue(makeForgetResult({ notFound: true }));
 
             const context = createMockContext();
             await cmd.handle(context, baseArgs({ args: ["nonexistent"] }));
@@ -165,7 +165,7 @@ describe("ForgetCommand", () => {
 
         it("dry-run does not remove", async () => {
             const { replayForget } = await import("@fern-api/generator-cli");
-            vi.mocked(replayForget).mockReturnValue(
+            vi.mocked(replayForget).mockResolvedValue(
                 makeForgetResult({ matched: [makePatch("patch-abc", "fix")], remaining: 1, totalPatches: 1 })
             );
 

--- a/packages/cli/cli-v2/src/commands/replay/forget/command.ts
+++ b/packages/cli/cli-v2/src/commands/replay/forget/command.ts
@@ -26,7 +26,7 @@ export class ForgetCommand {
         try {
             // --all mode
             if (args.all) {
-                const result = replayForget({ outputDir, options: { all: true, dryRun } });
+                const result = await replayForget({ outputDir, options: { all: true, dryRun } });
 
                 if (!result.initialized) {
                     context.stderr.info("Replay is not initialized. Nothing to forget.");
@@ -54,7 +54,7 @@ export class ForgetCommand {
 
             // Patch ID mode: all args start with "patch-"
             if (positionalArgs.length > 0 && positionalArgs.every((a) => a.startsWith("patch-"))) {
-                const result = replayForget({ outputDir, options: { patchIds: positionalArgs, dryRun } });
+                const result = await replayForget({ outputDir, options: { patchIds: positionalArgs, dryRun } });
 
                 if (!result.initialized) {
                     context.stderr.info("Replay is not initialized. Nothing to forget.");
@@ -84,7 +84,7 @@ export class ForgetCommand {
                 });
             }
             const pattern = positionalArgs.length === 1 ? positionalArgs[0] : undefined;
-            const result = replayForget({ outputDir, options: { pattern } });
+            const result = await replayForget({ outputDir, options: { pattern } });
 
             if (!result.initialized) {
                 context.stderr.info("Replay is not initialized. Nothing to forget.");
@@ -136,7 +136,7 @@ export class ForgetCommand {
 
             // Actually remove the matched patches
             const patchIds = matched.map((p) => p.id);
-            const removeResult = replayForget({ outputDir, options: { patchIds, dryRun: false } });
+            const removeResult = await replayForget({ outputDir, options: { patchIds, dryRun: false } });
 
             context.stderr.info(
                 `Removed ${removeResult.removed.length} patch(es). ${removeResult.remaining} remaining.`

--- a/packages/cli/cli-v2/src/commands/replay/status/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/replay/status/__test__/command.test.ts
@@ -58,6 +58,8 @@ function makeStatusResult(overrides: Partial<StatusResult> = {}): StatusResult {
         patches: [],
         unresolvedCount: 0,
         excludePatterns: [],
+        dismissed: [],
+        legacyDismissedCount: 0,
         ...overrides
     };
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -3636,7 +3636,7 @@ function addReplayForgetCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCont
             try {
                 // --all mode
                 if (argv.all) {
-                    const result = replayForget({ outputDir, options: { all: true, dryRun } });
+                    const result = await replayForget({ outputDir, options: { all: true, dryRun } });
 
                     if (!result.initialized) {
                         cliContext.logger.info("Replay is not initialized. Nothing to forget.");
@@ -3664,7 +3664,7 @@ function addReplayForgetCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCont
 
                 // Patch ID mode: all args start with "patch-"
                 if (args.length > 0 && args.every((a) => a.startsWith("patch-"))) {
-                    const result = replayForget({ outputDir, options: { patchIds: args, dryRun } });
+                    const result = await replayForget({ outputDir, options: { patchIds: args, dryRun } });
 
                     if (!result.initialized) {
                         cliContext.logger.info("Replay is not initialized. Nothing to forget.");
@@ -3688,7 +3688,7 @@ function addReplayForgetCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCont
 
                 // Search/pattern mode or no-args mode
                 const pattern = args.length === 1 ? args[0] : undefined;
-                const result = replayForget({ outputDir, options: { pattern } });
+                const result = await replayForget({ outputDir, options: { pattern } });
 
                 if (!result.initialized) {
                     cliContext.logger.info("Replay is not initialized. Nothing to forget.");
@@ -3741,7 +3741,7 @@ function addReplayForgetCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCont
 
                 // Actually remove the matched patches
                 const patchIds = matched.map((p) => p.id);
-                const removeResult = replayForget({ outputDir, options: { patchIds, dryRun: false } });
+                const removeResult = await replayForget({ outputDir, options: { patchIds, dryRun: false } });
 
                 cliContext.logger.info(
                     `Removed ${removeResult.removed.length} patch(es). ${removeResult.remaining} remaining.`

--- a/packages/generator-cli/changes/unreleased/bump-replay-0.19.0.yml
+++ b/packages/generator-cli/changes/unreleased/bump-replay-0.19.0.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump `@fern-api/replay` to 0.19.0.
+  type: chore

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -47,7 +47,7 @@
     "@fern-api/docker-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.18.0",
+    "@fern-api/replay": "0.19.0",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/src/__test__/replay-forget.test.ts
+++ b/packages/generator-cli/src/__test__/replay-forget.test.ts
@@ -126,8 +126,8 @@ describe("replayForget", { tags: ["slow"] }, () => {
             await cleanup?.();
         });
 
-        it("returns initialized=false", () => {
-            const result = replayForget({ outputDir: repoPath });
+        it("returns initialized=false", async () => {
+            const result = await replayForget({ outputDir: repoPath });
             expect(result.initialized).toBe(false);
         });
     });
@@ -146,8 +146,8 @@ describe("replayForget", { tags: ["slow"] }, () => {
             await cleanup?.();
         });
 
-        it("removes all patches", () => {
-            const result = replayForget({ outputDir: repoPath, options: { all: true } });
+        it("removes all patches", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { all: true } });
             expect(result.initialized).toBe(true);
             expect(result.removed).toHaveLength(2);
             expect(result.remaining).toBe(0);
@@ -168,8 +168,8 @@ describe("replayForget", { tags: ["slow"] }, () => {
             await cleanup?.();
         });
 
-        it("shows what would be removed without removing", () => {
-            const result = replayForget({ outputDir: repoPath, options: { all: true, dryRun: true } });
+        it("shows what would be removed without removing", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { all: true, dryRun: true } });
             expect(result.removed).toHaveLength(2);
 
             // Verify patches still exist
@@ -193,15 +193,15 @@ describe("replayForget", { tags: ["slow"] }, () => {
             await cleanup?.();
         });
 
-        it("removes specific patch by ID", () => {
-            const result = replayForget({ outputDir: repoPath, options: { patchIds: ["patch-aaa11111"] } });
+        it("removes specific patch by ID", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { patchIds: ["patch-aaa11111"] } });
             expect(result.removed).toHaveLength(1);
             expect(result.removed[0]?.id).toBe("patch-aaa11111");
             expect(result.remaining).toBe(1);
         });
 
-        it("reports already-forgotten IDs", () => {
-            const result = replayForget({ outputDir: repoPath, options: { patchIds: ["patch-nonexistent"] } });
+        it("reports already-forgotten IDs", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { patchIds: ["patch-nonexistent"] } });
             expect(result.removed).toHaveLength(0);
             expect(result.alreadyForgotten).toContain("patch-nonexistent");
             expect(result.notFound).toBe(true);
@@ -222,20 +222,20 @@ describe("replayForget", { tags: ["slow"] }, () => {
             await cleanup?.();
         });
 
-        it("matches patches by file path", () => {
-            const result = replayForget({ outputDir: repoPath, options: { pattern: "src/helper.ts" } });
+        it("matches patches by file path", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { pattern: "src/helper.ts" } });
             expect(result.matched).toHaveLength(1);
             expect(result.matched?.[0]?.id).toBe("patch-bbb22222");
         });
 
-        it("matches patches by commit message substring", () => {
-            const result = replayForget({ outputDir: repoPath, options: { pattern: "helper utility" } });
+        it("matches patches by commit message substring", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { pattern: "helper utility" } });
             expect(result.matched).toHaveLength(1);
             expect(result.matched?.[0]?.id).toBe("patch-bbb22222");
         });
 
-        it("returns notFound when no match", () => {
-            const result = replayForget({ outputDir: repoPath, options: { pattern: "nonexistent-file.ts" } });
+        it("returns notFound when no match", async () => {
+            const result = await replayForget({ outputDir: repoPath, options: { pattern: "nonexistent-file.ts" } });
             expect(result.notFound).toBe(true);
             expect(result.matched).toHaveLength(0);
         });
@@ -255,8 +255,8 @@ describe("replayForget", { tags: ["slow"] }, () => {
             await cleanup?.();
         });
 
-        it("returns all patches as matched for selection", () => {
-            const result = replayForget({ outputDir: repoPath });
+        it("returns all patches as matched for selection", async () => {
+            const result = await replayForget({ outputDir: repoPath });
             expect(result.matched).toHaveLength(2);
             expect(result.removed).toHaveLength(0);
         });

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -478,7 +478,7 @@ void yargs(hideBin(process.argv))
                                 description: "Search pattern (file path, glob, or commit message substring)"
                             });
                     },
-                    (argv) => {
+                    async (argv) => {
                         try {
                             const outputDir = resolve(cwd(), ".");
                             const args = argv.args ?? [];
@@ -486,23 +486,23 @@ void yargs(hideBin(process.argv))
 
                             let result;
                             if (argv.all) {
-                                result = replayForget({ outputDir, options: { all: true, dryRun } });
+                                result = await replayForget({ outputDir, options: { all: true, dryRun } });
                             } else if (argv.pattern) {
-                                result = replayForget({ outputDir, options: { pattern: argv.pattern, dryRun } });
+                                result = await replayForget({ outputDir, options: { pattern: argv.pattern, dryRun } });
                             } else if (args.length > 0) {
                                 // Check if args look like patch IDs
                                 const allPatchIds = args.every((a) => a.startsWith("patch-"));
                                 if (allPatchIds) {
-                                    result = replayForget({ outputDir, options: { patchIds: args, dryRun } });
+                                    result = await replayForget({ outputDir, options: { patchIds: args, dryRun } });
                                 } else {
                                     // Treat single arg as pattern
-                                    result = replayForget({
+                                    result = await replayForget({
                                         outputDir,
                                         options: { pattern: args[0], dryRun }
                                     });
                                 }
                             } else {
-                                result = replayForget({ outputDir, options: { dryRun } });
+                                result = await replayForget({ outputDir, options: { dryRun } });
                             }
 
                             process.stdout.write(JSON.stringify(result, null, 2) + "\n");

--- a/packages/generator-cli/src/replay/replay-forget.ts
+++ b/packages/generator-cli/src/replay/replay-forget.ts
@@ -9,6 +9,6 @@ export interface ReplayForgetParams {
     options?: ForgetOptions;
 }
 
-export function replayForget(params: ReplayForgetParams): ForgetResult {
+export async function replayForget(params: ReplayForgetParams): Promise<ForgetResult> {
     return forget(params.outputDir, params.options);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8008,8 +8008,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.18.0
-        version: 0.18.0
+        specifier: 0.19.0
+        version: 0.19.0
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9529,6 +9529,11 @@ packages:
 
   '@fern-api/replay@0.18.0':
     resolution: {integrity: sha512-C9tRzLLqJxRaEr6BqAhWpdksaqnnCPqt3fFeA63V52OhCo0tyV/30JN8MONBkYQexBeEU2erackvFAKflcMLmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.19.0':
+    resolution: {integrity: sha512-j3sq5l9ykpO7xncQ2BzdCDScf6l8SjPXBoFH5pvw8jJLx8CTB2Lq2LX2ujf44olhWJWKPQmz2yuokyNOilsetw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16509,6 +16514,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.18.0':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.36.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.19.0':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Bump `@fern-api/replay` from 0.18.0 to 0.19.0 in the generator-cli package.

## Changes Made

- Updated `@fern-api/replay` dependency to 0.19.0 in `packages/generator-cli/package.json`
- Added `await` to all `replayForget()` call sites — the `forget()` function in replay 0.19.0 is now async (returns `Promise<ForgetResult>`)
  - `packages/generator-cli/src/replay/replay-forget.ts` and `src/cli.ts`
  - `packages/cli/cli/src/cli.ts` (CLI v1)
  - `packages/cli/cli-v2/src/commands/replay/forget/command.ts` (CLI v2)
- Updated test mocks from `mockReturnValue` → `mockResolvedValue` in `packages/cli/cli-v2/src/commands/replay/forget/__test__/command.test.ts`
- Updated `Awaited<ReturnType<...>>` for the `ForgetResult` type alias in tests
- Added `dismissed: []` and `legacyDismissedCount: 0` defaults in `packages/cli/cli-v2/src/commands/replay/status/__test__/command.test.ts` (new required fields in `StatusResult`)
- Added unreleased changelog entry

## Testing

- [x] Local compilation verified: `pnpm turbo run compile --filter @fern-api/cli` and `--filter @fern-api/cli-v2` both pass (94 and 84 tasks respectively)
- [x] All CI checks passing

Link to Devin session: https://app.devin.ai/sessions/59b4205dc27b480f83f0ea3019d5c0a0
Requested by: @cadesark
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->