### PR TITLE
fix(cli): localize translated API nav titles

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-translated-api-nav-structural-divergence.yml
+++ b/packages/cli/cli/changes/unreleased/fix-translated-api-nav-structural-divergence.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix a 500 (PruneEmptyError) in localized docs when a translated OpenAPI spec changed a
+    structural identifier (e.g. an OpenAPI tag name, which derives subpackage and endpoint ids)
+    relative to the default-locale spec. API-reference navigation nodes are now matched to the
+    translated definition by a stable locator (HTTP method + path) in addition to id, so localized
+    sidebar titles still apply and the renderer can resolve the served API. When a node cannot be
+    matched at all, the affected API falls back to the default-locale definition with a warning
+    instead of crashing.
+  type: fix

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -3,6 +3,7 @@ import {
     applyTranslatedApiTitlesToNavTree,
     applyTranslatedFrontmatterToNavTree,
     applyTranslatedNavigationOverlays,
+    findIncompatibleTranslatedApiIds,
     getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
     replaceReferencedCode,
@@ -876,18 +877,52 @@ export async function runAppPreviewServer({
                     }
                 }
 
+                const baseApis = docsDefinition.apis as Record<string, APIV1Read.ApiDefinition>;
                 const localeApis = translatedApiDefinitions?.[locale];
-                const translatedApis =
-                    localeApis != null ? { ...docsDefinition.apis, ...localeApis } : docsDefinition.apis;
 
-                // Splicing `apis` alone leaves the sidebar in the default language,
-                // since the nav tree bakes in titles from the base API definition.
+                // A translated spec that drifts from the base — most commonly a changed
+                // OpenAPI tag name (which derives subpackage/endpoint ids), but also a
+                // missing/added endpoint or a changed path — produces an API whose nav
+                // nodes can't all be resolved. Serving such a definition would make the
+                // docs renderer fail to resolve a nav node and return a 500. For those
+                // APIs we serve the base (default-locale) definition and keep the base nav
+                // ids, but still localize the sidebar titles we can match by locator.
+                let servedLocaleApis = localeApis;
+                let rewritableApiIds: ReadonlySet<string> | undefined;
                 if (localeApis != null && updatedRoot != null) {
-                    updatedRoot = applyTranslatedApiTitlesToNavTree(
-                        updatedRoot,
-                        docsDefinition.apis as Record<string, APIV1Read.ApiDefinition>,
-                        localeApis
+                    const incompatibleApiIds = findIncompatibleTranslatedApiIds(updatedRoot, baseApis, localeApis);
+                    if (incompatibleApiIds.size > 0) {
+                        context.logger.warn(
+                            `Translated API definition(s) [${Array.from(incompatibleApiIds).join(", ")}] for locale ` +
+                                `"${locale}" diverge from the default-locale spec (e.g. changed OpenAPI tag names, ` +
+                                `operationIds, or paths, or a missing/added endpoint), so they can't be fully matched ` +
+                                `to the navigation tree. Serving the default-locale API for those (localized sidebar ` +
+                                `titles are still applied where they can be matched). For fully localized API reference ` +
+                                `content, translate only human-readable text and keep tag names/operationIds/paths ` +
+                                `identical to the base spec.`
+                        );
+                        servedLocaleApis = Object.fromEntries(
+                            Object.entries(localeApis).filter(([apiId]) => !incompatibleApiIds.has(apiId))
+                        );
+                    }
+                    rewritableApiIds = new Set(
+                        Object.keys(localeApis).filter((apiId) => !incompatibleApiIds.has(apiId))
                     );
+                }
+
+                const hasServedLocaleApis = servedLocaleApis != null && Object.keys(servedLocaleApis).length > 0;
+                const translatedApis = hasServedLocaleApis
+                    ? { ...docsDefinition.apis, ...servedLocaleApis }
+                    : docsDefinition.apis;
+
+                // Splicing `apis` alone leaves the sidebar in the default language, since
+                // the nav tree bakes in titles from the base API definition. Localize
+                // titles for every translated API (matched by id or locator); ids are only
+                // repointed for the APIs whose translated definition we actually serve.
+                if (localeApis != null && Object.keys(localeApis).length > 0 && updatedRoot != null) {
+                    updatedRoot = applyTranslatedApiTitlesToNavTree(updatedRoot, baseApis, localeApis, {
+                        rewritableApiIds
+                    });
                 }
 
                 const translatedDefinition: DocsV1Read.DocsDefinition = {

--- a/packages/cli/docs-resolver/package.json
+++ b/packages/cli/docs-resolver/package.json
@@ -27,8 +27,8 @@
     "compile": "tsc",
     "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
-    "test": "vitest --run src/utils/__test__",
-    "test:debug": "vitest --run --inspect src/utils/__test__"
+    "test": "vitest --run",
+    "test:debug": "vitest --run --inspect"
   },
   "dependencies": {
     "@fern-api/api-workspace-commons": "workspace:*",

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedApiTitlesToNavTree.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedApiTitlesToNavTree.test.ts
@@ -1,9 +1,39 @@
 import { APIV1Read, FernNavigation } from "@fern-api/fdr-sdk";
 import { describe, expect, it } from "vitest";
 
-import { applyTranslatedApiTitlesToNavTree } from "../applyTranslatedApiTitlesToNavTree.js";
+import {
+    applyTranslatedApiTitlesToNavTree,
+    findIncompatibleTranslatedApiIds
+} from "../applyTranslatedApiTitlesToNavTree.js";
 
 const ROOT_PACKAGE_ID = "__package__";
+
+// Endpoints/webhooks/websockets are matched across locales by a stable locator
+// (HTTP method + path). Real FDR definitions always carry these; the fixtures
+// default them from the node id so the locator is deterministic and unique.
+function withEndpointDefaults(endpoint: Partial<APIV1Read.EndpointDefinition>): Partial<APIV1Read.EndpointDefinition> {
+    return {
+        method: "GET",
+        path: { parts: [{ type: "literal", value: `/${endpoint.id ?? "endpoint"}` }], pathParameters: [] },
+        ...endpoint
+    } as Partial<APIV1Read.EndpointDefinition>;
+}
+
+function withWebhookDefaults(webhook: Partial<APIV1Read.WebhookDefinition>): Partial<APIV1Read.WebhookDefinition> {
+    return {
+        method: "POST",
+        path: [`${webhook.id ?? "webhook"}`],
+        ...webhook
+    } as Partial<APIV1Read.WebhookDefinition>;
+}
+
+function withWebSocketDefaults(webSocket: Partial<APIV1Read.WebSocketChannel>): Partial<APIV1Read.WebSocketChannel> {
+    return {
+        path: { parts: [{ type: "literal", value: `/${webSocket.id ?? "ws"}` }], pathParameters: [] },
+        environments: [],
+        ...webSocket
+    } as Partial<APIV1Read.WebSocketChannel>;
+}
 
 // Casts a plain test fixture to RootNode. Mirrors the convention used by the
 // sibling applyTranslatedFrontmatterToNavTree test — the helper only reads a
@@ -38,17 +68,17 @@ function makeApi(args: {
                 subpackageId,
                 name: sub.name,
                 displayName: sub.displayName,
-                endpoints: sub.endpoints ?? [],
-                websockets: sub.webSockets ?? [],
-                webhooks: sub.webhooks ?? []
+                endpoints: (sub.endpoints ?? []).map(withEndpointDefaults),
+                websockets: (sub.webSockets ?? []).map(withWebSocketDefaults),
+                webhooks: (sub.webhooks ?? []).map(withWebhookDefaults)
             }
         ])
     );
     return {
         rootPackage: {
-            endpoints: args.rootEndpoints ?? [],
-            websockets: args.rootWebSockets ?? [],
-            webhooks: args.rootWebhooks ?? []
+            endpoints: (args.rootEndpoints ?? []).map(withEndpointDefaults),
+            websockets: (args.rootWebSockets ?? []).map(withWebSocketDefaults),
+            webhooks: (args.rootWebhooks ?? []).map(withWebhookDefaults)
         },
         subpackages,
         types: {}
@@ -241,5 +271,572 @@ describe("applyTranslatedApiTitlesToNavTree", () => {
         };
         const result = applyTranslatedApiTitlesToNavTree(asRoot(root), {}, {});
         expect(result).toEqual(root);
+    });
+
+    it("matches an endpoint by locator and rewrites its id when a translated tag renamed the subpackage", () => {
+        // Base: tag "Account Permissions" -> subpackage_accountPermissions, endpoint id
+        // "endpoint_accountPermissions.index". Translated spec renamed the tag, so its ids
+        // diverge, but the HTTP method + path are unchanged.
+        const baseApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_accountPermissions: {
+                        name: "accountPermissions",
+                        endpoints: [
+                            {
+                                id: "index",
+                                name: "List account user roles",
+                                originalEndpointId: "endpoint_accountPermissions.index",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/v4/accounts/roles" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const translatedApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_アカウント権限: {
+                        name: "アカウント権限",
+                        displayName: "アカウント権限",
+                        endpoints: [
+                            {
+                                id: "index",
+                                name: "アカウントユーザーロールを一覧表示",
+                                originalEndpointId: "endpoint_アカウント権限.index",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/v4/accounts/roles" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const root = {
+            type: "root",
+            child: {
+                type: "endpoint",
+                endpointId: "endpoint_accountPermissions.index",
+                apiDefinitionId: API_ID,
+                title: "List account user roles"
+            }
+        };
+
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis);
+        const child = (result as unknown as { child: { title: string; endpointId: string } }).child;
+        expect(child.title).toBe("アカウントユーザーロールを一覧表示");
+        // The id is repointed to the translated API's id so the renderer can resolve it.
+        expect(child.endpointId).toBe("endpoint_アカウント権限.index");
+    });
+
+    it("localizes the title but keeps the base id for APIs excluded from rewritableApiIds", () => {
+        // Mirrors a drifted API: we serve the base definition (base ids), so the nav
+        // node id must stay as the base id, but the title is still localized.
+        const baseApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_accountPermissions: {
+                        name: "accountPermissions",
+                        endpoints: [
+                            {
+                                id: "index",
+                                name: "List account user roles",
+                                originalEndpointId: "endpoint_accountPermissions.index",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/v4/accounts/roles" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const translatedApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_アカウント権限: {
+                        name: "アカウント権限",
+                        displayName: "アカウント権限",
+                        endpoints: [
+                            {
+                                id: "index",
+                                name: "アカウントユーザーロールを一覧表示",
+                                originalEndpointId: "endpoint_アカウント権限.index",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/v4/accounts/roles" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const root = {
+            type: "root",
+            child: {
+                type: "endpoint",
+                endpointId: "endpoint_accountPermissions.index",
+                apiDefinitionId: API_ID,
+                title: "List account user roles"
+            }
+        };
+
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis, {
+            rewritableApiIds: new Set()
+        });
+        const child = (result as unknown as { child: { title: string; endpointId: string } }).child;
+        expect(child.title).toBe("アカウントユーザーロールを一覧表示");
+        // Id is NOT repointed because the base definition is served for this API.
+        expect(child.endpointId).toBe("endpoint_accountPermissions.index");
+    });
+
+    it("matches endpoints by locator even when a path parameter was renamed", () => {
+        // Locators ignore path-parameter *names* (only method + literal structure
+        // identify an endpoint), so a translated param name must not break matching.
+        const baseApis = {
+            [API_ID]: makeApi({
+                rootEndpoints: [
+                    {
+                        id: "index",
+                        name: "List account roles",
+                        originalEndpointId: "ep.index",
+                        method: "GET",
+                        path: {
+                            parts: [
+                                { type: "literal", value: "/v4/accounts/" },
+                                { type: "pathParameter", value: "account_id" },
+                                { type: "literal", value: "/roles" }
+                            ],
+                            pathParameters: []
+                        }
+                    }
+                ]
+            })
+        };
+        const translatedApis = {
+            [API_ID]: makeApi({
+                rootEndpoints: [
+                    {
+                        id: "index",
+                        name: "アカウントロールを一覧表示",
+                        originalEndpointId: "ep.index",
+                        method: "GET",
+                        path: {
+                            parts: [
+                                { type: "literal", value: "/v4/accounts/" },
+                                { type: "pathParameter", value: "アカウントID" },
+                                { type: "literal", value: "/roles" }
+                            ],
+                            pathParameters: []
+                        }
+                    }
+                ]
+            })
+        };
+        const root = {
+            type: "root",
+            child: { type: "endpoint", endpointId: "ep.index", apiDefinitionId: API_ID, title: "List account roles" }
+        };
+
+        const incompatible = findIncompatibleTranslatedApiIds(asRoot(root), baseApis, translatedApis);
+        expect(incompatible.size).toBe(0);
+
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis);
+        const child = (result as unknown as { child: { title: string } }).child;
+        expect(child.title).toBe("アカウントロールを一覧表示");
+    });
+
+    it("translates an apiPackage group title via endpoint membership when the tag id diverged", () => {
+        const baseApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_accountPermissions: {
+                        name: "accountPermissions",
+                        endpoints: [
+                            {
+                                id: "index",
+                                name: "List",
+                                originalEndpointId: "endpoint_accountPermissions.index",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/v4/accounts/roles" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const translatedApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_アカウント権限: {
+                        name: "アカウント権限",
+                        displayName: "アカウント権限",
+                        endpoints: [
+                            {
+                                id: "index",
+                                name: "一覧",
+                                originalEndpointId: "endpoint_アカウント権限.index",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/v4/accounts/roles" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const root = {
+            type: "root",
+            child: {
+                type: "apiPackage",
+                apiDefinitionId: API_ID,
+                title: "Account Permissions",
+                children: []
+            }
+        };
+
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis);
+        const child = (result as unknown as { child: { title: string } }).child;
+        expect(child.title).toBe("アカウント権限");
+    });
+
+    it("translates a websocket title and rewrites its id by locator when the tag was renamed", () => {
+        const baseApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_realtime: {
+                        name: "realtime",
+                        webSockets: [
+                            {
+                                id: "stream",
+                                name: "Realtime stream",
+                                path: { parts: [{ type: "literal", value: "/v4/ws/stream" }], pathParameters: [] },
+                                environments: []
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const translatedApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_リアルタイム: {
+                        name: "リアルタイム",
+                        webSockets: [
+                            {
+                                id: "stream",
+                                name: "リアルタイムストリーム",
+                                path: { parts: [{ type: "literal", value: "/v4/ws/stream" }], pathParameters: [] },
+                                environments: []
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const root = {
+            type: "root",
+            child: {
+                type: "webSocket",
+                webSocketId: "subpackage_realtime.stream",
+                apiDefinitionId: API_ID,
+                title: "Realtime stream"
+            }
+        };
+
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis);
+        const child = (result as unknown as { child: { title: string; webSocketId: string } }).child;
+        expect(child.title).toBe("リアルタイムストリーム");
+        expect(child.webSocketId).toBe("subpackage_リアルタイム.stream");
+    });
+
+    it("translates a webhook title and rewrites its id by locator when the tag was renamed", () => {
+        const baseApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_events: {
+                        name: "events",
+                        webhooks: [{ id: "created", name: "On created", method: "POST", path: ["events", "created"] }]
+                    }
+                }
+            })
+        };
+        const translatedApis = {
+            [API_ID]: makeApi({
+                subpackages: {
+                    subpackage_イベント: {
+                        name: "イベント",
+                        webhooks: [{ id: "created", name: "作成時", method: "POST", path: ["events", "created"] }]
+                    }
+                }
+            })
+        };
+        const root = {
+            type: "root",
+            child: {
+                type: "webhook",
+                webhookId: "subpackage_events.created",
+                apiDefinitionId: API_ID,
+                title: "On created"
+            }
+        };
+
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis);
+        const child = (result as unknown as { child: { title: string; webhookId: string } }).child;
+        expect(child.title).toBe("作成時");
+        expect(child.webhookId).toBe("subpackage_イベント.created");
+    });
+
+    it("rewrites ids for a compatible API but only localizes titles for a drifted one in the same tree", () => {
+        // Models the real customer case: two APIs share one nav tree. API_OK is a clean
+        // translation (served translated → ids may be repointed). API_DRIFT is missing an
+        // endpoint that the nav references, so the base definition is served for it; its
+        // matchable node must keep the base id (so the renderer resolves it) while still
+        // getting a localized title.
+        const API_OK = "api-ok";
+        const API_DRIFT = "api-drift";
+        const okEndpoint = (name: string, originalEndpointId: string) => ({
+            id: "index",
+            name,
+            originalEndpointId,
+            method: "GET" as const,
+            path: { parts: [{ type: "literal" as const, value: "/ok/roles" }], pathParameters: [] }
+        });
+        const driftPresent = (name: string, originalEndpointId: string) => ({
+            id: "present",
+            name,
+            originalEndpointId,
+            method: "GET" as const,
+            path: { parts: [{ type: "literal" as const, value: "/drift/present" }], pathParameters: [] }
+        });
+        const baseApis = {
+            [API_OK]: makeApi({
+                subpackages: {
+                    subpackage_accounts: {
+                        name: "accounts",
+                        endpoints: [okEndpoint("List", "endpoint_accounts.index")]
+                    }
+                }
+            }),
+            [API_DRIFT]: makeApi({
+                subpackages: {
+                    subpackage_files: {
+                        name: "files",
+                        endpoints: [
+                            driftPresent("Present", "endpoint_files.present"),
+                            // This one is absent from the translated spec below.
+                            {
+                                id: "missing",
+                                name: "Missing",
+                                originalEndpointId: "endpoint_files.missing",
+                                method: "GET",
+                                path: { parts: [{ type: "literal", value: "/drift/missing" }], pathParameters: [] }
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        const translatedApis = {
+            [API_OK]: makeApi({
+                subpackages: {
+                    subpackage_アカウント: {
+                        name: "アカウント",
+                        endpoints: [okEndpoint("一覧", "endpoint_アカウント.index")]
+                    }
+                }
+            }),
+            [API_DRIFT]: makeApi({
+                subpackages: {
+                    subpackage_ファイル: {
+                        name: "ファイル",
+                        endpoints: [driftPresent("存在", "endpoint_ファイル.present")]
+                    }
+                }
+            })
+        };
+        const root = {
+            type: "root",
+            children: [
+                { type: "endpoint", endpointId: "endpoint_accounts.index", apiDefinitionId: API_OK, title: "List" },
+                {
+                    type: "endpoint",
+                    endpointId: "endpoint_files.present",
+                    apiDefinitionId: API_DRIFT,
+                    title: "Present"
+                },
+                { type: "endpoint", endpointId: "endpoint_files.missing", apiDefinitionId: API_DRIFT, title: "Missing" }
+            ]
+        };
+
+        const incompatible = findIncompatibleTranslatedApiIds(asRoot(root), baseApis, translatedApis);
+        expect(incompatible.has(API_OK)).toBe(false);
+        expect(incompatible.has(API_DRIFT)).toBe(true);
+
+        const rewritableApiIds = new Set(Object.keys(translatedApis).filter((apiId) => !incompatible.has(apiId)));
+        const result = applyTranslatedApiTitlesToNavTree(asRoot(root), baseApis, translatedApis, {
+            rewritableApiIds
+        });
+        const children = (
+            result as unknown as {
+                children: Array<{ title: string; endpointId: string }>;
+            }
+        ).children;
+
+        // Compatible API: title localized AND id repointed to the translated definition.
+        expect(children[0]?.title).toBe("一覧");
+        expect(children[0]?.endpointId).toBe("endpoint_アカウント.index");
+
+        // Drifted API, matchable node: title localized but id kept (base definition is served).
+        expect(children[1]?.title).toBe("存在");
+        expect(children[1]?.endpointId).toBe("endpoint_files.present");
+
+        // Drifted API, unmatchable node: left fully untouched.
+        expect(children[2]?.title).toBe("Missing");
+        expect(children[2]?.endpointId).toBe("endpoint_files.missing");
+    });
+
+    describe("findIncompatibleTranslatedApiIds", () => {
+        it("returns no incompatible ids when endpoints match by locator despite renamed ids", () => {
+            const baseApis = {
+                [API_ID]: makeApi({
+                    subpackages: {
+                        subpackage_accountPermissions: {
+                            name: "accountPermissions",
+                            endpoints: [
+                                {
+                                    id: "index",
+                                    originalEndpointId: "endpoint_accountPermissions.index",
+                                    method: "GET",
+                                    path: { parts: [{ type: "literal", value: "/v4/roles" }], pathParameters: [] }
+                                }
+                            ]
+                        }
+                    }
+                })
+            };
+            const translatedApis = {
+                [API_ID]: makeApi({
+                    subpackages: {
+                        subpackage_blabla: {
+                            name: "blabla",
+                            endpoints: [
+                                {
+                                    id: "index",
+                                    originalEndpointId: "endpoint_blabla.index",
+                                    method: "GET",
+                                    path: { parts: [{ type: "literal", value: "/v4/roles" }], pathParameters: [] }
+                                }
+                            ]
+                        }
+                    }
+                })
+            };
+            const root = {
+                type: "root",
+                child: {
+                    type: "endpoint",
+                    endpointId: "endpoint_accountPermissions.index",
+                    apiDefinitionId: API_ID,
+                    title: "List"
+                }
+            };
+
+            const incompatible = findIncompatibleTranslatedApiIds(asRoot(root), baseApis, translatedApis);
+            expect(incompatible.size).toBe(0);
+        });
+
+        it("flags an API whose nav endpoint cannot be matched (path changed too)", () => {
+            const baseApis = {
+                [API_ID]: makeApi({
+                    rootEndpoints: [
+                        {
+                            id: "index",
+                            originalEndpointId: "ep.index",
+                            method: "GET",
+                            path: { parts: [{ type: "literal", value: "/v4/roles" }], pathParameters: [] }
+                        }
+                    ]
+                })
+            };
+            const translatedApis = {
+                [API_ID]: makeApi({
+                    rootEndpoints: [
+                        {
+                            id: "index",
+                            originalEndpointId: "ep.renamed",
+                            method: "GET",
+                            path: { parts: [{ type: "literal", value: "/v4/roles-renamed" }], pathParameters: [] }
+                        }
+                    ]
+                })
+            };
+            const root = {
+                type: "root",
+                child: {
+                    type: "endpoint",
+                    endpointId: "ep.index",
+                    apiDefinitionId: API_ID,
+                    title: "List"
+                }
+            };
+
+            const incompatible = findIncompatibleTranslatedApiIds(asRoot(root), baseApis, translatedApis);
+            expect(incompatible.has(API_ID)).toBe(true);
+        });
+
+        it("flags an API when a base nav endpoint is missing entirely from the translated spec", () => {
+            // The customer's real failure mode: the translated spec drifted and dropped an
+            // endpoint the base nav tree still references.
+            const baseApis = {
+                [API_ID]: makeApi({
+                    rootEndpoints: [
+                        {
+                            id: "present",
+                            originalEndpointId: "ep.present",
+                            method: "GET",
+                            path: { parts: [{ type: "literal", value: "/present" }], pathParameters: [] }
+                        },
+                        {
+                            id: "missing",
+                            originalEndpointId: "ep.missing",
+                            method: "GET",
+                            path: { parts: [{ type: "literal", value: "/missing" }], pathParameters: [] }
+                        }
+                    ]
+                })
+            };
+            const translatedApis = {
+                [API_ID]: makeApi({
+                    rootEndpoints: [
+                        {
+                            id: "present",
+                            originalEndpointId: "ep.present",
+                            method: "GET",
+                            path: { parts: [{ type: "literal", value: "/present" }], pathParameters: [] }
+                        }
+                    ]
+                })
+            };
+            const root = {
+                type: "root",
+                children: [
+                    { type: "endpoint", endpointId: "ep.present", apiDefinitionId: API_ID, title: "Present" },
+                    { type: "endpoint", endpointId: "ep.missing", apiDefinitionId: API_ID, title: "Missing" }
+                ]
+            };
+
+            const incompatible = findIncompatibleTranslatedApiIds(asRoot(root), baseApis, translatedApis);
+            expect(incompatible.has(API_ID)).toBe(true);
+        });
+
+        it("flags a translated API that has no base counterpart", () => {
+            const incompatible = findIncompatibleTranslatedApiIds(
+                asRoot({ type: "root", child: {} }),
+                {},
+                { [API_ID]: makeApi({ rootEndpoints: [{ id: "a", originalEndpointId: "a.id" }] }) }
+            );
+            expect(incompatible.has(API_ID)).toBe(true);
+        });
     });
 });

--- a/packages/cli/docs-resolver/src/applyTranslatedApiTitlesToNavTree.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedApiTitlesToNavTree.ts
@@ -1,13 +1,307 @@
 import { titleCase } from "@fern-api/core-utils";
 import { APIV1Read, FernNavigation } from "@fern-api/fdr-sdk";
 
-interface ApiTitleMaps {
-    endpoints: Map<string, string>;
-    webhooks: Map<string, string>;
-    webSockets: Map<string, string>;
-    graphql: Map<string, string>;
+/**
+ * Stringifies a path for use as a stable, translation-resistant locator.
+ *
+ * Path parameters are normalized to a positional placeholder (`{}`) rather than
+ * their declared name. A parameter's name is not what identifies an endpoint
+ * (method + literal path structure is), and some translators rename path
+ * parameters in translated specs, which would otherwise spuriously diverge the
+ * locator.
+ */
+function stringifyPathPartsForLocator(path: APIV1Read.EndpointPathPart[]): string {
+    return path.map((part) => (part.type === "literal" ? part.value : "{}")).join("");
+}
+
+/**
+ * Resolves a single base-locale API node id (and its translated title) against a
+ * translated API definition.
+ *
+ * Translations are expected to only localize human-readable *text*, leaving
+ * structural identifiers (OpenAPI tag names, operationIds, paths) untouched. In
+ * that common case the translated API shares the base API's node ids, so a node
+ * resolves by an exact id match.
+ *
+ * When a translator does change a structural identifier — most commonly an
+ * OpenAPI tag name, which is what derives subpackage and endpoint ids — the
+ * translated API's ids diverge from the base navigation tree. We recover from
+ * this by matching nodes on a stable locator (HTTP method + path), and report
+ * the translated id so the caller can repoint the navigation node at it. This
+ * keeps the localized title *and* prevents the docs renderer from looking up a
+ * node id that no longer exists in the served API (which previously surfaced as
+ * a 500 / PruneEmptyError).
+ */
+interface TranslatedNodeMatch {
+    /** The id of the matching node in the translated API (may equal the base id). */
+    translatedId: string;
+    /** The translated, human-readable title, when present. */
+    title: string | undefined;
+}
+
+interface ApplyTranslatedApiTitlesOptions {
+    /**
+     * The set of `apiDefinitionId`s whose nav node ids may be repointed at the
+     * translated definition. When omitted, all APIs are eligible (the translated
+     * definition is assumed to be served for every API). Pass the set of
+     * fully-matchable APIs (see {@link findIncompatibleTranslatedApiIds}) when the
+     * base definition is served for drifted APIs, so their nav ids stay resolvable.
+     */
+    rewritableApiIds?: ReadonlySet<string>;
+}
+
+interface ApiTranslationResolver {
+    resolveEndpoint(baseNavId: string): TranslatedNodeMatch | undefined;
+    resolveWebhook(baseNavId: string): TranslatedNodeMatch | undefined;
+    resolveWebSocket(baseNavId: string): TranslatedNodeMatch | undefined;
+    /** GraphQL operation titles keyed by their (stable) operation id. */
+    graphqlTitlesById: Map<string, string>;
     /** Subpackage grouping titles, keyed by the default-locale (base) computed title. */
     packagesByBaseTitle: Map<string, string>;
+}
+
+function endpointLocator(endpoint: APIV1Read.EndpointDefinition): string {
+    return `${endpoint.method} ${stringifyPathPartsForLocator(endpoint.path.parts)}`;
+}
+
+function webhookLocator(webhook: APIV1Read.WebhookDefinition): string {
+    return `${webhook.method} ${webhook.path.join("/")}`;
+}
+
+function webSocketLocator(webSocket: APIV1Read.WebSocketChannel): string {
+    return `WSS ${stringifyPathPartsForLocator(webSocket.path.parts)}`;
+}
+
+function nonEmptyTitle(name: string | null | undefined): string | undefined {
+    return name != null && name.length > 0 ? name : undefined;
+}
+
+function subpackageTitle(pkg: { name: string; displayName?: string | null }): string {
+    return pkg.displayName ?? titleCase(pkg.name);
+}
+
+function subpackageLocators(pkg: APIV1Read.ApiDefinitionSubpackage): string[] {
+    return [
+        ...pkg.endpoints.map(endpointLocator),
+        ...pkg.webhooks.map(webhookLocator),
+        ...pkg.websockets.map(webSocketLocator)
+    ];
+}
+
+/**
+ * Builds a per-locator → translated-id index plus a base-id → locator index for a
+ * single node kind, so a base navigation id can be resolved to its translated
+ * counterpart either directly (id unchanged) or via its stable locator.
+ */
+function buildResolverForKind<TDef>(
+    baseEntries: ReadonlyMap<string, TDef>,
+    translatedEntries: ReadonlyMap<string, TDef>,
+    locatorOf: (def: TDef) => string,
+    titleOf: (def: TDef) => string | undefined
+): (baseNavId: string) => TranslatedNodeMatch | undefined {
+    const translatedIdByLocator = new Map<string, string>();
+    for (const [navId, def] of translatedEntries) {
+        // First writer wins; duplicate locators within one API are not expected.
+        if (!translatedIdByLocator.has(locatorOf(def))) {
+            translatedIdByLocator.set(locatorOf(def), navId);
+        }
+    }
+
+    return (baseNavId: string): TranslatedNodeMatch | undefined => {
+        const exact = translatedEntries.get(baseNavId);
+        if (exact != null) {
+            return { translatedId: baseNavId, title: titleOf(exact) };
+        }
+        const baseDef = baseEntries.get(baseNavId);
+        if (baseDef == null) {
+            return undefined;
+        }
+        const translatedId = translatedIdByLocator.get(locatorOf(baseDef));
+        if (translatedId == null) {
+            return undefined;
+        }
+        const translatedDef = translatedEntries.get(translatedId);
+        return { translatedId, title: translatedDef != null ? titleOf(translatedDef) : undefined };
+    };
+}
+
+function buildPackagesByBaseTitle(
+    baseApi: APIV1Read.ApiDefinition,
+    translatedApi: APIV1Read.ApiDefinition
+): Map<string, string> {
+    const packagesByBaseTitle = new Map<string, string>();
+
+    // Id-based matching: handles the common case where the tag name (and thus the
+    // subpackage id) is unchanged and only the display text differs. Also covers
+    // grouping subpackages that have no endpoints of their own.
+    for (const [subpackageId, translatedSubpackage] of Object.entries(translatedApi.subpackages)) {
+        const baseSubpackage = baseApi.subpackages[subpackageId];
+        if (baseSubpackage == null) {
+            continue;
+        }
+        const baseTitle = subpackageTitle(baseSubpackage);
+        const translatedTitle = subpackageTitle(translatedSubpackage);
+        if (baseTitle !== translatedTitle) {
+            packagesByBaseTitle.set(baseTitle, translatedTitle);
+        }
+    }
+
+    // Membership-based matching: when the tag name was translated, the subpackage
+    // id diverges, so id-based matching misses it. Pair base and translated
+    // subpackages by a shared endpoint/webhook/websocket locator instead.
+    const baseTitleByLocator = new Map<string, string>();
+    for (const baseSubpackage of Object.values(baseApi.subpackages)) {
+        const baseTitle = subpackageTitle(baseSubpackage);
+        for (const locator of subpackageLocators(baseSubpackage)) {
+            if (!baseTitleByLocator.has(locator)) {
+                baseTitleByLocator.set(locator, baseTitle);
+            }
+        }
+    }
+    for (const translatedSubpackage of Object.values(translatedApi.subpackages)) {
+        const translatedTitle = subpackageTitle(translatedSubpackage);
+        for (const locator of subpackageLocators(translatedSubpackage)) {
+            const baseTitle = baseTitleByLocator.get(locator);
+            if (baseTitle != null && baseTitle !== translatedTitle && !packagesByBaseTitle.has(baseTitle)) {
+                packagesByBaseTitle.set(baseTitle, translatedTitle);
+            }
+        }
+    }
+
+    return packagesByBaseTitle;
+}
+
+function buildApiTranslationResolvers(
+    baseApis: Record<string, APIV1Read.ApiDefinition>,
+    translatedApis: Record<string, APIV1Read.ApiDefinition>
+): Map<string, ApiTranslationResolver> {
+    const resolvers = new Map<string, ApiTranslationResolver>();
+    for (const [apiId, translatedApi] of Object.entries(translatedApis)) {
+        const baseApi = baseApis[apiId];
+        if (baseApi == null) {
+            continue;
+        }
+        const baseHolder = FernNavigation.ApiDefinitionHolder.create(baseApi);
+        const translatedHolder = FernNavigation.ApiDefinitionHolder.create(translatedApi);
+
+        const resolveEndpoint = buildResolverForKind(
+            baseHolder.endpoints,
+            translatedHolder.endpoints,
+            endpointLocator,
+            (endpoint) => nonEmptyTitle(endpoint.name)
+        );
+        const resolveWebhook = buildResolverForKind(
+            baseHolder.webhooks,
+            translatedHolder.webhooks,
+            webhookLocator,
+            (webhook) => nonEmptyTitle(webhook.name)
+        );
+        const resolveWebSocket = buildResolverForKind(
+            baseHolder.webSockets,
+            translatedHolder.webSockets,
+            webSocketLocator,
+            (webSocket) => nonEmptyTitle(webSocket.name)
+        );
+
+        const graphqlTitlesById = new Map<string, string>();
+        for (const [id, operation] of translatedHolder.graphqlOperations) {
+            const name = operation.displayName ?? operation.name;
+            const title = nonEmptyTitle(name);
+            if (title != null) {
+                graphqlTitlesById.set(id, title);
+            }
+        }
+
+        resolvers.set(apiId, {
+            resolveEndpoint,
+            resolveWebhook,
+            resolveWebSocket,
+            graphqlTitlesById,
+            packagesByBaseTitle: buildPackagesByBaseTitle(baseApi, translatedApi)
+        });
+    }
+    return resolvers;
+}
+
+function getApiDefinitionId(node: Record<string, unknown>): string | undefined {
+    return typeof node.apiDefinitionId === "string" ? node.apiDefinitionId : undefined;
+}
+
+function visitNavigationNodes(node: unknown, callback: (node: Record<string, unknown>) => void): void {
+    if (node == null || typeof node !== "object") {
+        return;
+    }
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            visitNavigationNodes(item, callback);
+        }
+        return;
+    }
+    const obj = node as Record<string, unknown>;
+    callback(obj);
+    for (const value of Object.values(obj)) {
+        visitNavigationNodes(value, callback);
+    }
+}
+
+/**
+ * Returns the set of `apiDefinitionId`s whose translated API definition is
+ * structurally incompatible with the base navigation tree — i.e. the nav tree
+ * references an endpoint/webhook/websocket node that cannot be matched (by id or
+ * by locator) in the translated API.
+ *
+ * This happens when a translated spec changes a structural identifier (most
+ * commonly an OpenAPI tag name, but also operationIds or paths). Serving such a
+ * definition would make the docs renderer fail to resolve nav nodes and return a
+ * 500. Callers should fall back to the base (default-locale) API for these ids.
+ */
+export function findIncompatibleTranslatedApiIds(
+    root: FernNavigation.V1.RootNode | undefined,
+    baseApis: Record<string, APIV1Read.ApiDefinition>,
+    translatedApis: Record<string, APIV1Read.ApiDefinition>
+): Set<string> {
+    const incompatible = new Set<string>();
+
+    // A translated API with no base counterpart can't be reconciled against the
+    // base-keyed nav tree.
+    for (const apiId of Object.keys(translatedApis)) {
+        if (baseApis[apiId] == null) {
+            incompatible.add(apiId);
+        }
+    }
+
+    if (root == null) {
+        return incompatible;
+    }
+
+    const resolvers = buildApiTranslationResolvers(baseApis, translatedApis);
+
+    visitNavigationNodes(root, (obj) => {
+        const apiDefinitionId = getApiDefinitionId(obj);
+        if (apiDefinitionId == null || incompatible.has(apiDefinitionId)) {
+            return;
+        }
+        const resolver = resolvers.get(apiDefinitionId);
+        if (resolver == null) {
+            return;
+        }
+        const type = obj.type;
+        if (type === "endpoint" && typeof obj.endpointId === "string") {
+            if (resolver.resolveEndpoint(obj.endpointId) == null) {
+                incompatible.add(apiDefinitionId);
+            }
+        } else if (type === "webhook" && typeof obj.webhookId === "string") {
+            if (resolver.resolveWebhook(obj.webhookId) == null) {
+                incompatible.add(apiDefinitionId);
+            }
+        } else if (type === "webSocket" && typeof obj.webSocketId === "string") {
+            if (resolver.resolveWebSocket(obj.webSocketId) == null) {
+                incompatible.add(apiDefinitionId);
+            }
+        }
+    });
+
+    return incompatible;
 }
 
 /**
@@ -16,122 +310,95 @@ interface ApiTitleMaps {
  * equivalents, so the left-hand sidebar isn't left in the default language when a
  * translated API definition is paired with the base navigation tree.
  *
- * Endpoint-like nodes are matched by the nav ids the tree was built from (via
- * {@link FernNavigation.ApiDefinitionHolder}). Subpackage grouping nodes don't
- * persist their subpackage id, so they are matched by their base-locale title,
- * which is unique within a single API.
+ * Endpoint-like nodes are matched first by the nav ids the tree was built from,
+ * and — when a translated spec changed a structural identifier such as an OpenAPI
+ * tag name — by a stable locator (HTTP method + path). In the latter case the
+ * node's id is also rewritten to the translated id so the docs renderer can
+ * resolve it against the served (translated) API. Subpackage grouping nodes don't
+ * persist their subpackage id, so they are matched by their base-locale title.
+ *
+ * For APIs whose translated spec has drifted from the base (see
+ * {@link findIncompatibleTranslatedApiIds}), the base definition is served, so
+ * pass those APIs *out* of `options.rewritableApiIds`: titles are still localized
+ * where a node matches by locator, but ids are left as the base ids the served
+ * definition exposes (preventing a 500 / PruneEmptyError). Unmatched nodes are
+ * left fully untouched.
  *
  * @param root - the navigation tree whose API titles should be localized
  * @param baseApis - default-locale API definitions, keyed by apiDefinitionId
- *   (used to derive subpackage base titles)
  * @param translatedApis - translated API definitions, keyed by the same apiDefinitionId
+ * @param options - see {@link ApplyTranslatedApiTitlesOptions}
  */
 export function applyTranslatedApiTitlesToNavTree(
     root: FernNavigation.V1.RootNode,
     baseApis: Record<string, APIV1Read.ApiDefinition>,
-    translatedApis: Record<string, APIV1Read.ApiDefinition>
+    translatedApis: Record<string, APIV1Read.ApiDefinition>,
+    options?: ApplyTranslatedApiTitlesOptions
 ): FernNavigation.V1.RootNode {
-    const mapsByApiId = new Map<string, ApiTitleMaps>();
-    for (const [apiId, translatedApi] of Object.entries(translatedApis)) {
-        const holder = FernNavigation.ApiDefinitionHolder.create(translatedApi);
+    const resolvers = buildApiTranslationResolvers(baseApis, translatedApis);
+    const rewritableApiIds = options?.rewritableApiIds;
 
-        const endpoints = new Map<string, string>();
-        for (const [id, endpoint] of holder.endpoints) {
-            if (endpoint.name != null && endpoint.name.length > 0) {
-                endpoints.set(id, endpoint.name);
-            }
-        }
-        const webhooks = new Map<string, string>();
-        for (const [id, webhook] of holder.webhooks) {
-            if (webhook.name != null && webhook.name.length > 0) {
-                webhooks.set(id, webhook.name);
-            }
-        }
-        const webSockets = new Map<string, string>();
-        for (const [id, webSocket] of holder.webSockets) {
-            if (webSocket.name != null && webSocket.name.length > 0) {
-                webSockets.set(id, webSocket.name);
-            }
-        }
-        const graphql = new Map<string, string>();
-        for (const [id, operation] of holder.graphqlOperations) {
-            const name = operation.displayName ?? operation.name;
-            if (name != null && name.length > 0) {
-                graphql.set(id, name);
-            }
-        }
-
-        // Matched by base-locale title; only record entries whose title actually
-        // changes, so untranslated subpackages are left alone.
-        const packagesByBaseTitle = new Map<string, string>();
-        const baseApi = baseApis[apiId];
-        if (baseApi != null) {
-            for (const [subpackageId, translatedSubpackage] of Object.entries(translatedApi.subpackages)) {
-                const baseSubpackage = baseApi.subpackages[subpackageId];
-                if (baseSubpackage == null) {
-                    continue;
-                }
-                const baseTitle = baseSubpackage.displayName ?? titleCase(baseSubpackage.name);
-                const translatedTitle = translatedSubpackage.displayName ?? titleCase(translatedSubpackage.name);
-                if (baseTitle !== translatedTitle) {
-                    packagesByBaseTitle.set(baseTitle, translatedTitle);
-                }
-            }
-        }
-
-        mapsByApiId.set(apiId, { endpoints, webhooks, webSockets, graphql, packagesByBaseTitle });
-    }
+    // Whether nav node ids may be repointed at the translated definition for this
+    // API. This is only safe when the translated definition is actually served
+    // for the API (i.e. it can resolve *every* nav node). When the translated
+    // spec has drifted from the base, the base definition is served instead, so
+    // we localize titles but must keep the base ids the served API exposes.
+    const canRewriteIds = (apiDefinitionId: string): boolean =>
+        rewritableApiIds == null || rewritableApiIds.has(apiDefinitionId);
 
     // Deep clone so we never mutate the base nav tree, which may be shared by reference.
     const clone = structuredClone(root);
 
-    const visit = (node: unknown): void => {
-        if (node == null || typeof node !== "object") {
+    visitNavigationNodes(clone, (obj) => {
+        const apiDefinitionId = getApiDefinitionId(obj);
+        const resolver = apiDefinitionId != null ? resolvers.get(apiDefinitionId) : undefined;
+        if (resolver == null || apiDefinitionId == null) {
             return;
         }
-        if (Array.isArray(node)) {
-            for (const item of node) {
-                visit(item);
-            }
-            return;
-        }
-        const obj = node as Record<string, unknown>;
-        const apiDefinitionId = typeof obj.apiDefinitionId === "string" ? obj.apiDefinitionId : undefined;
-        const maps = apiDefinitionId != null ? mapsByApiId.get(apiDefinitionId) : undefined;
-        if (maps != null) {
-            const type = obj.type;
-            if (type === "endpoint" && typeof obj.endpointId === "string") {
-                const translated = maps.endpoints.get(obj.endpointId);
-                if (translated != null) {
-                    obj.title = translated;
+        const rewriteIds = canRewriteIds(apiDefinitionId);
+        const type = obj.type;
+        if (type === "endpoint" && typeof obj.endpointId === "string") {
+            const match = resolver.resolveEndpoint(obj.endpointId);
+            if (match != null) {
+                if (rewriteIds) {
+                    obj.endpointId = match.translatedId;
                 }
-            } else if (type === "webhook" && typeof obj.webhookId === "string") {
-                const translated = maps.webhooks.get(obj.webhookId);
-                if (translated != null) {
-                    obj.title = translated;
-                }
-            } else if (type === "webSocket" && typeof obj.webSocketId === "string") {
-                const translated = maps.webSockets.get(obj.webSocketId);
-                if (translated != null) {
-                    obj.title = translated;
-                }
-            } else if (type === "graphql" && typeof obj.graphqlOperationId === "string") {
-                const translated = maps.graphql.get(obj.graphqlOperationId);
-                if (translated != null) {
-                    obj.title = translated;
-                }
-            } else if (type === "apiPackage" && typeof obj.title === "string") {
-                const translated = maps.packagesByBaseTitle.get(obj.title);
-                if (translated != null) {
-                    obj.title = translated;
+                if (match.title != null) {
+                    obj.title = match.title;
                 }
             }
+        } else if (type === "webhook" && typeof obj.webhookId === "string") {
+            const match = resolver.resolveWebhook(obj.webhookId);
+            if (match != null) {
+                if (rewriteIds) {
+                    obj.webhookId = match.translatedId;
+                }
+                if (match.title != null) {
+                    obj.title = match.title;
+                }
+            }
+        } else if (type === "webSocket" && typeof obj.webSocketId === "string") {
+            const match = resolver.resolveWebSocket(obj.webSocketId);
+            if (match != null) {
+                if (rewriteIds) {
+                    obj.webSocketId = match.translatedId;
+                }
+                if (match.title != null) {
+                    obj.title = match.title;
+                }
+            }
+        } else if (type === "graphql" && typeof obj.graphqlOperationId === "string") {
+            const translated = resolver.graphqlTitlesById.get(obj.graphqlOperationId);
+            if (translated != null) {
+                obj.title = translated;
+            }
+        } else if (type === "apiPackage" && typeof obj.title === "string") {
+            const translated = resolver.packagesByBaseTitle.get(obj.title);
+            if (translated != null) {
+                obj.title = translated;
+            }
         }
-        for (const value of Object.values(obj)) {
-            visit(value);
-        }
-    };
+    });
 
-    visit(clone);
     return clone;
 }

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -8,7 +8,10 @@ export {
     stripMdxComments,
     transformAtPrefixImports
 } from "@fern-api/docs-markdown-utils";
-export { applyTranslatedApiTitlesToNavTree } from "./applyTranslatedApiTitlesToNavTree.js";
+export {
+    applyTranslatedApiTitlesToNavTree,
+    findIncompatibleTranslatedApiIds
+} from "./applyTranslatedApiTitlesToNavTree.js";
 export { applyTranslatedFrontmatterToNavTree } from "./applyTranslatedFrontmatterToNavTree.js";
 export {
     applyTranslatedNavigationOverlays,

--- a/packages/cli/docs-resolver/vitest.config.ts
+++ b/packages/cli/docs-resolver/vitest.config.ts
@@ -1,14 +1,23 @@
-import { defaultConfig, defineConfig, mergeConfig } from "@fern-api/configs/vitest/base.mjs";
+import { defaultConfig, defineConfig } from "@fern-api/configs/vitest/base.mjs";
 
-export default mergeConfig(
-    defaultConfig,
-    defineConfig({
-        test: {
-            server: {
-                deps: {
-                    inline: ["@fern-api/ui-core-utils"]
-                }
-            }
-        }
-    })
-);
+// `src/__test__` also holds heavier integration tests that currently fail to load
+// their API workspace fixtures in this environment, so we can't run the whole
+// directory (the shared base config's `**/*.{test,spec}.ts` glob would pick them
+// up). Until those are fixed, run the util tests plus the (pure) docs translation
+// unit tests explicitly. Add new pure unit tests here as they are written.
+const include = [
+    "src/utils/__test__/**/*.test.ts",
+    "src/__test__/applyTranslatedApiTitlesToNavTree.test.ts",
+    "src/__test__/applyTranslatedFrontmatterToNavTree.test.ts",
+    "src/__test__/applyTranslatedNavigationOverlays.test.ts",
+    "src/__test__/translations-config.test.ts",
+    "src/__test__/sidebar-title.test.ts"
+];
+
+export default defineConfig({
+    ...defaultConfig,
+    test: {
+        ...defaultConfig.test,
+        include
+    }
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -8,6 +8,7 @@ import {
     applyTranslatedFrontmatterToNavTree,
     applyTranslatedNavigationOverlays,
     DocsDefinitionResolver,
+    findIncompatibleTranslatedApiIds,
     getTranslatedAnnouncement,
     type RegisterApiFn,
     replaceImagePathsAndUrls,
@@ -1126,6 +1127,34 @@ export async function publishDocs({
                                     translatedApisForTitles[baseApiId] = translatedRead;
                                 }
                             }
+
+                            // A translated spec that drifts from the base — a changed OpenAPI tag
+                            // name (which derives subpackage/endpoint ids), a missing/added
+                            // endpoint, or a changed path — produces an API whose nav nodes can't
+                            // all be resolved against it. Repointing the nav at such a definition
+                            // would make the docs renderer fail to resolve a node and 500. For those
+                            // APIs we keep the nav pointed at the base (default-locale) definition,
+                            // but still localize the sidebar titles we can match by locator.
+                            const incompatibleApiIds = findIncompatibleTranslatedApiIds(
+                                updatedRoot,
+                                baseApisForTitles,
+                                translatedApisForTitles
+                            );
+                            if (incompatibleApiIds.size > 0) {
+                                context.logger.warn(
+                                    `Translated API definition(s) [${Array.from(incompatibleApiIds).join(", ")}] for ` +
+                                        `locale "${locale}" diverge from the default-locale spec (e.g. changed OpenAPI ` +
+                                        `tag names, operationIds, or paths, or a missing/added endpoint), so they can't ` +
+                                        `be fully matched to the navigation tree. Serving the default-locale API for ` +
+                                        `those (localized sidebar titles are still applied where they can be matched). ` +
+                                        `For fully localized API reference content, translate only human-readable text ` +
+                                        `and keep tag names/operationIds/paths identical to the base spec.`
+                                );
+                            }
+                            const rewritableApiIds = new Set(
+                                Object.keys(translatedApisForTitles).filter((apiId) => !incompatibleApiIds.has(apiId))
+                            );
+
                             // Work on a deep clone before the in-place id rewrite below, since
                             // locales run concurrently off the shared base nav tree. Title
                             // patching already clones, so only clone explicitly when it's skipped.
@@ -1134,10 +1163,16 @@ export async function publishDocs({
                                     ? applyTranslatedApiTitlesToNavTree(
                                           updatedRoot,
                                           baseApisForTitles,
-                                          translatedApisForTitles
+                                          translatedApisForTitles,
+                                          { rewritableApiIds }
                                       )
                                     : structuredClone(updatedRoot);
                             for (const [baseApiId, translatedApiId] of localeApiIdMap) {
+                                // Keep the base apiDefinitionId for incompatible APIs so the nav
+                                // resolves against the base definition instead of the divergent one.
+                                if (incompatibleApiIds.has(baseApiId)) {
+                                    continue;
+                                }
                                 updateApiDefinitionIdInTree(updatedRoot, baseApiId, translatedApiId);
                             }
                         }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,6 +1,7 @@
 import {
     applyTranslatedApiTitlesToNavTree,
     type DocsDefinitionResolver,
+    findIncompatibleTranslatedApiIds,
     type TranslatedApiSpec
 } from "@fern-api/docs-resolver";
 import {
@@ -672,11 +673,48 @@ export async function buildAllTranslationInputs({
                             }
                         }
                     }
+
+                    // A translated spec that drifts from the base — a changed OpenAPI tag name
+                    // (which derives subpackage/endpoint ids), a missing/added endpoint, or a
+                    // changed path — produces an API whose nav nodes can't all be resolved
+                    // against it. Serving it would make the docs renderer fail to resolve a
+                    // node and 500. For those APIs we serve the base (default-locale) definition
+                    // and keep the base nav ids, but still localize the sidebar titles we can
+                    // match by locator.
+                    const incompatibleApiIds = findIncompatibleTranslatedApiIds(
+                        translatedDefinition.config.root,
+                        baseReadApis,
+                        translatedApisForTitles
+                    );
+                    if (incompatibleApiIds.size > 0) {
+                        context.logger.warn(
+                            `Translated API definition(s) [${Array.from(incompatibleApiIds).join(", ")}] for locale ` +
+                                `"${locale}" diverge from the default-locale spec (e.g. changed OpenAPI tag names, ` +
+                                `operationIds, or paths, or a missing/added endpoint), so they can't be fully matched ` +
+                                `to the navigation tree. Serving the default-locale API for those (localized sidebar ` +
+                                `titles are still applied where they can be matched). For fully localized API reference ` +
+                                `content, translate only human-readable text and keep tag names/operationIds/paths ` +
+                                `identical to the base spec.`
+                        );
+                        for (const apiId of incompatibleApiIds) {
+                            // Serve the base definition (with base ids) for the drifted API so
+                            // the nav nodes still resolve; titles are localized below.
+                            const baseDef = apiDefinitions.get(apiId);
+                            if (baseDef != null) {
+                                localeApiDefinitions.set(apiId, baseDef);
+                            }
+                        }
+                    }
+                    const rewritableApiIds = new Set(
+                        Object.keys(translatedApisForTitles).filter((apiId) => !incompatibleApiIds.has(apiId))
+                    );
+
                     if (Object.keys(translatedApisForTitles).length > 0) {
                         translatedDefinition.config.root = applyTranslatedApiTitlesToNavTree(
                             translatedDefinition.config.root,
                             baseReadApis,
-                            translatedApisForTitles
+                            translatedApisForTitles,
+                            { rewritableApiIds }
                         );
                     }
                 }


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11458

Fix localized docs builds so translated OpenAPI specs that rename API tags no longer cause API reference navigation to 500.

This also lets translated sidebar titles apply when tag-derived endpoint/subpackage ids diverge by matching API nav nodes via stable locators, while gracefully falling back to the default-locale API when a translated spec has drifted too far to safely serve.

## Changes Made
- Match translated API nav nodes by stable endpoint/webhook/websocket locators in addition to exact ids.
- Rewrite nav ids to translated ids only when the translated API can be safely served; otherwise keep base ids and localize titles where possible.
- Detect incompatible translated API definitions and fall back to the default-locale API instead of allowing `PruneEmptyError` / 500s.
- Apply the same behavior in local docs preview and both docs publish paths.
- Add regression coverage for renamed tags, missing translated endpoints, path-parameter rename tolerance, mixed compatible/drifted APIs, webhooks, and websockets.
- Wire pure docs translation unit tests into `@fern-api/docs-resolver`'s test script via `vitest.config.ts`.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- `pnpm turbo run test --filter @fern-api/docs-resolver --force`
- `pnpm turbo run compile --filter @fern-api/docs-resolver --force`
- `pnpm turbo run compile --filter @fern-api/docs-preview --filter @fern-api/remote-workspace-runner --filter @fern-api/docs-resolver`
- `pnpm fern:build`
- Manually verified Frame.io localized docs page returns 200 and shows the localized `アカウント権限テスト` sidebar title.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->