### PR TITLE
fix(ruby): handle unknown types in dynamic snippets generation

### DIFF
--- a/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
+++ b/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
@@ -331,6 +331,16 @@ export class TypeLiteral extends AstNode {
             writer.write("[]");
             return;
         }
+        // Use %w[] for arrays where every element is a simple string with no
+        // spaces, backslashes, or brackets that would break the syntax. Mirrors
+        // the list case so rubocop's Style/WordArray is satisfied.
+        if (
+            value.length >= 2 &&
+            value.every((element): element is string => typeof element === "string" && !/[\s\\[\]]/.test(element))
+        ) {
+            writer.write(`%w[${value.join(" ")}]`);
+            return;
+        }
         writer.write("[");
         value.forEach((element, index) => {
             if (index > 0) {

--- a/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
+++ b/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
@@ -8,7 +8,7 @@ export interface NamedValue {
     value: AstNode;
 }
 
-type InternalTypeLiteral = Str | InterpolatedStr | Int | Float | Bool | Hash | Set_ | List_ | Nop | Nil;
+type InternalTypeLiteral = Str | InterpolatedStr | Int | Float | Bool | Hash | Set_ | List_ | Nop | Nil | Unknown;
 
 interface Str {
     type: "str";
@@ -61,6 +61,11 @@ interface Nop {
 
 interface Nil {
     type: "nil";
+}
+
+interface Unknown {
+    type: "unknown";
+    value: unknown;
 }
 
 export class TypeLiteral extends AstNode {
@@ -134,6 +139,10 @@ export class TypeLiteral extends AstNode {
 
     public static nil(): TypeLiteral {
         return new this({ type: "nil" });
+    }
+
+    public static unknown(value: unknown): TypeLiteral {
+        return new this({ type: "unknown", value });
     }
 
     public static isNop(typeLiteral: AstNode): boolean {
@@ -281,9 +290,78 @@ export class TypeLiteral extends AstNode {
             case "nil":
                 writer.write("nil");
                 break;
+            case "unknown":
+                this.writeUnknown({ writer, value: this.internalType.value });
+                break;
             default:
                 assertNever(this.internalType);
         }
+    }
+
+    private writeUnknown({ writer, value }: { writer: Writer; value: unknown }): void {
+        switch (typeof value) {
+            case "boolean":
+                writer.write(value ? "true" : "false");
+                return;
+            case "string":
+                TypeLiteral.string(value).write(writer);
+                return;
+            case "number":
+                writer.write(value.toString());
+                return;
+            case "object":
+                if (value == null) {
+                    writer.write("nil");
+                    return;
+                }
+                if (Array.isArray(value)) {
+                    this.writeUnknownArray({ writer, value });
+                    return;
+                }
+                this.writeUnknownObject({ writer, value });
+                return;
+            default:
+                writer.write("nil");
+                return;
+        }
+    }
+
+    private writeUnknownArray({ writer, value }: { writer: Writer; value: unknown[] }): void {
+        if (value.length === 0) {
+            writer.write("[]");
+            return;
+        }
+        writer.write("[");
+        value.forEach((element, index) => {
+            if (index > 0) {
+                writer.write(", ");
+            }
+            TypeLiteral.unknown(element).write(writer);
+        });
+        writer.write("]");
+    }
+
+    private writeUnknownObject({ writer, value }: { writer: Writer; value: object }): void {
+        const entries = Object.entries(value);
+        if (entries.length === 0) {
+            writer.write("{}");
+            return;
+        }
+        writer.write("{\n");
+        entries.forEach(([key, val], index) => {
+            if (index > 0) {
+                writer.writeLine(",");
+            }
+            writer.indent();
+            if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) {
+                writer.write(`${key}: `);
+            } else {
+                writer.write(`"${key}" => `);
+            }
+            TypeLiteral.unknown(val).write(writer);
+            writer.dedent();
+        });
+        writer.write("\n}");
     }
 }
 

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -43,7 +43,14 @@ client.service.create_big_entity(
     rating: 8.5,
     type: "movie",
     tag: "tag-12efs9dv",
-    metadata: {},
+    metadata: {
+      academyAward: true,
+      releaseDate: "2023-12-08",
+      ratings: {
+        rottenTomatoes: 97,
+        imdb: 7.6
+      }
+    },
     revenue: 1000000
   },
   migration: {
@@ -79,7 +86,14 @@ client.service.create_movie(
   rating: 8,
   type: "movie",
   tag: "development",
-  metadata: {},
+  metadata: {
+    actors: ["Christian Bale", "Florence Pugh", "Willem Dafoe"],
+    releaseDate: "2023-12-08",
+    ratings: {
+      rottenTomatoes: 97,
+      imdb: 7.6
+    }
+  },
   revenue: 1000000
 )
 "

--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicToLiteralMapper.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicToLiteralMapper.ts
@@ -62,7 +62,7 @@ export class DynamicTypeLiteralMapper {
             case "set":
                 return this.convertSet({ set: args.typeReference.value, value: args.value });
             case "unknown":
-                return ruby.TypeLiteral.nop();
+                return ruby.TypeLiteral.unknown(args.value);
             default:
                 assertNever(args.typeReference);
         }

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-unknown-type-snippets.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-unknown-type-snippets.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix dynamic snippets silently dropping values with unknown type references
+    (e.g. additionalProperties, free-form objects). Previously returned nop,
+    now properly serializes the raw value as a Ruby literal.
+  type: fix

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/README.md
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/README.md
@@ -30,7 +30,16 @@ require "seed"
 
 client = Seed::Client.new
 
-client.create_plant
+client.create_plant(request: {
+  name: "Venus Flytrap",
+  species: "Dionaea muscipula",
+  care: {
+    light: "full sun",
+    water: "distilled only",
+    humidity: "high"
+  },
+  tags: %w[carnivorous tropical]
+})
 ```
 
 ## Environments

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example0/snippet.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example0/snippet.rb
@@ -2,4 +2,13 @@ require "seed"
 
 client = Seed::Client.new(base_url: "https://api.fern.com")
 
-client.create_plant
+client.create_plant(request: {
+  name: "Venus Flytrap",
+  species: "Dionaea muscipula",
+  care: {
+    light: "full sun",
+    water: "distilled only",
+    humidity: "high"
+  },
+  tags: %w[carnivorous tropical]
+})

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example1/snippet.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example1/snippet.rb
@@ -2,4 +2,6 @@ require "seed"
 
 client = Seed::Client.new(base_url: "https://api.fern.com")
 
-client.create_plant
+client.create_plant(request: {
+  key: "value"
+})

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example2/snippet.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example2/snippet.rb
@@ -2,4 +2,12 @@ require "seed"
 
 client = Seed::Client.new(base_url: "https://api.fern.com")
 
-client.update_plant(plant_id: "plantId")
+client.update_plant(
+  plant_id: "plantId",
+  body: {
+    name: "Updated Venus Flytrap",
+    care: {
+      light: "partial shade"
+    }
+  }
+)

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example3/snippet.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/dynamic-snippets/example3/snippet.rb
@@ -2,4 +2,9 @@ require "seed"
 
 client = Seed::Client.new(base_url: "https://api.fern.com")
 
-client.update_plant(plant_id: "plantId")
+client.update_plant(
+  plant_id: "plantId",
+  body: {
+    key: "value"
+  }
+)

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/reference.md
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/reference.md
@@ -26,7 +26,16 @@ Creates a plant with example JSON but no request body schema.
 <dd>
 
 ```ruby
-client.create_plant
+client.create_plant(request: {
+  name: "Venus Flytrap",
+  species: "Dionaea muscipula",
+  care: {
+    light: "full sun",
+    water: "distilled only",
+    humidity: "high"
+  },
+  tags: %w[carnivorous tropical]
+})
 ```
 </dd>
 </dl>
@@ -88,7 +97,15 @@ Updates a plant with example JSON but no request body schema.
 <dd>
 
 ```ruby
-client.update_plant(plant_id: "plantId")
+client.update_plant(
+  plant_id: "plantId",
+  body: {
+    name: "Updated Venus Flytrap",
+    care: {
+      light: "partial shade"
+    }
+  }
+)
 ```
 </dd>
 </dl>


### PR DESCRIPTION
## Description
The Ruby v2 dynamic snippets generator silently dropped values typed as `unknown` (e.g. `additionalProperties`, free-form objects). The `DynamicTypeLiteralMapper` mapped the `unknown` type reference to `ruby.TypeLiteral.nop()`, so the value never appeared in generated snippets.

## Changes Made
- Add an `unknown` variant to `TypeLiteral` (`generators/ruby-v2/ast/src/ast/TypeLiteral.ts`) with a `TypeLiteral.unknown(value)` factory and a `writeUnknown` writer that serializes the raw JS value into an idiomatic Ruby literal:
  - primitives (`boolean`/`string`/`number`) and `null` → `true`/`false`/string/number/`nil`
  - arrays → Ruby array literal, recursing per element
  - objects → Ruby hash literal, using `key: value` for identifier-safe keys and `"key" => value` otherwise, recursing per value
- Map the `unknown` type reference to the new literal in `DynamicToLiteralMapper.ts`:
  ```diff
  - return ruby.TypeLiteral.nop();
  + return ruby.TypeLiteral.unknown(args.value);
  ```
- Add an unreleased changelog entry (`type: fix`).

## Testing
- [x] `tsc` compiles clean for the `ruby-v2/ast` package containing the change
- [ ] Unit tests added/updated
- [ ] Manual testing completed

Note: this branch reproduces a fix authored in session https://app.devin.ai/sessions/5f542fdd1c6d4561a4c635e6569fcc30, which had read-only git access and could not push.

Link to Devin session: https://app.devin.ai/sessions/63d9a6a7c2c24ef8bed536b7579ae352
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->