### PR TITLE
fix(typescript): omit null query params instead of serializing as empty string

### DIFF
--- a/generators/typescript/model/type-reference-converters/src/TypeReferenceToStringExpressionConverter.ts
+++ b/generators/typescript/model/type-reference-converters/src/TypeReferenceToStringExpressionConverter.ts
@@ -120,7 +120,7 @@ export class TypeReferenceToStringExpressionConverter extends AbstractTypeRefere
             primitive: (type) => this.primitive(type, params),
             named: ({ shape }) => {
                 if (shape === FernIr.ShapeType.Enum) {
-                    return (reference) => reference;
+                    return this.jsonStringify.bind(this);
                 }
                 if (shape === FernIr.ShapeType.UndiscriminatedUnion) {
                     return this.jsonStringifyIfNotString.bind(this);

--- a/generators/typescript/model/type-reference-converters/src/TypeReferenceToStringExpressionConverter.ts
+++ b/generators/typescript/model/type-reference-converters/src/TypeReferenceToStringExpressionConverter.ts
@@ -24,8 +24,8 @@ export class TypeReferenceToStringExpressionConverter extends AbstractTypeRefere
                 ts.factory.createConditionalExpression(
                     ts.factory.createBinaryExpression(
                         reference,
-                        ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsEqualsToken),
-                        ts.factory.createIdentifier("undefined")
+                        ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
+                        ts.factory.createNull()
                     ),
                     ts.factory.createToken(ts.SyntaxKind.QuestionToken),
                     this.convert(params)(reference),

--- a/generators/typescript/model/type-reference-converters/src/TypeReferenceToStringExpressionConverter.ts
+++ b/generators/typescript/model/type-reference-converters/src/TypeReferenceToStringExpressionConverter.ts
@@ -120,7 +120,7 @@ export class TypeReferenceToStringExpressionConverter extends AbstractTypeRefere
             primitive: (type) => this.primitive(type, params),
             named: ({ shape }) => {
                 if (shape === FernIr.ShapeType.Enum) {
-                    return this.jsonStringify.bind(this);
+                    return (reference) => reference;
                 }
                 if (shape === FernIr.ShapeType.UndiscriminatedUnion) {
                     return this.jsonStringifyIfNotString.bind(this);

--- a/generators/typescript/model/type-reference-converters/src/__test__/TypeReferenceConverters.test.ts
+++ b/generators/typescript/model/type-reference-converters/src/__test__/TypeReferenceConverters.test.ts
@@ -1308,7 +1308,7 @@ describe("TypeReferenceToStringExpressionConverter", () => {
             expect(result).toBe("val.toString()");
         });
 
-        it("wraps with !== undefined check for nullable reference", () => {
+        it("wraps with != null check for nullable reference", () => {
             const converter = createConverter({
                 isNullable: () => true
             });
@@ -1316,7 +1316,7 @@ describe("TypeReferenceToStringExpressionConverter", () => {
                 typeReference: nullableRef(primitiveRef("INTEGER"))
             });
             const result = getTextOfTsNode(fn(ts.factory.createIdentifier("val")));
-            expect(result).toContain("!== undefined");
+            expect(result).toContain("!= null");
             expect(result).toContain("toString");
         });
 

--- a/generators/typescript/sdk/changes/unreleased/fix-enum-query-param-serialization.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-enum-query-param-serialization.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix nullable enum query parameters being serialized as empty strings.
+    Changed null-check from strict equality (`!== undefined`) to loose equality
+    (`!= null`) so that both `null` and `undefined` are correctly omitted from
+    query parameters. Also updated the runtime `qs.ts` serializer to skip `null`
+    values instead of encoding them as empty strings.
+  type: fix

--- a/generators/typescript/sdk/changes/unreleased/fix-enum-query-param-serialization.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-enum-query-param-serialization.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix enum query parameter serialization in noSerdeLayer mode. Enum values
+    passed as query parameters were not being stringified, causing APIs to
+    receive malformed values (e.g. empty strings or `[object Object]`).
+  type: fix

--- a/generators/typescript/sdk/changes/unreleased/fix-enum-query-param-serialization.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-enum-query-param-serialization.yml
@@ -1,5 +1,0 @@
-- summary: |
-    Fix enum query parameter serialization in noSerdeLayer mode. Enum values
-    passed as query parameters were not being stringified, causing APIs to
-    receive malformed values (e.g. empty strings or `[object Object]`).
-  type: fix

--- a/generators/typescript/utils/core-utilities/src/core/url/qs.ts
+++ b/generators/typescript/utils/core-utilities/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/generators/typescript/utils/core-utilities/tests/unit/url/qs.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/accept-header/src/core/url/qs.ts
+++ b/seed/ts-sdk/accept-header/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/accept-header/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/alias-extends/src/core/url/qs.ts
+++ b/seed/ts-sdk/alias-extends/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/alias-extends/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/alias/src/core/url/qs.ts
+++ b/seed/ts-sdk/alias/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/alias/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/alias/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/allof-inline/src/core/url/qs.ts
+++ b/seed/ts-sdk/allof-inline/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/allof-inline/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/allof-inline/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/allof-inline/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/allof-inline/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/allof/src/core/url/qs.ts
+++ b/seed/ts-sdk/allof/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/allof/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/allof/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/allof/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/allof/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/any-auth/always-send-auth/src/core/url/qs.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/any-auth/always-send-auth/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/any-auth/always-send-auth/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/url/qs.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/api-wide-base-path-with-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/api-wide-base-path/src/core/url/qs.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/url/qs.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/url/qs.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/core/url/qs.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/basic-auth/src/core/url/qs.ts
+++ b/seed/ts-sdk/basic-auth/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/basic-auth/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/url/qs.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/bytes-download/src/core/url/qs.ts
+++ b/seed/ts-sdk/bytes-download/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/bytes-download/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/bytes-download/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/bytes-download/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/bytes-download/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/bytes-upload/src/core/url/qs.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/bytes-upload/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/circular-references-advanced/src/core/url/qs.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/circular-references-extends/src/core/url/qs.ts
+++ b/seed/ts-sdk/circular-references-extends/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/circular-references-extends/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/circular-references-extends/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/circular-references-extends/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/circular-references-extends/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/circular-references/src/core/url/qs.ts
+++ b/seed/ts-sdk/circular-references/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/circular-references/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/cli-multi-spec-namespaced/src/core/url/qs.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/cli-multi-spec/src/core/url/qs.ts
+++ b/seed/ts-sdk/cli-multi-spec/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/cli-multi-spec/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/cli-multi-spec/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/cli-multi-spec/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/cli-multi-spec/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/client-side-params/src/core/url/qs.ts
+++ b/seed/ts-sdk/client-side-params/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/client-side-params/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/client-side-params/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/content-type/src/core/url/qs.ts
+++ b/seed/ts-sdk/content-type/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/content-type/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/url/qs.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/dollar-string-examples/src/core/url/qs.ts
+++ b/seed/ts-sdk/dollar-string-examples/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/dollar-string-examples/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/dollar-string-examples/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/dollar-string-examples/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/dollar-string-examples/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/empty-clients/src/core/url/qs.ts
+++ b/seed/ts-sdk/empty-clients/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/empty-clients/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/endpoint-security-auth/src/core/url/qs.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/endpoint-security-auth/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/endpoint-security-auth/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/endpoint-security-auth/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/endpoint-security-auth/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/queryParam/client/Client.ts
@@ -45,8 +45,8 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand: toJson(operand),
-            maybeOperand: maybeOperand != null ? toJson(maybeOperand) : undefined,
+            operand,
+            maybeOperand: maybeOperand != null ? maybeOperand : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))
                 : typeof operandOrColor === "string"
@@ -120,11 +120,11 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand: Array.isArray(operand) ? operand.map((item) => toJson(item)) : toJson(operand),
+            operand: Array.isArray(operand) ? operand.map((item) => item) : operand,
             maybeOperand: Array.isArray(maybeOperand)
-                ? maybeOperand.map((item) => toJson(item))
+                ? maybeOperand.map((item) => item)
                 : maybeOperand != null
-                  ? toJson(maybeOperand)
+                  ? maybeOperand
                   : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/queryParam/client/Client.ts
@@ -45,8 +45,8 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand,
-            maybeOperand: maybeOperand != null ? maybeOperand : undefined,
+            operand: toJson(operand),
+            maybeOperand: maybeOperand != null ? toJson(maybeOperand) : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))
                 : typeof operandOrColor === "string"
@@ -120,11 +120,11 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand: Array.isArray(operand) ? operand.map((item) => item) : operand,
+            operand: Array.isArray(operand) ? operand.map((item) => toJson(item)) : toJson(operand),
             maybeOperand: Array.isArray(maybeOperand)
-                ? maybeOperand.map((item) => item)
+                ? maybeOperand.map((item) => toJson(item))
                 : maybeOperand != null
-                  ? maybeOperand
+                  ? toJson(maybeOperand)
                   : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/core/url/qs.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/queryParam/client/Client.ts
@@ -45,8 +45,8 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand: toJson(operand),
-            maybeOperand: maybeOperand != null ? toJson(maybeOperand) : undefined,
+            operand,
+            maybeOperand: maybeOperand != null ? maybeOperand : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))
                 : typeof operandOrColor === "string"
@@ -120,11 +120,11 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand: Array.isArray(operand) ? operand.map((item) => toJson(item)) : toJson(operand),
+            operand: Array.isArray(operand) ? operand.map((item) => item) : operand,
             maybeOperand: Array.isArray(maybeOperand)
-                ? maybeOperand.map((item) => toJson(item))
+                ? maybeOperand.map((item) => item)
                 : maybeOperand != null
-                  ? toJson(maybeOperand)
+                  ? maybeOperand
                   : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/queryParam/client/Client.ts
@@ -45,8 +45,8 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand,
-            maybeOperand: maybeOperand != null ? maybeOperand : undefined,
+            operand: toJson(operand),
+            maybeOperand: maybeOperand != null ? toJson(maybeOperand) : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))
                 : typeof operandOrColor === "string"
@@ -120,11 +120,11 @@ export class QueryParamClient {
     ): Promise<core.WithRawResponse<void>> {
         const { operand, maybeOperand, operandOrColor, maybeOperandOrColor } = request;
         const _queryParams: Record<string, unknown> = {
-            operand: Array.isArray(operand) ? operand.map((item) => item) : operand,
+            operand: Array.isArray(operand) ? operand.map((item) => toJson(item)) : toJson(operand),
             maybeOperand: Array.isArray(maybeOperand)
-                ? maybeOperand.map((item) => item)
+                ? maybeOperand.map((item) => toJson(item))
                 : maybeOperand != null
-                  ? maybeOperand
+                  ? toJson(maybeOperand)
                   : undefined,
             operandOrColor: Array.isArray(operandOrColor)
                 ? operandOrColor.map((item) => (typeof item === "string" ? item : toJson(item)))

--- a/seed/ts-sdk/enum/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/enum/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/enum/serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/enum/serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/enum/serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/enum/serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/enum/serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/enum/serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/error-property/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/error-property/union-utils/src/core/url/qs.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/errors/src/core/url/qs.ts
+++ b/seed/ts-sdk/errors/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/errors/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/errors/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/url/qs.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/url/qs.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/bigint/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/local-files/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/output-src-only/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/use-jest/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/use-jest/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/url/qs.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/extends/src/core/url/qs.ts
+++ b/seed/ts-sdk/extends/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/extends/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/extends/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/extra-properties/src/core/url/qs.ts
+++ b/seed/ts-sdk/extra-properties/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/extra-properties/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-download/stream-wrapper/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-download/stream-wrapper/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload-openapi/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload-openapi/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload/inline/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload/inline/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload/serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload/serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload/use-jest/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload/use-jest/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload/use-jest/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload/use-jest/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload/use-jest/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/file-upload/wrapper/src/core/url/qs.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/folders/src/core/url/qs.ts
+++ b/seed/ts-sdk/folders/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/folders/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/folders/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/url/qs.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/header-auth-environment-variable/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/header-auth-environment-variable/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/header-auth/src/core/url/qs.ts
+++ b/seed/ts-sdk/header-auth/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/header-auth/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/header-auth/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/header-auth/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/header-auth/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/http-head/src/core/url/qs.ts
+++ b/seed/ts-sdk/http-head/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/http-head/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/idempotency-headers/src/core/url/qs.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/idempotency-headers/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/url/qs.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/url/qs.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/url/qs.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/url/qs.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/url/qs.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/core/url/qs.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/url/qs.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/inline-enum-type-name-override/src/core/url/qs.ts
+++ b/seed/ts-sdk/inline-enum-type-name-override/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/inline-enum-type-name-override/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/inline-enum-type-name-override/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/inline-enum-type-name-override/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/inline-enum-type-name-override/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/license/src/core/url/qs.ts
+++ b/seed/ts-sdk/license/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/license/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/license/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/license/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/literal-user-agent/src/core/url/qs.ts
+++ b/seed/ts-sdk/literal-user-agent/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/literal-user-agent/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/literal-user-agent/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/literal-user-agent/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/literal-user-agent/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/literal/src/core/url/qs.ts
+++ b/seed/ts-sdk/literal/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/literal/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/literal/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/literals-unions/src/core/url/qs.ts
+++ b/seed/ts-sdk/literals-unions/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/literals-unions/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/literals-unions/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/url/qs.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/mixed-file-directory/src/core/url/qs.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/multi-line-docs/src/core/url/qs.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/multi-line-docs/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/multi-url-environment-reference/src/core/url/qs.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/multi-url-environment-reference/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/multi-url-environment-reference/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/multi-url-environment/src/core/url/qs.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/multi-url-environment/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/multiple-request-bodies/src/core/url/qs.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/no-content-response/src/core/url/qs.ts
+++ b/seed/ts-sdk/no-content-response/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/no-content-response/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/no-content-response/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/no-content-response/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/no-content-response/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/no-environment/src/core/url/qs.ts
+++ b/seed/ts-sdk/no-environment/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/no-environment/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/no-retries/src/core/url/qs.ts
+++ b/seed/ts-sdk/no-retries/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/no-retries/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/no-retries/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/no-retries/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/no-retries/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/null-type/src/core/url/qs.ts
+++ b/seed/ts-sdk/null-type/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/null-type/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/null-type/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/null-type/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/null-type/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/nullable-allof-extends/src/core/url/qs.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/nullable-allof-extends/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/nullable-allof-extends/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/nullable-allof-extends/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/nullable-allof-extends/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
+++ b/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
@@ -767,9 +767,9 @@ export class NullableOptionalClient {
     ): Promise<core.WithRawResponse<SeedNullableOptional.UserResponse[]>> {
         const { role, status, secondaryRole } = request;
         const _queryParams: Record<string, unknown> = {
-            role: role !== undefined ? role : undefined,
+            role: role != null ? role : undefined,
             status: status != null ? status : undefined,
-            secondaryRole: secondaryRole !== undefined ? secondaryRole : undefined,
+            secondaryRole: secondaryRole != null ? secondaryRole : undefined,
         };
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);
         const _response = await core.fetcher({

--- a/seed/ts-sdk/nullable-optional/src/core/url/qs.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/nullable-optional/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/nullable-optional/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/nullable-request-body/src/core/url/qs.ts
+++ b/seed/ts-sdk/nullable-request-body/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/nullable-request-body/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/nullable-request-body/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/nullable-request-body/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/nullable-request-body/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/nullable/src/core/url/qs.ts
+++ b/seed/ts-sdk/nullable/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/nullable/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/object/src/core/url/qs.ts
+++ b/seed/ts-sdk/object/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/object/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/object/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/object/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/objects-with-imports/src/core/url/qs.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/objects-with-imports/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/openapi-subtitle/src/core/url/qs.ts
+++ b/seed/ts-sdk/openapi-subtitle/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/openapi-subtitle/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/openapi-subtitle/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/openapi-subtitle/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/openapi-subtitle/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/optional/src/core/url/qs.ts
+++ b/seed/ts-sdk/optional/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/optional/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/optional/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/package-yml/src/core/url/qs.ts
+++ b/seed/ts-sdk/package-yml/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/package-yml/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/pagination-custom/src/core/url/qs.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/pagination-custom/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/pagination-uri-path/src/core/url/qs.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/pagination-uri-path/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/pagination-uri-path/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/pagination-uri-path/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/pagination-uri-path/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/pagination/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/pagination/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/url/qs.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/url/qs.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/plain-text/src/core/url/qs.ts
+++ b/seed/ts-sdk/plain-text/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/plain-text/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/url/qs.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/public-object/src/core/url/qs.ts
+++ b/seed/ts-sdk/public-object/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/public-object/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-param-name-conflict/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-param-name-conflict/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-param-name-conflict/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-param-name-conflict/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-param-name-conflict/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-param-name-conflict/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters-openapi/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters-openapi/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/query-parameters/serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/query-parameters/serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/url/qs.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/url/qs.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/url/qs.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/required-nullable/src/core/url/qs.ts
+++ b/seed/ts-sdk/required-nullable/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/required-nullable/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/required-nullable/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/required-nullable/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/required-nullable/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/reserved-keywords/src/core/url/qs.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/reserved-keywords/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/response-property/src/core/url/qs.ts
+++ b/seed/ts-sdk/response-property/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/response-property/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/schemaless-request-body-examples/src/core/url/qs.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/schemaless-request-body-examples/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/schemaless-request-body-examples/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/server-sent-event-examples/src/core/url/qs.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/url/qs.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/server-sent-events/src/core/url/qs.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/server-sent-events/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/server-url-templating/src/core/url/qs.ts
+++ b/seed/ts-sdk/server-url-templating/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/server-url-templating/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/server-url-templating/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/server-url-templating/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/server-url-templating/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/bundle/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/bundle/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/jsr/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/jsr/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/naming/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/naming/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/naming/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/naming/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/naming/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/no-scripts/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/oidc-token/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/use-oxc/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/use-oxc/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/use-prettier/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-api/use-yarn/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/simple-fhir/src/core/url/qs.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/simple-fhir/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/single-url-environment-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/streaming-parameter/src/core/url/qs.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/streaming-parameter/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/streaming/serde-layer/src/core/url/qs.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/streaming/wrapper/src/core/url/qs.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/trace/exhaustive/src/core/url/qs.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/trace/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/url/qs.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/trace/serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/trace/serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/trace/serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/trace/serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/trace/serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/trace/serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/ts-express-casing/src/core/url/qs.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/ts-express-casing/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/ts-extra-properties/src/core/url/qs.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/ts-extra-properties/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/ts-extra-properties/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/ts-extra-properties/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/ts-extra-properties/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/url/qs.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/url/qs.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/url/qs.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/url/qs.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/unions-with-local-date/src/core/url/qs.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/unions-with-local-date/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/unions-with-local-date/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/unions-with-local-date/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/unions-with-local-date/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/unions/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/unions/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/unions/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/unions/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/unions/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/unions/serde-layer/src/core/url/qs.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/unions/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/unions/serde-layer/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/unions/serde-layer/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/unions/serde-layer/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/url/qs.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/url-form-encoded/src/core/url/qs.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/url-form-encoded/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/validation/src/core/url/qs.ts
+++ b/seed/ts-sdk/validation/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/validation/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/validation/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/variables/src/core/url/qs.ts
+++ b/seed/ts-sdk/variables/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/variables/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/variables/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/version-no-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/version-no-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/version-no-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/version/src/core/url/qs.ts
+++ b/seed/ts-sdk/version/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/version/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/version/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/version/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/webhook-audience/src/core/url/qs.ts
+++ b/seed/ts-sdk/webhook-audience/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/webhook-audience/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/webhook-audience/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/webhook-audience/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/webhook-audience/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/webhooks/no-custom-config/src/core/url/qs.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/webhooks/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/webhooks/no-custom-config/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/url/qs.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/url/qs.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/websocket-multi-url/src/core/url/qs.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/websocket-multi-url/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/websocket-multi-url/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/websocket-multi-url/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/websocket-multi-url/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/websocket/no-serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/url/qs.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/websocket/serde/src/core/url/qs.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/websocket/serde/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 

--- a/seed/ts-sdk/x-fern-default/src/core/url/qs.ts
+++ b/seed/ts-sdk/x-fern-default/src/core/url/qs.ts
@@ -27,7 +27,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
     for (const [key, value] of Object.entries(obj)) {
         const fullKey = prefix ? `${prefix}[${key}]` : key;
 
-        if (value === undefined) {
+        if (value == null) {
             continue;
         }
 
@@ -47,7 +47,7 @@ function stringifyObject(obj: Record<string, unknown>, prefix = "", options: Req
             } else {
                 for (let i = 0; i < value.length; i++) {
                     const item = value[i];
-                    if (item === undefined) {
+                    if (item == null) {
                         continue;
                     }
                     if (typeof item === "object" && !Array.isArray(item) && item !== null) {

--- a/seed/ts-sdk/x-fern-default/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/x-fern-default/tests/unit/fetcher/createRequestUrl.test.ts
@@ -77,7 +77,7 @@ describe("Test createRequestUrl", () => {
                 undefinedValue: undefined,
                 emptyString: "",
             },
-            expected: "https://api.example.com?valid=value&nullValue=&emptyString=",
+            expected: "https://api.example.com?valid=value&emptyString=",
         },
         {
             description: "should handle deeply nested objects",

--- a/seed/ts-sdk/x-fern-default/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/x-fern-default/tests/unit/url/qs.test.ts
@@ -189,12 +189,12 @@ describe("Test qs toQueryString", () => {
             {
                 description: "should handle arrays with null/undefined values",
                 input: { items: ["a", null, "c", undefined, "e"] },
-                expected: "items%5B0%5D=a&items%5B1%5D=&items%5B2%5D=c&items%5B4%5D=e",
+                expected: "items%5B0%5D=a&items%5B2%5D=c&items%5B4%5D=e",
             },
             {
                 description: "should handle objects with null/undefined values",
                 input: { name: "John", age: null, email: undefined, active: true },
-                expected: "name=John&age=&active=true",
+                expected: "name=John&active=true",
             },
         ];
 


### PR DESCRIPTION
## Description
Refs https://github.com/square/square-nodejs-sdk/issues/240

Nullable enum query parameters (e.g. `sort_order?: SortOrder | null`) were serialized as empty strings in the URL when `null`, causing APIs like Square to reject with `INVALID_ENUM_VALUE`.

## Root Cause

Two null-handling gaps combined:

1. **Generator** — `TypeReferenceToStringExpressionConverter` used `!== undefined` (strict) for nullable types, so `null` passed through to the query params object
2. **Runtime** — `qs.ts` only skipped `undefined` values (`=== undefined`), serializing `null` as empty string (`sort_order=`)

## Changes Made

- `TypeReferenceToStringExpressionConverter.ts`: nullable branch now uses `!= null` (loose), catching both null and undefined
- `qs.ts`: `stringifyObject` now uses `== null` to skip both null and undefined values
- Updated all seed snapshots (220 qs.ts files + nullable-optional fixture Client.ts)

## Testing
- [x] Reproduced bug: null enum query param → `sort_order=` → API rejects
- [x] Verified fix: null values now omitted from query string entirely
- [x] Source files compile with tsc
- [x] Seed snapshots updated