### PR TITLE
chore(typescript): remove tsgolint rebuild-from-source Docker stage

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -1,29 +1,3 @@
-# Stage 1: Rebuild oxlint-tsgolint from source under go1.26.4 so the embedded
-# go/stdlib clears vulnerability scanners. The published binaries are still
-# compiled with an older upstream Go toolchain.
-FROM golang:1.26.4-trixie AS tsgolint-rebuild
-ARG TSGOLINT_VERSION=0.22.1
-ENV GOTOOLCHAIN=go1.26.4
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN git config --global user.email "build@example.com" && \
-    git config --global user.name "Build" && \
-    git clone --depth 1 --branch v${TSGOLINT_VERSION} \
-        https://github.com/oxc-project/tsgolint.git /src/tsgolint && \
-    cd /src/tsgolint && \
-    # Equivalent of `just init`: init the typescript-go submodule
-    # (NOT recursively — typescript-go's own microsoft/TypeScript
-    # sub-submodule is huge and not needed for tsgolint's build),
-    # apply patches, copy internal/collections so internal/utils can
-    # import it (the file comment explains the duplication).
-    git submodule update --init --depth 1 typescript-go && \
-    cd typescript-go && \
-    git am --3way --no-gpg-sign ../patches/*.patch && \
-    cd .. && \
-    mkdir -p internal/collections && \
-    find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \; && \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
-    ls -la /out/tsgolint
-
 FROM node:24.17.0-trixie-slim
 
 ENV PNPM_STORE_PATH=/.pnpm-cache
@@ -95,34 +69,15 @@ RUN pnpm add -g typescript@~5.7.2 \
   oxfmt@0.48.0 \
   @biomejs/biome@2.4.3 \
   oxlint@1.63.0 \
-  oxlint-tsgolint@0.22.1 \
+  oxlint-tsgolint@0.23.0 \
   @types/node@^18.19.70 \
   webpack@^5.97.1 \
   msw@2.11.2 \
   vitest@^4.1.1
 
-# Replace the prebuilt @oxlint-tsgolint/linux-* binary with the locally
-# rebuilt one so it embeds the patched Go stdlib.
-COPY --from=tsgolint-rebuild /out/tsgolint /tmp/tsgolint-rebuilt
-RUN chmod +x /tmp/tsgolint-rebuilt && \
-    set -eux; \
-    found=0; \
-    for f in $(find / -type f -name tsgolint -path '*@oxlint-tsgolint*' 2>/dev/null); do \
-        cp /tmp/tsgolint-rebuilt "$f"; \
-        chmod +x "$f"; \
-        found=1; \
-        echo "Replaced tsgolint binary at $f"; \
-    done; \
-    if [ "$found" = "0" ]; then \
-        echo "::error::Could not find any tsgolint binary to replace"; \
-        exit 1; \
-    fi; \
-    rm /tmp/tsgolint-rebuilt
-
-# Clean pnpm content-addressable store (holds the pre-built tsgolint
-# binary compiled with go1.26.2) and corepack cache (holds a second
-# pnpm dist with bundled undici 6.26.0). Patch the npm-installed pnpm's
-# bundled undici to 6.27.0 to clear CVE-2026-12151.
+# Clean pnpm content-addressable store and corepack cache to reduce
+# image size. Patch pnpm's bundled undici to 6.27.0 to clear
+# CVE-2026-12151.
 RUN rm -rf /.pnpm/store /.pnpm-cache /root/.cache/node/corepack && \
     cd /usr/local/lib/node_modules/pnpm/dist/node_modules && \
     npm pack undici@6.27.0 && \

--- a/generators/typescript/sdk/changes/unreleased/remove-tsgolint-rebuild.yml
+++ b/generators/typescript/sdk/changes/unreleased/remove-tsgolint-rebuild.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Remove the tsgolint rebuild-from-source Docker stage. The published
+    oxlint-tsgolint 0.23.0 binaries are now used directly, eliminating the
+    golang image pull, typescript-go submodule clone, and Go compilation
+    that made Dockerfile builds slow. The two Go stdlib CVEs previously
+    addressed by the rebuild (CVE-2026-42507 net/textproto, CVE-2026-27145
+    crypto/x509) are not exercisable by a linting binary; they will clear
+    automatically when tsgolint ships a release built with go1.26.4+.
+  type: chore

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,24 +1,3 @@
-# Stage 1: Rebuild oxlint-tsgolint from source under go1.26.4 so the embedded
-# go/stdlib clears CVE-2026-42507 and CVE-2026-27145 (fixed in 1.26.4).
-# The published 0.23.0 binaries are compiled with go1.26.3.
-FROM golang:1.26.4-trixie AS tsgolint-rebuild
-ARG TSGOLINT_VERSION=0.23.0
-ENV GOTOOLCHAIN=go1.26.4
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN git config --global user.email "build@example.com" && \
-    git config --global user.name "Build" && \
-    git clone --depth 1 --branch v${TSGOLINT_VERSION} \
-        https://github.com/oxc-project/tsgolint.git /src/tsgolint && \
-    cd /src/tsgolint && \
-    git submodule update --init --depth 1 typescript-go && \
-    cd typescript-go && \
-    git am --3way --no-gpg-sign ../patches/*.patch && \
-    cd .. && \
-    mkdir -p internal/collections && \
-    find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \; && \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
-    ls -la /out/tsgolint
-
 FROM node:24.17-trixie-slim
 
 # Apply latest Debian security updates so that grype-tracked OS package
@@ -111,27 +90,9 @@ RUN pnpm add -g typescript@~5.9.3 \
   msw@2.12.14 \
   vitest@^4.1.1
 
-# Replace the prebuilt @oxlint-tsgolint/linux-* binary with the locally
-# rebuilt one so it embeds the patched Go stdlib.
-COPY --from=tsgolint-rebuild /out/tsgolint /tmp/tsgolint-rebuilt
-RUN chmod +x /tmp/tsgolint-rebuilt && \
-    set -eux; \
-    found=0; \
-    for f in $(find / -type f -name tsgolint -path '*@oxlint-tsgolint*' 2>/dev/null); do \
-        cp /tmp/tsgolint-rebuilt "$f"; \
-        chmod +x "$f"; \
-        found=1; \
-        echo "Replaced tsgolint binary at $f"; \
-    done; \
-    if [ "$found" = "0" ]; then \
-        echo "::error::Could not find any tsgolint binary to replace"; \
-        exit 1; \
-    fi; \
-    rm /tmp/tsgolint-rebuilt
-
-# Clean pnpm content-addressable store (holds the pre-built tsgolint
-# binary compiled with go1.26.2) and corepack cache. Patch pnpm's
-# bundled undici to 6.27.0 to clear CVE-2026-12151.
+# Clean pnpm content-addressable store and corepack cache to reduce
+# image size. Patch pnpm's bundled undici to 6.27.0 to clear
+# CVE-2026-12151.
 RUN rm -rf /.pnpm/store /.pnpm-cache /root/.cache/node/corepack && \
     cd /usr/local/lib/node_modules/pnpm/dist/node_modules && \
     npm pack undici@6.27.0 && \


### PR DESCRIPTION
## Description

Remove the `tsgolint-rebuild` multi-stage Docker build from both the TypeScript SDK CLI Dockerfile and the seed Dockerfile (`docker/seed/Dockerfile.ts`). The rebuild stage pulled the full `golang:1.26.4-trixie` image, cloned the typescript-go submodule, applied patches, and recompiled tsgolint from source — all to swap in go1.26.4 and clear two Go stdlib CVEs. This made Docker builds very slow.

## Changes Made

- Removed the entire `FROM golang:1.26.4-trixie AS tsgolint-rebuild` stage (~20 lines) from `generators/typescript/sdk/cli/Dockerfile`
- Removed the `COPY --from=tsgolint-rebuild` and binary replacement `RUN` block (~18 lines) from the CLI Dockerfile
- Removed the same rebuild stage and binary replacement from `docker/seed/Dockerfile.ts` (~45 lines)
- Bumped `oxlint-tsgolint` from 0.22.1 → 0.23.0 in the seed Dockerfile to match the CLI Dockerfile
- Added unreleased changelog entry

## Context

The two CVEs addressed by the rebuild (CVE-2026-42507 `net/textproto`, CVE-2026-27145 `crypto/x509`) are not exercisable by a linting binary — they are false positives for this use case. The tsgolint repo's CI resolves `go 1.26` to the latest patch, so the next tsgolint release will be built with go1.26.4+ and the findings will clear automatically.

## Testing

- `pnpm run check` passes (biome format/lint)
- No functional code changes — only Dockerfile build logic and changelog

Link to Devin session: https://app.devin.ai/sessions/3ec35684ab9a41a49cc5da05d590ec8b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->