### PR TITLE
chore(cli-generator): remap arch-doc-refresh playbook from cli-sdk to fern monorepo

### DIFF
--- a/generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md
+++ b/generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md
@@ -13,6 +13,11 @@
 > (see [README.md](./README.md) for activation steps). The playbook
 > below is runtime-neutral — any model with access to those four
 > sources can execute it.
+>
+> **Repo context.** The CLI generator and its architecture docs now live
+> inside the `fern-api/fern` monorepo under `generators/cli/sdk/`. The
+> former standalone repo `fern-api/cli-sdk` is archived and read-only.
+> All paths below are relative to the `fern-api/fern` repo root.
 
 ---
 
@@ -35,7 +40,7 @@ that:
 
 The agent is empowered to **propose** doc changes. It is **not**
 empowered to make architectural decisions, close tickets, or modify any
-file outside `docs/architecture/`.
+file outside `generators/cli/sdk/docs/architecture/`.
 
 ---
 
@@ -58,17 +63,28 @@ timestamp.
 Configured in [`sources.yml`](./sources.yml). All sources are queried in
 parallel.
 
-### 1. GitHub (`fern-api/cli-sdk`)
+### 1. GitHub (`fern-api/fern`, scoped to `generators/cli/sdk/`)
 
-- **Merged PRs in window**: `gh pr list --state merged --search 'merged:>=<since>'`.
+Because the CLI generator now lives inside the `fern-api/fern` monorepo,
+the agent must scope its GitHub queries to changes under
+`generators/cli/sdk/`.
+
+- **Merged PRs in window**: identify PRs that touch files under
+  `generators/cli/sdk/` using
+  `git log --since=<since> --merges --format='%H' -- generators/cli/sdk/`
+  then resolve each merge commit to its PR number. Alternatively,
+  `gh pr list -R fern-api/fern --state merged --search 'merged:>=<since>'`
+  filtered to only PRs whose changed files intersect `generators/cli/sdk/`.
   For each PR, capture: number, title, body, merged-by, files changed,
   commit messages, the linked Linear ticket(s) (regex `FER-\d+` in title
   and body).
-- **Closed issues in window**: `gh issue list --state closed --search 'closed:>=<since>'`.
+- **Closed issues in window**: `gh issue list -R fern-api/fern --state closed --search 'closed:>=<since>'`
+  filtered to issues mentioning `cli-sdk`, `cli-generator`, or
+  `generators/cli/`.
 - **Diffstat on architecturally significant paths**: see [the path list
   below](#architecturally-significant-paths).
 
-### 2. Linear (`Fern` team → `[SDKs] CLI Generator` project)
+### 2. Linear (`Fern` team -> `[SDKs] CLI Generator` project)
 
 - All tickets that changed status to `Done` in the window.
 - All tickets in `In Progress` *that mention or are linked from* a merged
@@ -134,21 +150,24 @@ For each change packet, decide one of:
 
 | Class | Action |
 |---|---|
-| **Shape change** | Affects `ARCHITECTURE.md` §3 (context), §5 (building blocks), or §6 (runtime view). Propose a patch. |
-| **Cross-cutting concept change** | Affects `ARCHITECTURE.md` §8. Propose a patch. |
+| **Shape change** | Affects `ARCHITECTURE.md` S3 (context), S5 (building blocks), or S6 (runtime view). Propose a patch. |
+| **Cross-cutting concept change** | Affects `ARCHITECTURE.md` S8. Propose a patch. |
 | **New formal ADR opportunity** | A load-bearing reversible decision has been made. Propose a new row in `decisions/INDEX.md` under "Implicit decisions" with provenance, and flag it as a candidate for promotion. |
-| **Risk surface change** | Affects `ARCHITECTURE.md` §11. Propose a patch. |
+| **Risk surface change** | Affects `ARCHITECTURE.md` S11. Propose a patch. |
 | **No architectural impact** | Skip. Do not list in the PR. (Counted in the Slack digest as "N PRs with no arch impact".) |
 
 ### Step 4: Compose the PR
 
 The PR contains exactly these changes:
 
-1. Patches to `docs/architecture/*.md` (no other file paths).
-2. A new entry in `docs/architecture/CHANGELOG-ARCH.md` under
+1. Patches to `generators/cli/sdk/docs/architecture/*.md` (no other file paths).
+2. A new entry in `generators/cli/sdk/docs/architecture/CHANGELOG-ARCH.md` under
    `## [Unreleased]` (or under a date heading if the human approved a
    freeze).
 3. Updated `<!-- last-run: ... -->` marker.
+
+The PR must be opened against `fern-api/fern` (not the archived
+`fern-api/cli-sdk`).
 
 **Citation requirement.** Every claim in the PR must link to its source.
 No claim without at least one of:
@@ -164,12 +183,12 @@ If a claim depends on multiple sources, link all of them.
 After the PR is opened, post to `#project-cli-generator`:
 
 ```
-🏗️ Weekly architecture digest — <since> to <now>
+Weekly architecture digest — <since> to <now>
 
-📦 <N> merged PRs · <M> with architectural impact
-🎯 <K> new implicit decisions surfaced
-🔄 <R> reversals or revisions to existing entries
-👻 <O> out-of-band signals (Slack/Notion without a matching PR)
+<N> merged PRs · <M> with architectural impact
+<K> new implicit decisions surfaced
+<R> reversals or revisions to existing entries
+<O> out-of-band signals (Slack/Notion without a matching PR)
 
 PR: <github-url>
 ```
@@ -182,42 +201,43 @@ just the notification.
 ## Architecturally significant paths
 
 When deciding if a PR has architectural impact, give extra weight to
-diffs in these paths. (This is a heuristic — a PR that touches *only*
-peripheral code can still be architecturally significant if the
-accompanying Slack/Notion/Linear signal says so.)
+diffs in these paths (all relative to the `fern-api/fern` repo root).
+(This is a heuristic — a PR that touches *only* peripheral code can
+still be architecturally significant if the accompanying
+Slack/Notion/Linear signal says so.)
 
 ```
-src/lib.rs
-src/openapi/app.rs
-src/openapi/parser.rs
-src/openapi/discovery.rs
-src/openapi/executor.rs
-src/openapi/overlay.rs
-src/openapi/commands.rs
-src/graphql/app.rs
-src/graphql/parser.rs
-src/graphql/discovery.rs
-src/graphql/executor.rs
-src/graphql/commands.rs
-src/asyncapi/app.rs
-src/asyncapi/parser.rs
-src/asyncapi/discovery.rs
-src/asyncapi/executor.rs
-src/asyncapi/overlay.rs
-src/asyncapi/commands.rs
-src/auth/provider.rs
-src/auth/credential.rs
-src/auth/compose.rs
-src/auth/oauth2.rs
-src/http.rs
-src/websocket/**
-src/formatter.rs
-src/validate.rs
-src/error.rs
-src/custom_commands.rs
-src/early_intercept.rs
-Cargo.toml
-docs/adr/**
+generators/cli/sdk/src/lib.rs
+generators/cli/sdk/src/openapi/app.rs
+generators/cli/sdk/src/openapi/parser.rs
+generators/cli/sdk/src/openapi/discovery.rs
+generators/cli/sdk/src/openapi/executor.rs
+generators/cli/sdk/src/openapi/overlay.rs
+generators/cli/sdk/src/openapi/commands.rs
+generators/cli/sdk/src/graphql/app.rs
+generators/cli/sdk/src/graphql/parser.rs
+generators/cli/sdk/src/graphql/discovery.rs
+generators/cli/sdk/src/graphql/executor.rs
+generators/cli/sdk/src/graphql/commands.rs
+generators/cli/sdk/src/asyncapi/app.rs
+generators/cli/sdk/src/asyncapi/parser.rs
+generators/cli/sdk/src/asyncapi/discovery.rs
+generators/cli/sdk/src/asyncapi/executor.rs
+generators/cli/sdk/src/asyncapi/overlay.rs
+generators/cli/sdk/src/asyncapi/commands.rs
+generators/cli/sdk/src/auth/provider.rs
+generators/cli/sdk/src/auth/credential.rs
+generators/cli/sdk/src/auth/compose.rs
+generators/cli/sdk/src/auth/oauth2.rs
+generators/cli/sdk/src/http.rs
+generators/cli/sdk/src/websocket/**
+generators/cli/sdk/src/formatter.rs
+generators/cli/sdk/src/validate.rs
+generators/cli/sdk/src/error.rs
+generators/cli/sdk/src/custom_commands.rs
+generators/cli/sdk/src/early_intercept.rs
+generators/cli/sdk/Cargo.toml
+generators/cli/sdk/docs/adr/**
 ```
 
 When this list needs updates (new module, removed module), it's a
@@ -230,9 +250,9 @@ candidate change itself — surface it in the PR.
 ### The agent MUST
 
 - Cite every claim. No source = no claim.
-- Stay inside `docs/architecture/**`. Never edit code, `Cargo.toml`,
-  workflows, or any file elsewhere in the repo.
-- Open the PR as **draft**. Never use `--auto-merge`.
+- Stay inside `generators/cli/sdk/docs/architecture/**`. Never edit
+  code, `Cargo.toml`, workflows, or any file elsewhere in the repo.
+- Open the PR as **draft** against `fern-api/fern`. Never use `--auto-merge`.
 - Update the `<!-- last-run: ... -->` marker before exiting.
 - Distinguish *decisions* from *features*. Adding `x-fern-foo` extension
   support is a feature; deciding *not* to share extension parsing
@@ -246,30 +266,31 @@ candidate change itself — surface it in the PR.
   for next run` section in the PR body.
 - Make architectural claims that aren't supported by at least one
   cited source.
-- Modify or rewrite existing ADRs in `docs/adr/`. New ADRs are a
-  human-authored act; the agent only proposes "promote D-X to ADR" in
-  `decisions/INDEX.md`.
+- Push to or open PRs against the archived `fern-api/cli-sdk` repo.
+- Modify or rewrite existing ADRs in `generators/cli/sdk/docs/adr/`.
+  New ADRs are a human-authored act; the agent only proposes "promote
+  D-X to ADR" in `decisions/INDEX.md`.
 - Touch the bootstrap-era implicit decisions (D-A through D-P) except
   to add `**Promoted to ADR-NNNN**` notes when a human has promoted
   one, or to add reversal notes when the team has reversed one.
 
 ### Recoverable failures
 
-- A source times out → note it, continue.
-- The branch already exists from a prior failed run → push to it
+- A source times out -> note it, continue.
+- The branch already exists from a prior failed run -> push to it
   (`git push --force-with-lease`) and reopen the PR if needed.
-- No architectural changes detected → still open a PR with just the
+- No architectural changes detected -> still open a PR with just the
   `<!-- last-run: ... -->` bump and a `### No architectural changes in
   window` note in `CHANGELOG-ARCH.md`. (This is intentional: it gives
   the team a heartbeat that the agent ran and saw nothing.)
 
 ### Hard failures (stop and alert)
 
-- GitHub auth failure → post `❌ arch-doc-refresh failed: auth` to
+- GitHub auth failure -> post `arch-doc-refresh failed: auth` to
   `#project-cli-generator`, exit non-zero.
-- Multiple consecutive runs find no signal across all four sources →
+- Multiple consecutive runs find no signal across all four sources ->
   the watch window is probably wrong; alert and ask a human.
-- A claim cannot be cited → drop the claim. Do not invent a citation.
+- A claim cannot be cited -> drop the claim. Do not invent a citation.
 
 ---
 
@@ -279,13 +300,14 @@ The text below is what the model sees. Variables in `{{double-braces}}`
 are substituted at invocation.
 
 ````markdown
-You are the architecture-doc refresh agent for `fern-api/cli-sdk`.
+You are the architecture-doc refresh agent for the CLI generator
+embedded in `fern-api/fern` (under `generators/cli/sdk/`).
 
 ## Current state of the docs
 
-<!-- contents of docs/architecture/ARCHITECTURE.md -->
-<!-- contents of docs/architecture/decisions/INDEX.md -->
-<!-- contents of docs/architecture/CHANGELOG-ARCH.md -->
+<!-- contents of generators/cli/sdk/docs/architecture/ARCHITECTURE.md -->
+<!-- contents of generators/cli/sdk/docs/architecture/decisions/INDEX.md -->
+<!-- contents of generators/cli/sdk/docs/architecture/CHANGELOG-ARCH.md -->
 
 ## Window
 
@@ -294,7 +316,7 @@ To:   {{now-iso}}
 
 ## Source data
 
-### GitHub merged PRs
+### GitHub merged PRs (touching generators/cli/sdk/)
 {{github-prs}}
 
 ### Linear tickets
@@ -308,17 +330,18 @@ To:   {{now-iso}}
 
 ## Your task
 
-Follow the methodology in `docs/architecture/automation/PLAYBOOK.md`,
-specifically Steps 2–4. Output:
+Follow the methodology in
+`generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md`,
+specifically Steps 2-4. Output:
 
-1. A unified diff against `docs/architecture/**` only.
-2. A Slack digest in the exact format under §"Slack digest".
+1. A unified diff against `generators/cli/sdk/docs/architecture/**` only.
+2. A Slack digest in the exact format under S"Slack digest".
 3. A list of `## TODO for next run` items if anything didn't fit.
 
 Constraints:
 - Every claim must cite at least one source URL.
-- Stay inside `docs/architecture/**`.
-- Open the PR as draft.
+- Stay inside `generators/cli/sdk/docs/architecture/**`.
+- Open the PR as draft against `fern-api/fern`.
 - Update the `<!-- last-run: -->` marker.
 ````
 
@@ -341,8 +364,8 @@ a release.
 
 ## How to edit this playbook
 
-Open a PR that modifies this file. CODEOWNERS (if/when configured)
-should require an architecture owner's review. The Devin schedule
-will pick up the new playbook on its next run — no schedule restart
-needed because the schedule references the repo path, not a frozen
-snapshot.
+Open a PR against `fern-api/fern` that modifies this file. CODEOWNERS
+(if/when configured) should require an architecture owner's review. The
+Devin schedule will pick up the new playbook on its next run — no
+schedule restart needed because the schedule references the repo path,
+not a frozen snapshot.

--- a/generators/cli/sdk/docs/architecture/automation/README.md
+++ b/generators/cli/sdk/docs/architecture/automation/README.md
@@ -22,7 +22,7 @@ A scheduled agent runs **weekly** (Mondays, 14:00 UTC). Each run, it:
 4. Posts a digest to `#project-cli-generator`.
 
 Humans review and merge. No auto-merge. The agent stays inside
-`docs/architecture/**`.
+`generators/cli/sdk/docs/architecture/**`.
 
 ## Where the schedule lives
 
@@ -74,7 +74,7 @@ devin run --playbook arch-doc-refresh --since 2026-05-01
 ```
 
 Or, locally, by feeding `PLAYBOOK.md` to a Claude Code session along
-with the current state of `docs/architecture/`. Useful for testing
+with the current state of `generators/cli/sdk/docs/architecture/`. Useful for testing
 playbook edits before they land on the schedule.
 
 ## How to update the playbook

--- a/generators/cli/sdk/docs/architecture/automation/README.md
+++ b/generators/cli/sdk/docs/architecture/automation/README.md
@@ -1,4 +1,4 @@
-# `docs/architecture/automation/`
+# `generators/cli/sdk/docs/architecture/automation/`
 
 The architecture docs in this directory don't keep themselves up to date.
 This subdirectory describes the *automation contract* that does:
@@ -45,8 +45,8 @@ The Devin schedule is **not yet activated**. To activate:
    ```bash
    devin playbook create \
      --name arch-doc-refresh \
-     --description "Weekly architecture-doc refresh for fern-api/cli-sdk" \
-     --content "$(cat docs/architecture/automation/PLAYBOOK.md)"
+     --description "Weekly architecture-doc refresh for CLI generator in fern-api/fern" \
+     --content "$(cat generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md)"
    ```
 
 2. Create the scheduled Devin session:
@@ -55,7 +55,7 @@ The Devin schedule is **not yet activated**. To activate:
      --playbook arch-doc-refresh \
      --cron '0 14 * * 1' \
      --tz UTC \
-     --repo fern-api/cli-sdk
+     --repo fern-api/fern
    ```
 
 3. Verify on the next Monday that the digest lands in
@@ -79,10 +79,10 @@ playbook edits before they land on the schedule.
 
 ## How to update the playbook
 
-Open a PR that modifies [`PLAYBOOK.md`](./PLAYBOOK.md) or
-[`sources.yml`](./sources.yml). The Devin schedule re-reads both files
-on every run, so changes apply on the next scheduled run — no schedule
-restart needed.
+Open a PR against `fern-api/fern` that modifies
+[`PLAYBOOK.md`](./PLAYBOOK.md) or [`sources.yml`](./sources.yml). The
+Devin schedule re-reads both files on every run, so changes apply on the
+next scheduled run — no schedule restart needed.
 
 When editing the prompt, also update the corresponding section in
 `PLAYBOOK.md` (the prompt template is embedded there). The
@@ -130,9 +130,9 @@ The human review step is where:
 
 ## Relationship to the bootstrap
 
-The bootstrap of `docs/architecture/` (everything outside this
-subdirectory) was authored by hand from `AGENTS.md`, existing ADRs,
-Linear, and commit history. The agent picks up from there — its job
-is to keep the bootstrap fresh, not to redo it. If the bootstrap is
-materially wrong, fix it directly in a human-authored PR; don't wait
-for the agent to notice.
+The bootstrap of `generators/cli/sdk/docs/architecture/` (everything
+outside this subdirectory) was authored by hand from `AGENTS.md`,
+existing ADRs, Linear, and commit history. The agent picks up from
+there — its job is to keep the bootstrap fresh, not to redo it. If the
+bootstrap is materially wrong, fix it directly in a human-authored PR
+against `fern-api/fern`; don't wait for the agent to notice.

--- a/generators/cli/sdk/docs/architecture/automation/sources.yml
+++ b/generators/cli/sdk/docs/architecture/automation/sources.yml
@@ -10,38 +10,47 @@ version: 1
 # GitHub: where the code lives.
 # ---------------------------------------------------------------------------
 github:
-  repo: fern-api/cli-sdk
+  repo: fern-api/fern
+  # The CLI generator lives under this prefix in the monorepo.
+  # Only PRs touching files under this path are relevant.
+  scope_prefix: generators/cli/sdk/
   base_branch: main
   # PRs opened by the agent target this branch:
   target_branch: main
   # Architecturally-significant paths get extra weight when classifying PRs.
   # Source of truth — keep in sync with PLAYBOOK.md §"Architecturally significant paths".
   significant_paths:
-    - src/lib.rs
-    - src/openapi/app.rs
-    - src/openapi/parser.rs
-    - src/openapi/discovery.rs
-    - src/openapi/executor.rs
-    - src/openapi/overlay.rs
-    - src/openapi/commands.rs
-    - src/graphql/app.rs
-    - src/graphql/parser.rs
-    - src/graphql/discovery.rs
-    - src/graphql/executor.rs
-    - src/graphql/commands.rs
-    - src/auth/provider.rs
-    - src/auth/credential.rs
-    - src/auth/compose.rs
-    - src/auth/oauth2.rs
-    - src/http.rs
-    - src/websocket/**
-    - src/formatter.rs
-    - src/validate.rs
-    - src/error.rs
-    - src/custom_commands.rs
-    - src/early_intercept.rs
-    - Cargo.toml
-    - docs/adr/**
+    - generators/cli/sdk/src/lib.rs
+    - generators/cli/sdk/src/openapi/app.rs
+    - generators/cli/sdk/src/openapi/parser.rs
+    - generators/cli/sdk/src/openapi/discovery.rs
+    - generators/cli/sdk/src/openapi/executor.rs
+    - generators/cli/sdk/src/openapi/overlay.rs
+    - generators/cli/sdk/src/openapi/commands.rs
+    - generators/cli/sdk/src/graphql/app.rs
+    - generators/cli/sdk/src/graphql/parser.rs
+    - generators/cli/sdk/src/graphql/discovery.rs
+    - generators/cli/sdk/src/graphql/executor.rs
+    - generators/cli/sdk/src/graphql/commands.rs
+    - generators/cli/sdk/src/asyncapi/app.rs
+    - generators/cli/sdk/src/asyncapi/parser.rs
+    - generators/cli/sdk/src/asyncapi/discovery.rs
+    - generators/cli/sdk/src/asyncapi/executor.rs
+    - generators/cli/sdk/src/asyncapi/overlay.rs
+    - generators/cli/sdk/src/asyncapi/commands.rs
+    - generators/cli/sdk/src/auth/provider.rs
+    - generators/cli/sdk/src/auth/credential.rs
+    - generators/cli/sdk/src/auth/compose.rs
+    - generators/cli/sdk/src/auth/oauth2.rs
+    - generators/cli/sdk/src/http.rs
+    - generators/cli/sdk/src/websocket/**
+    - generators/cli/sdk/src/formatter.rs
+    - generators/cli/sdk/src/validate.rs
+    - generators/cli/sdk/src/error.rs
+    - generators/cli/sdk/src/custom_commands.rs
+    - generators/cli/sdk/src/early_intercept.rs
+    - generators/cli/sdk/Cargo.toml
+    - generators/cli/sdk/docs/adr/**
 
 # ---------------------------------------------------------------------------
 # Linear: where tickets live.
@@ -110,10 +119,10 @@ window:
 output:
   # Files the agent is permitted to modify:
   allowed_paths:
-    - docs/architecture/ARCHITECTURE.md
-    - docs/architecture/CHANGELOG-ARCH.md
-    - docs/architecture/decisions/INDEX.md
-    - docs/architecture/diagrams/**
+    - generators/cli/sdk/docs/architecture/ARCHITECTURE.md
+    - generators/cli/sdk/docs/architecture/CHANGELOG-ARCH.md
+    - generators/cli/sdk/docs/architecture/decisions/INDEX.md
+    - generators/cli/sdk/docs/architecture/diagrams/**
   # The agent must not touch anything outside these paths.
   pr_settings:
     branch_prefix: arch-doc-refresh


### PR DESCRIPTION
## Description

Remaps the architecture-doc refresh automation config from the now-archived `fern-api/cli-sdk` repo to the `fern-api/fern` monorepo paths under `generators/cli/sdk/`.

## Changes Made

### `generators/cli/sdk/docs/architecture/automation/sources.yml`
- `github.repo`: `fern-api/cli-sdk` → `fern-api/fern`
- Added `github.scope_prefix: generators/cli/sdk/` so the agent only considers PRs touching the CLI generator subtree
- All 33 `significant_paths` entries prefixed with `generators/cli/sdk/` (e.g. `src/lib.rs` → `generators/cli/sdk/src/lib.rs`)
- All 4 `output.allowed_paths` entries prefixed with `generators/cli/sdk/` (e.g. `docs/architecture/ARCHITECTURE.md` → `generators/cli/sdk/docs/architecture/ARCHITECTURE.md`)

### `generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md`
- Added repo-context note explaining the monorepo move
- GitHub source section rewritten to scope queries to `generators/cli/sdk/` (using `git log -- generators/cli/sdk/` or filtered `gh pr list`)
- All file path references updated (`docs/architecture/` → `generators/cli/sdk/docs/architecture/`)
- PR composition step now explicitly requires opening against `fern-api/fern`
- Quality gates: added "MUST NOT push to or open PRs against archived `fern-api/cli-sdk`"
- Prompt template: all paths updated to `generators/cli/sdk/...`

### `generators/cli/sdk/docs/architecture/automation/README.md`
- Section heading updated to full monorepo path
- `devin playbook create` command updated to reference `generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md`
- `devin schedule create` updated: `--repo fern-api/cli-sdk` → `--repo fern-api/fern`
- PR and bootstrap instructions updated to reference `fern-api/fern`
- Fixed two additional stale path references (TL;DR scope and manual invocation instruction)

## Testing
- [x] Verified all target paths exist in `fern-api/fern` (`generators/cli/sdk/docs/architecture/`, `generators/cli/sdk/docs/adr/`, `generators/cli/sdk/src/`)
- No unit tests affected — these are documentation/config files only

Link to Devin session: https://app.devin.ai/sessions/a050315fcaee4d2ab5a2bef6d5ce4ad1
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->