### PR TITLE
fix(cli): register two-field basic auth at root so auth status lists it [FER-11474]

### DIFF
--- a/generators/cli/CLAUDE.md
+++ b/generators/cli/CLAUDE.md
@@ -121,7 +121,8 @@ Each scheme in the IR's `auth.schemes` is visited via
 |---|---|---|
 | `bearer` | `.auth_scheme_env("<key>", "<env>")` | `scheme.tokenEnvVar` ?? `<BIN>_TOKEN` |
 | `header` | `.auth_scheme_env("<key>", "<env>")` | `scheme.headerEnvVar` ?? `<BIN>_API_KEY` |
-| `basic` | `.auth_basic_scheme("<key>", <user>, <pass>)` | `scheme.{username,password}EnvVar` ?? `<BIN>_{USERNAME,PASSWORD}`; `*Omit: true` becomes `AuthCredentialSource::literal("")` |
+| `basic` (both halves bound) | `.auth(BasicAuth::new("<key>").username_env(...).password_env(...))` at root, so `auth status` enumerates it [FER-11474] | `scheme.{username,password}EnvVar` ?? `<BIN>_{USERNAME,PASSWORD}` |
+| `basic` (`usernameOmit`/`passwordOmit`) | `.auth_provider("<key>", BasicAuthProvider::…)` — stays binding-level; no root path for `BasicAuthProvider` | the bound half's env var; omitted half is a literal `""` |
 | `oauth`, `inferred`, `_other` | Skipped — the SDK has no runtime provider yet | — |
 
 Env-var names come from the IR first because that's where the user's

--- a/generators/cli/CLAUDE.md
+++ b/generators/cli/CLAUDE.md
@@ -87,7 +87,7 @@ the path the patched Cargo.toml references).
 | [`src/patchDistWorkspace.ts`](src/patchDistWorkspace.ts) | Strips Fern-specific cargo-dist metadata (npm-scope, npm-package) from the shipped `dist-workspace.toml`. |
 | [`src/identity.ts`](src/identity.ts) | `deriveBinaryName`, `toKebabCase`, `toEnvVarPrefix`. Resolves `customConfig.binaryName ?? ir.apiDisplayName`. |
 | [`src/customConfig.ts`](src/customConfig.ts) | Type + boundary validator for `generators.yml`'s `config:` block. `binaryName` and `customCommands` (unified flag controlling types/SDK/glue generation). |
-| [`src/detectAuth.ts`](src/detectAuth.ts) | Visits the IR's `auth.schemes` (via `FernIr.AuthScheme._visit`) and emits one `.auth_scheme_env(...)` / `.auth_basic_scheme(...)` per supported scheme. Synchronous — no disk reads. |
+| [`src/detectAuth.ts`](src/detectAuth.ts) | Visits the IR's `auth.schemes` (via `FernIr.AuthScheme._visit`) and emits one auth binding per supported scheme, each tagged `placement: "root" \| "binding"`. Bearer, header, and two-field basic go to root (typed builders like `BasicAuth`) so `auth status` enumerates them; only the `usernameOmit`/`passwordOmit` custom-provider variants stay binding-level. Synchronous — no disk reads. |
 | [`build.mjs`](build.mjs) | Bundles `src/cli.ts` → `dist/cli.cjs`, copies `./sdk/` → `./dist/sdk/` with `SDK_IGNORE` (template dev files that shouldn't ship). |
 | [`Dockerfile`](Dockerfile) | Bakes `dist/` into the generator image. Entrypoint reads `/fern/config.json`. |
 | [`./sdk/`](./sdk/) | Hand-authored Rust SDK — the bulk of the CLI's runtime behavior. Edit this when you need to extend what `CliApp` can do. |

--- a/generators/cli/changes/unreleased/fix-basic-auth-status-visibility.yml
+++ b/generators/cli/changes/unreleased/fix-basic-auth-status-visibility.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generated CLIs now register two-field HTTP Basic auth at the root level
+    (`.auth(BasicAuth::new(...))`) instead of on the `OpenApiBinding`. This
+    makes `<bin> auth status` correctly enumerate the basic scheme, which it
+    previously reported as "No auth schemes are declared" even though
+    credentials were wired and requests authenticated correctly. Request-time
+    behavior is unchanged — the root builder lowers to the same
+    `SchemeBinding::Basic` and still propagates to the binding. (FER-11474)
+  type: fix

--- a/generators/cli/src/__test__/detectAuth.test.ts
+++ b/generators/cli/src/__test__/detectAuth.test.ts
@@ -119,18 +119,16 @@ describe("detectAuthBindings", () => {
         );
     });
 
-    it("basic auth: IR usernameEnvVar + passwordEnvVar drive both sources", () => {
+    it("basic auth (both halves): root-level BasicAuth builder so auth status enumerates it [FER-11474]", () => {
         const bindings = detectAuthBindings({
             auth: auth(basic({ key: "BasicAuth", usernameEnvVar: "CLOSE_USER", passwordEnvVar: "CLOSE_PASS" })),
             binaryName: "close"
         });
         expect(bindings[0]?.rustCall).toBe(
-            '.auth_basic_scheme("BasicAuth", ' +
-                'AuthCredentialSource::from_env("CLOSE_USER"), ' +
-                'AuthCredentialSource::from_env("CLOSE_PASS"))'
+            '.auth(BasicAuth::new("BasicAuth").username_env("CLOSE_USER").password_env("CLOSE_PASS"))'
         );
-        expect(bindings[0]?.placement).toBe("binding");
-        expect(bindings[0]?.authTypeImport).toBe("AuthCredentialSource");
+        expect(bindings[0]?.placement).toBe("root");
+        expect(bindings[0]?.authTypeImport).toBe("BasicAuth");
     });
 
     it("basic auth with passwordOmit (Close pattern): emits auth_provider with BasicAuthProvider::username_only", () => {
@@ -169,10 +167,9 @@ describe("detectAuthBindings", () => {
             binaryName: "acme"
         });
         expect(bindings[0]?.rustCall).toBe(
-            '.auth_basic_scheme("BasicAuth", ' +
-                'AuthCredentialSource::from_env("ACME_USERNAME"), ' +
-                'AuthCredentialSource::from_env("ACME_PASSWORD"))'
+            '.auth(BasicAuth::new("BasicAuth").username_env("ACME_USERNAME").password_env("ACME_PASSWORD"))'
         );
+        expect(bindings[0]?.placement).toBe("root");
     });
 
     it("multiple schemes all produce bindings, in declared order", () => {

--- a/generators/cli/src/detectAuth.ts
+++ b/generators/cli/src/detectAuth.ts
@@ -29,9 +29,14 @@ export interface DetectedAuthBinding {
  *   - `bearer` → `.auth(BearerAuth::new("<key>").env("<env>"))`
  *   - `header` → `.auth(ApiKeyAuth::new("<key>").source(...))` with a
  *     `--api-key` flag tried first, falling back to the env var
- *   - `basic` (both halves bound) → `.auth_basic_scheme(...)`
+ *   - `basic` (both halves bound) → `.auth(BasicAuth::new("<key>").username_env(...).password_env(...))`
+ *     at root, so `auth status` enumerates the scheme [FER-11474]. The
+ *     root `BasicAuth` builder lowers to the same `SchemeBinding::Basic`
+ *     as the binding-level `.auth_basic_scheme(...)` and still propagates
+ *     to the binding via `set_root_auth`, so request-time auth is unchanged.
  *   - `basic` with `passwordOmit: true` →
- *     `.auth_provider("<key>", BasicAuthProvider::username_only(...))`
+ *     `.auth_provider("<key>", BasicAuthProvider::username_only(...))` —
+ *     stays binding-level; no root path exists for `BasicAuthProvider`.
  *   - `basic` with `usernameOmit: true` → symmetric
  *     `.auth_provider("<key>", BasicAuthProvider::password_only(...))`
  *   - `basic` with both omitted → skipped (nothing to bind)
@@ -133,11 +138,15 @@ function bindingForScheme(
                     kind: "basic"
                 };
             }
+            // Both halves bound → root-level typed builder. Placed at root
+            // (like bearer/header) so the framework `auth` subcommand can
+            // enumerate it; `set_root_auth` still propagates it down to the
+            // binding for request-time credential resolution [FER-11474].
             return {
                 schemeName: basic.key,
-                rustCall: `.auth_basic_scheme("${basic.key}", AuthCredentialSource::from_env("${usernameEnv}"), AuthCredentialSource::from_env("${passwordEnv}"))`,
-                placement: "binding",
-                authTypeImport: "AuthCredentialSource",
+                rustCall: `.auth(BasicAuth::new("${basic.key}").username_env("${usernameEnv}").password_env("${passwordEnv}"))`,
+                placement: "root",
+                authTypeImport: "BasicAuth",
                 envVars: [usernameEnv, passwordEnv],
                 kind: "basic"
             };


### PR DESCRIPTION
## Summary

Fixes [FER-11474](https://linear.app/buildwithfern/issue/FER-11474). Generated Fern CLIs whose auth resolves to standard two-field HTTP **Basic** report `No auth schemes are declared` from `<bin> auth status`, even though credentials are wired and requests authenticate correctly. This is cosmetic but confusing — it surfaced while a prospect evaluated the Mailchimp CLI.

## Root cause

There are two `auth_bindings` registries in `fern-cli-sdk`:

- **App-level** on the framework `CliApp` — populated by `.auth(...)`. This is the **only** list the framework `auth` subcommand reads (`dispatch_auth(..., &self.auth_bindings, ...)` → `handle_status`).
- **Binding-level** on `OpenApiBinding` — populated by `.auth_basic_scheme(...)`.

`propagate_root_auth` pushes app-level auth *down* to bindings via `set_root_auth`, but there is no reverse harvest, so binding-level schemes never reach the list `auth status` reads.

The generator's `detectAuth.ts` placed schemes accordingly:

| scheme | placement | visible in `auth status`? |
|---|---|---|
| bearer | root (`.auth(BearerAuth)`) | ✅ |
| header | root (`.auth(ApiKeyAuth)`) | ✅ |
| **basic (two-field)** | **binding (`.auth_basic_scheme`)** | ❌ |

Basic was the one scheme not migrated to root when the auth-at-root architecture landed (fern `8c3588d9dec`) — the `BasicAuth` root builder existed and was unit-tested in cli-sdk (`b4e773d`), but no sample binary exercised it, so it was overlooked.

## Change

Emit two-field basic via the root `BasicAuth` typed builder:

```diff
-.auth_basic_scheme("basicAuth", AuthCredentialSource::from_env("X_USERNAME"), AuthCredentialSource::from_env("X_PASSWORD"))   // on OpenApiBinding
+.auth(BasicAuth::new("basicAuth").username_env("X_USERNAME").password_env("X_PASSWORD"))                                       // at root
```

## Why this is safe for existing users

- `BasicAuth::into_binding()` lowers to the **identical** `SchemeBinding::Basic { username, password }` variant as `.auth_basic_scheme(...)`.
- `set_root_auth` still propagates root auth into every binding, so request-time credential resolution is **unchanged byte-for-byte**.
- The only added effects are (a) the scheme now appears in `auth status`, and (b) `validate_auth` runs for it — and that path **warns, never errors**.

## Explicitly out of scope

The `usernameOmit` / `passwordOmit` custom-provider variants (e.g. the Close "API-key-in-basic-slot" pattern) **stay binding-level** — there is no root path for `BasicAuthProvider`. Those configs see **zero change** and do not regress. Giving them accurate `auth status` requires a root provider path or a binding→app harvest, tracked separately.

## Testing

- Updated and ran `detectAuth.test.ts` (12 passing) — asserts root placement + `BasicAuth` builder output for two-field basic.
- Ran consumer suites `copySpecs` / `emitReadme` / `emitReference` / `generateAgentSkills` (44 passing) — confirms `main.rs` rendering, README, and skills are unaffected.

### Recommended reviewer/CI check

The end-to-end seed repro from the ticket (builds + runs a real basic-auth CLI):

```
pnpm seed run --generator cli \
  --path ~/.frond/companies/mailchimp/config-repo/fern/apis/mailchimp-cli \
  --output-path /tmp/mailchimp-seed-out --skip-scripts
cd /tmp/mailchimp-seed-out && cargo build
MAILCHIMP_USERNAME=any MAILCHIMP_PASSWORD=fake ./target/debug/mailchimp auth status
```

Expected after this change: `auth status` lists the `basicAuth` scheme instead of "No auth schemes are declared."

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->