### PR TITLE
chore(cli-generator): add Prerequisites section to arch-doc-refresh playbook

### DIFF
--- a/generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md
+++ b/generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md
@@ -58,6 +58,24 @@ timestamp.
 
 ---
 
+## Prerequisites
+
+Before starting the methodology, ensure:
+
+1. **Repository**: clone or check out `fern-api/fern`. All commands and
+   file paths in this playbook assume the repo root as the working
+   directory.
+2. **Scope**: the CLI generator lives under `generators/cli/sdk/`. Only
+   files within this subtree are relevant to the agent.
+3. **Configuration**: read
+   `generators/cli/sdk/docs/architecture/automation/sources.yml` for
+   runtime parameters (repo, scope prefix, Linear project, Slack
+   channels, significant paths, output constraints).
+4. **Do not** clone or reference `fern-api/cli-sdk` — that repo is
+   archived and read-only.
+
+---
+
 ## Sources (read-only)
 
 Configured in [`sources.yml`](./sources.yml). All sources are queried in


### PR DESCRIPTION
## Description

Adds explicit "Prerequisites" section to the architecture documentation refresh playbook so the automation agent unambiguously knows to work in `fern-api/fern` (not the archived `fern-api/cli-sdk`).

## Changes Made

- Added a Prerequisites section before the Sources section in `generators/cli/sdk/docs/architecture/automation/PLAYBOOK.md`
- Instructs the agent to clone/work in `fern-api/fern`, scope to `generators/cli/sdk/`, read `sources.yml`, and avoid the archived repo

## Testing

- [x] Manual review — no code changes, documentation only


Link to Devin session: https://app.devin.ai/sessions/4cf1acf4fdf7438a9e79faf55b9d0237
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->