### PR TITLE
fix(cli): add S3 download timeouts to prevent remote generation hang

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-remote-gen-polling-hang.yml
+++ b/packages/cli/cli/changes/unreleased/fix-remote-gen-polling-hang.yml
@@ -1,7 +1,6 @@
 - summary: |
-    Fix remote generation hanging indefinitely after task completion. The async
-    "finished" handler in processUpdate() was invoked via the fiddle-sdk's
-    _visit() method which does not await async visitor results, causing the
-    polling loop to never detect completion. Replaced with a direct switch
-    statement and added download timeouts to prevent indefinite hangs.
+    Fix remote generation CLI hanging indefinitely when S3 download stalls.
+    Added connection timeout (60s) and overall download timeout (5 min) to
+    both downloadZipForTask and downloadAndExtractZipToDirectory, so the CLI
+    fails with a clear error instead of blocking forever.
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-remote-gen-polling-hang.yml
+++ b/packages/cli/cli/changes/unreleased/fix-remote-gen-polling-hang.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix remote generation hanging indefinitely after task completion. The async
+    "finished" handler in processUpdate() was invoked via the fiddle-sdk's
+    _visit() method which does not await async visitor results, causing the
+    polling loop to never detect completion. Replaced with a direct switch
+    statement and added download timeouts to prevent indefinite hangs.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -1,5 +1,5 @@
 import { FERNIGNORE_FILENAME, generatorsYml, getFernIgnorePaths } from "@fern-api/configuration";
-import { noop } from "@fern-api/core-utils";
+import { assertNeverNoThrow } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import {
     buildReplayTelemetryProps,
@@ -200,16 +200,21 @@ export class RemoteTaskHandler {
             );
         };
 
-        await remoteTask.status._visit<void | Promise<void>>({
-            notStarted: noop,
-            running: noop,
-            failed: ({ message, s3PreSignedReadUrl }) => {
+        const status = remoteTask.status;
+        switch (status.type) {
+            case "notStarted":
+            case "running":
+                break;
+            case "failed": {
+                const { message, s3PreSignedReadUrl } = status;
                 if (s3PreSignedReadUrl != null) {
                     logS3Url(s3PreSignedReadUrl);
                 }
                 this.context.failAndThrow(message, undefined, { code: CliError.Code.ContainerError });
-            },
-            finished: async (finishedStatus) => {
+                break;
+            }
+            case "finished": {
+                const finishedStatus = status;
                 if (finishedStatus.s3PreSignedReadUrlV2 != null) {
                     logS3Url(finishedStatus.s3PreSignedReadUrlV2);
                     const absolutePathToLocalOutput = this.getAbsolutePathToLocalOutput();
@@ -237,11 +242,14 @@ export class RemoteTaskHandler {
                 }
 
                 this.emitReplayTelemetryIfReady();
-            },
-            _other: () => {
-                this.context.logger.warn("Received unknown update type: " + remoteTask.status.type);
+                break;
             }
-        });
+            default:
+                // Forward-compatible: warn on unknown status types from newer server versions
+                assertNeverNoThrow(status);
+                this.context.logger.warn("Received unknown update type: " + (status as { type: string }).type);
+                break;
+        }
 
         return this.#isFinished
             ? {
@@ -480,6 +488,9 @@ async function downloadFilesForTask({
     }
 }
 
+/** Maximum time (ms) to wait for the S3 download to complete, including streaming. */
+const S3_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1_000;
+
 async function downloadZipForTask({
     s3PreSignedReadUrl,
     absolutePathToLocalOutput
@@ -489,7 +500,9 @@ async function downloadZipForTask({
 }): Promise<void> {
     // initiate request
     const request = await axios.get(s3PreSignedReadUrl, {
-        responseType: "stream"
+        responseType: "stream",
+        timeout: 60_000,
+        signal: AbortSignal.timeout(S3_DOWNLOAD_TIMEOUT_MS)
     });
 
     // pipe to zip
@@ -655,7 +668,9 @@ async function downloadAndExtractZipToDirectory({
     outputPath: AbsoluteFilePath;
 }): Promise<void> {
     const request = await axios.get(s3PreSignedReadUrl, {
-        responseType: "stream"
+        responseType: "stream",
+        timeout: 60_000,
+        signal: AbortSignal.timeout(S3_DOWNLOAD_TIMEOUT_MS)
     });
 
     const tmpDir = await tmp.dir({ prefix: "fern", unsafeCleanup: true });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -1,5 +1,5 @@
 import { FERNIGNORE_FILENAME, generatorsYml, getFernIgnorePaths } from "@fern-api/configuration";
-import { assertNeverNoThrow } from "@fern-api/core-utils";
+import { noop } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import {
     buildReplayTelemetryProps,
@@ -200,21 +200,16 @@ export class RemoteTaskHandler {
             );
         };
 
-        const status = remoteTask.status;
-        switch (status.type) {
-            case "notStarted":
-            case "running":
-                break;
-            case "failed": {
-                const { message, s3PreSignedReadUrl } = status;
+        await remoteTask.status._visit<void | Promise<void>>({
+            notStarted: noop,
+            running: noop,
+            failed: ({ message, s3PreSignedReadUrl }) => {
                 if (s3PreSignedReadUrl != null) {
                     logS3Url(s3PreSignedReadUrl);
                 }
                 this.context.failAndThrow(message, undefined, { code: CliError.Code.ContainerError });
-                break;
-            }
-            case "finished": {
-                const finishedStatus = status;
+            },
+            finished: async (finishedStatus) => {
                 if (finishedStatus.s3PreSignedReadUrlV2 != null) {
                     logS3Url(finishedStatus.s3PreSignedReadUrlV2);
                     const absolutePathToLocalOutput = this.getAbsolutePathToLocalOutput();
@@ -242,14 +237,11 @@ export class RemoteTaskHandler {
                 }
 
                 this.emitReplayTelemetryIfReady();
-                break;
+            },
+            _other: () => {
+                this.context.logger.warn("Received unknown update type: " + remoteTask.status.type);
             }
-            default:
-                // Forward-compatible: warn on unknown status types from newer server versions
-                assertNeverNoThrow(status);
-                this.context.logger.warn("Received unknown update type: " + (status as { type: string }).type);
-                break;
-        }
+        });
 
         return this.#isFinished
             ? {


### PR DESCRIPTION
## Description

Fixes the CLI hanging indefinitely after remote generation completes when the S3 download stalls.

## Root Cause

Both `downloadZipForTask` and `downloadAndExtractZipToDirectory` call `axios.get(s3PreSignedReadUrl, { responseType: "stream" })` with **no timeout**. After the Fiddle coordinator returns `"_type": "finished"` and the CLI enters the finished handler, it attempts to download generated files from S3. If S3 is unreachable (e.g. through a corporate proxy), the download hangs forever and the CLI never exits.

Evidence from the user's debug logs:
```
DEBUG 21:31:57.176Z fernapi/fern-typescript-sdk Generated files. View here: https://s3.amazonaws.com/...
┌─
│ ⡀  fernapi/fern-typescript-sdk   ← CLI stuck here, download never completes
└─
```

## Changes Made

Added timeouts to both S3 download functions in `RemoteTaskHandler.ts`:

```diff
 const request = await axios.get(s3PreSignedReadUrl, {
-    responseType: "stream"
+    responseType: "stream",
+    timeout: 60_000,                              // 60s connection timeout
+    signal: AbortSignal.timeout(S3_DOWNLOAD_TIMEOUT_MS)  // 5 min overall
 });
```

- `timeout: 60_000` — axios connection/response timeout (60 seconds)
- `AbortSignal.timeout(S3_DOWNLOAD_TIMEOUT_MS)` — hard 5-minute cap on the entire download including streaming

The CLI will now fail with a clear `NetworkError` ("Failed to download files") instead of blocking indefinitely.

## Testing

- [x] TypeScript compilation passes
- [x] Biome lint passes
- [x] Unit tests pass (`pnpm turbo run test --filter @fern-api/remote-workspace-runner`)


Link to Devin session: https://app.devin.ai/sessions/ac52847fd52a4366b0f8e9125af51345
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->