### PR TITLE
chore(deps): bump pnpm, @sigstore/core, and sigstore/rekor to fix CVEs in generator and seed containers

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -48,12 +48,14 @@ RUN git clone --depth 1 --branch v${RUNC_VERSION} https://github.com/opencontain
     go mod vendor && \
     make static EXTRA_LDFLAGS="-s -w" && \
     cp runc /overlay/usr/local/bin/runc
+ARG REKOR_VERSION=1.5.2
 RUN git clone --depth 1 --branch docker-v${MOBY_VERSION} https://github.com/moby/moby.git /src/moby && \
     cd /src/moby && \
     go get golang.org/x/net@v${XNET_VERSION} \
            golang.org/x/crypto@v${XCRYPTO_VERSION} \
            golang.org/x/sys@v${XSYS_VERSION} \
            github.com/containerd/containerd/v2@v${CONTAINERD_VERSION} \
+           github.com/sigstore/rekor@v${REKOR_VERSION} \
            go.opentelemetry.io/otel/sdk@v${OTEL_SDK_VERSION} \
            go.opentelemetry.io/otel@v${OTEL_SDK_VERSION} \
            go.opentelemetry.io/otel/trace@v${OTEL_SDK_VERSION} \

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -49,12 +49,14 @@ RUN git clone --depth 1 --branch v${RUNC_VERSION} https://github.com/opencontain
     go mod vendor && \
     make static EXTRA_LDFLAGS="-s -w" && \
     cp runc /overlay/usr/local/bin/runc
+ARG REKOR_VERSION=1.5.2
 RUN git clone --depth 1 --branch docker-v${MOBY_VERSION} https://github.com/moby/moby.git /src/moby && \
     cd /src/moby && \
     go get golang.org/x/net@v${XNET_VERSION} \
            golang.org/x/crypto@v${XCRYPTO_VERSION} \
            golang.org/x/sys@v${XSYS_VERSION} \
            github.com/containerd/containerd/v2@v${CONTAINERD_VERSION} \
+           github.com/sigstore/rekor@v${REKOR_VERSION} \
            go.opentelemetry.io/otel/sdk@v${OTEL_SDK_VERSION} \
            go.opentelemetry.io/otel@v${OTEL_SDK_VERSION} \
            go.opentelemetry.io/otel/trace@v${OTEL_SDK_VERSION} \

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -49,12 +49,14 @@ RUN git clone --depth 1 --branch v${RUNC_VERSION} https://github.com/opencontain
     go mod vendor && \
     make static EXTRA_LDFLAGS="-s -w" && \
     cp runc /overlay/usr/local/bin/runc
+ARG REKOR_VERSION=1.5.2
 RUN git clone --depth 1 --branch docker-v${MOBY_VERSION} https://github.com/moby/moby.git /src/moby && \
     cd /src/moby && \
     go get golang.org/x/net@v${XNET_VERSION} \
            golang.org/x/crypto@v${XCRYPTO_VERSION} \
            golang.org/x/sys@v${XSYS_VERSION} \
            github.com/containerd/containerd/v2@v${CONTAINERD_VERSION} \
+           github.com/sigstore/rekor@v${REKOR_VERSION} \
            go.opentelemetry.io/otel/sdk@v${OTEL_SDK_VERSION} \
            go.opentelemetry.io/otel@v${OTEL_SDK_VERSION} \
            go.opentelemetry.io/otel/trace@v${OTEL_SDK_VERSION} \

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -83,9 +83,11 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf tar-7.5.16.tgz --strip-components=1 -C tar/ && \
     rm tar-7.5.16.tgz
 
-# pnpm 10.34.3 bundles tar 7.5.16, clearing GHSA-vmf3-w455-68vh from pnpm's vendored copy.
-RUN npm install -g pnpm@10.34.3 --force
-RUN corepack prepare pnpm@10.34.3
+# pnpm 10.34.4 bundles tar 7.5.16, clearing GHSA-vmf3-w455-68vh from pnpm's vendored copy.
+# 10.34.4 also fixes CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
+# GHSA-72r4-9c5j-mj57.
+RUN npm install -g pnpm@10.34.4 --force
+RUN corepack prepare pnpm@10.34.4
 RUN npm install -g yarn@1.22.22 --force
 RUN corepack prepare yarn@1.22.22
 

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -83,11 +83,10 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf tar-7.5.16.tgz --strip-components=1 -C tar/ && \
     rm tar-7.5.16.tgz
 
-# pnpm 10.34.4 bundles tar 7.5.16, clearing GHSA-vmf3-w455-68vh from pnpm's vendored copy.
-# 10.34.4 also fixes CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
-# GHSA-72r4-9c5j-mj57.
-RUN npm install -g pnpm@10.34.4 --force
-RUN corepack prepare pnpm@10.34.4
+# pnpm 11.5.3+ clears CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
+# GHSA-72r4-9c5j-mj57, and bundles tar 7.5.16 (GHSA-vmf3-w455-68vh).
+RUN npm install -g pnpm@11.5.3 --force
+RUN corepack prepare pnpm@11.5.3
 RUN npm install -g yarn@1.22.22 --force
 RUN corepack prepare yarn@1.22.22
 

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -29,7 +29,7 @@ FROM node:24.17.0-trixie-slim
 ENV PNPM_STORE_PATH=/.pnpm-cache
 ENV YARN_CACHE_FOLDER=/.yarn-cache
 ENV PNPM_HOME=/.pnpm
-ENV PATH=$PNPM_HOME:$PATH
+ENV PATH=$PNPM_HOME/bin:$PNPM_HOME:$PATH
 
 # Apply latest Debian security updates so that grype-tracked OS package
 # vulnerabilities (perl-base, liblzma5, libgnutls30, libpam*, libc*, gpgv,

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -83,10 +83,10 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf tar-7.5.16.tgz --strip-components=1 -C tar/ && \
     rm tar-7.5.16.tgz
 
-# pnpm 11.5.3+ clears CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
+# pnpm 11.8.0+ clears CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
 # GHSA-72r4-9c5j-mj57, and bundles tar 7.5.16 (GHSA-vmf3-w455-68vh).
-RUN npm install -g pnpm@11.5.3 --force
-RUN corepack prepare pnpm@11.5.3
+RUN npm install -g pnpm@11.8.0 --force
+RUN corepack prepare pnpm@11.8.0
 RUN npm install -g yarn@1.22.22 --force
 RUN corepack prepare yarn@1.22.22
 

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -119,6 +119,18 @@ RUN chmod +x /tmp/tsgolint-rebuilt && \
     fi; \
     rm /tmp/tsgolint-rebuilt
 
+# Clean pnpm content-addressable store (holds the pre-built tsgolint
+# binary compiled with go1.26.2) and corepack cache (holds a second
+# pnpm dist with bundled undici 6.26.0). Patch the npm-installed pnpm's
+# bundled undici to 6.27.0 to clear CVE-2026-12151.
+RUN rm -rf /.pnpm/store /.pnpm-cache /root/.cache/node/corepack && \
+    cd /usr/local/lib/node_modules/pnpm/dist/node_modules && \
+    npm pack undici@6.27.0 && \
+    rm -rf undici && \
+    mkdir undici && \
+    tar -xzf undici-6.27.0.tgz --strip-components=1 -C undici/ && \
+    rm undici-6.27.0.tgz
+
 WORKDIR /
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -111,6 +111,19 @@ RUN for dir in \
       fi; \
     done
 
+# Patch @sigstore/core to 3.2.1 to fix GHSA-jfc7-64v2-mr8c.
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/@sigstore/core; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz -o core-3.2.1.tgz && \
+        mkdir -p core && \
+        tar -xzf core-3.2.1.tgz --strip-components=1 -C core/ && \
+        rm core-3.2.1.tgz; \
+      fi; \
+    done
+
 COPY generators/csharp/sdk/features.yml /assets/features.yml
 COPY generators/csharp/sdk/dist /dist
 

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -38,6 +38,18 @@ RUN set -eux; \
     tar -xzf "${TARBALL}" -C "${NPM_NM}/tar" --strip-components=1; \
     cd / && rm -rf /tmp/pkg-fix /root/.npm
 
+# Patch @sigstore/core to 3.2.1 to fix GHSA-jfc7-64v2-mr8c.
+RUN set -eux; \
+    NPM_NM=/usr/local/lib/node_modules/npm/node_modules; \
+    if [ -d "${NPM_NM}/@sigstore/core" ]; then \
+        TARBALL="$(npm pack @sigstore/core@3.2.1 --silent)"; \
+        rm -rf "${NPM_NM}/@sigstore/core"; \
+        mkdir -p "${NPM_NM}/@sigstore/core"; \
+        tar -xzf "${TARBALL}" -C "${NPM_NM}/@sigstore/core" --strip-components=1; \
+        rm -f "${TARBALL}"; \
+    fi; \
+    cd / && rm -rf /tmp/pkg-fix /root/.npm
+
 COPY generators/go-v2/sdk/dist/ /dist/
 
 # Stage 2: Final Go image

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -211,6 +211,19 @@ RUN for dir in \
       fi; \
     done
 
+# Patch @sigstore/core to 3.2.1 to fix GHSA-jfc7-64v2-mr8c.
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/@sigstore/core; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz -o core-3.2.1.tgz && \
+        mkdir -p core && \
+        tar -xzf core-3.2.1.tgz --strip-components=1 -C core/ && \
+        rm core-3.2.1.tgz; \
+      fi; \
+    done
+
 # Copy Node CLI from first stage and rename it /bin/java-v2
 COPY --from=node /dist/cli.cjs /bin/java-v2
 COPY --from=node /assets/features.yml /assets/features.yml

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -89,6 +89,19 @@ RUN for dir in \
       fi; \
     done
 
+# Patch @sigstore/core to 3.2.1 to fix GHSA-jfc7-64v2-mr8c.
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/@sigstore/core; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz -o core-3.2.1.tgz && \
+        mkdir -p core && \
+        tar -xzf core-3.2.1.tgz --strip-components=1 -C core/ && \
+        rm core-3.2.1.tgz; \
+      fi; \
+    done
+
 RUN curl -fsSL https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.94.2/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer \
     && chmod +x /usr/local/bin/php-cs-fixer \
     && php-cs-fixer --version

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -109,6 +109,19 @@ RUN for dir in \
       fi; \
     done
 
+# Patch @sigstore/core to 3.2.1 to fix GHSA-jfc7-64v2-mr8c.
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/@sigstore/core; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz -o core-3.2.1.tgz && \
+        mkdir -p core && \
+        tar -xzf core-3.2.1.tgz --strip-components=1 -C core/ && \
+        rm core-3.2.1.tgz; \
+      fi; \
+    done
+
 # Install ruff.
 RUN pip install ruff==0.15.7
 RUN ruff --version

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -76,6 +76,19 @@ RUN for dir in \
       fi; \
     done
 
+# Patch @sigstore/core to 3.2.1 to fix GHSA-jfc7-64v2-mr8c.
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/@sigstore/core; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz -o core-3.2.1.tgz && \
+        mkdir -p core && \
+        tar -xzf core-3.2.1.tgz --strip-components=1 -C core/ && \
+        rm core-3.2.1.tgz; \
+      fi; \
+    done
+
 ARG SENTRY_DSN
 ARG SENTRY_ENVIRONMENT=production
 ARG SENTRY_RELEASE

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -129,6 +129,17 @@ RUN chmod +x /tmp/tsgolint-rebuilt && \
     fi; \
     rm /tmp/tsgolint-rebuilt
 
+# Clean pnpm content-addressable store (holds the pre-built tsgolint
+# binary compiled with go1.26.2) and corepack cache. Patch pnpm's
+# bundled undici to 6.27.0 to clear CVE-2026-12151.
+RUN rm -rf /.pnpm/store /.pnpm-cache /root/.cache/node/corepack && \
+    cd /usr/local/lib/node_modules/pnpm/dist/node_modules && \
+    npm pack undici@6.27.0 && \
+    rm -rf undici && \
+    mkdir undici && \
+    tar -xzf undici-6.27.0.tgz --strip-components=1 -C undici/ && \
+    rm undici-6.27.0.tgz
+
 COPY generators/typescript/sdk/cli/dist/ /
 
 ENTRYPOINT ["node", "--enable-source-maps", "/cli.cjs"]

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -94,10 +94,10 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf tar-7.5.16.tgz --strip-components=1 -C tar/ && \
     rm tar-7.5.16.tgz
 
-# pnpm 10.34.4 bundles patched picomatch, brace-expansion, tar (7.5.16), and ip-address.
-# 10.34.4 also fixes CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
-# GHSA-72r4-9c5j-mj57.
-RUN npm install -g pnpm@10.34.4 --force
+# pnpm 11.5.3+ clears CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
+# GHSA-72r4-9c5j-mj57, and bundles patched picomatch, brace-expansion, tar (7.5.16),
+# and ip-address.
+RUN npm install -g pnpm@11.5.3 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -56,7 +56,7 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 ENV PNPM_STORE_PATH=/.pnpm-cache
 ENV YARN_CACHE_FOLDER=/.yarn-cache
 ENV PNPM_HOME=/.pnpm
-ENV PATH=$PNPM_HOME:$PATH
+ENV PATH=$PNPM_HOME/bin:$PNPM_HOME:$PATH
 ARG SENTRY_DSN
 ARG SENTRY_ENVIRONMENT=production
 ARG SENTRY_RELEASE

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -94,10 +94,10 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf tar-7.5.16.tgz --strip-components=1 -C tar/ && \
     rm tar-7.5.16.tgz
 
-# pnpm 11.5.3+ clears CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
+# pnpm 11.8.0+ clears CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
 # GHSA-72r4-9c5j-mj57, and bundles patched picomatch, brace-expansion, tar (7.5.16),
 # and ip-address.
-RUN npm install -g pnpm@11.5.3 --force
+RUN npm install -g pnpm@11.8.0 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -94,8 +94,10 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf tar-7.5.16.tgz --strip-components=1 -C tar/ && \
     rm tar-7.5.16.tgz
 
-# pnpm 10.34.3 bundles patched picomatch, brace-expansion, tar (7.5.16), and ip-address.
-RUN npm install -g pnpm@10.34.3 --force
+# pnpm 10.34.4 bundles patched picomatch, brace-expansion, tar (7.5.16), and ip-address.
+# 10.34.4 also fixes CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c,
+# GHSA-72r4-9c5j-mj57.
+RUN npm install -g pnpm@10.34.4 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \


### PR DESCRIPTION
## Description

Bumps vulnerable dependencies in generator and seed container Dockerfiles to address active CVE alerts.

## Changes Made

### pnpm 10.34.3 → 11.8.0 (typescript-sdk-generator, ts-seed)
- Fixes CVE-2026-55697, GHSA-fr4h-3cph-29xv, GHSA-qrv3-253h-g69c, GHSA-72r4-9c5j-mj57
- Upgraded to 11.8.0 because scanners only recognize the 11.x fix track
- Added `$PNPM_HOME/bin` to PATH (pnpm 11 changed the global bin directory)
- Cleans pnpm content-addressable store after installs to remove pre-built Go 1.26.2 binaries cached from oxlint-tsgolint npm package
- Patches pnpm's bundled undici 6.26.0 → 6.27.0 to clear CVE-2026-12151 (scanner accepts 6.27.0 but not 6.26.0)
- Deletes corepack cache (second pnpm dist with bundled undici)
- Files: `docker/seed/Dockerfile.ts`, `generators/typescript/sdk/cli/Dockerfile`

### @sigstore/core 3.2.0 → 3.2.1 (sdk-generator containers)
- Fixes GHSA-jfc7-64v2-mr8c
- Patches npm's bundled `@sigstore/core` (transitive dep via `@sigstore/tuf`) in containers using the `node:24.17` base image (which ships npm 11.12.1)
- Files: `generators/{swift,python,go,php,csharp,java}/sdk/Dockerfile`

### sigstore/rekor v1.5.0 → v1.5.2 (seed containers)
- Fixes GHSA-47q9-m4ww-924m
- Adds `github.com/sigstore/rekor@v1.5.2` to the moby `go get` commands so the rebuilt dockerd binary embeds the patched version
- Files: `docker/seed/Dockerfile.{python,go,php}`

## Testing

- [x] `pnpm run check` (biome lint) passes
- [x] All CI grype scans pass
- [x] CI docker builds verify the Dockerfiles are syntactically correct
- [ ] User rebuilds containers and validates scanner results

Link to Devin session: https://app.devin.ai/sessions/a4b623265fb8497295ade571054e0a32
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->