### PR TITLE
chore(seed): add any-auth-basic-oauth-openapi reference fixture

### DIFF
--- a/test-definitions/fern/apis/any-auth-basic-oauth-openapi/generators.yml
+++ b/test-definitions/fern/apis/any-auth-basic-oauth-openapi/generators.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+auth-schemes:
+  BasicAuth:
+    scheme: basic
+    username:
+      name: username
+      env: BASIC_AUTH_USERNAME
+    password:
+      name: password
+      env: BASIC_AUTH_PASSWORD
+  OAuth:
+    scheme: oauth
+    type: client-credentials
+    client-id-env: OAUTH_CLIENT_ID
+    client-secret-env: OAUTH_CLIENT_SECRET
+    get-token:
+      endpoint: POST /oauth/token
+      request-properties:
+        client-id: $request.client_id
+        client-secret: $request.client_secret
+      response-properties:
+        access-token: $response.access_token
+        expires-in: $response.expires_in
+api:
+  auth:
+    any:
+      - BasicAuth
+      - OAuth
+  specs:
+    - openapi: ./openapi.yml
+groups: {}

--- a/test-definitions/fern/apis/any-auth-basic-oauth-openapi/openapi.yml
+++ b/test-definitions/fern/apis/any-auth-basic-oauth-openapi/openapi.yml
@@ -1,0 +1,106 @@
+openapi: 3.0.1
+info:
+  title: Basic Auth + OAuth Client Credentials Example
+  version: 1.0.0
+security:
+  - BasicAuth: []
+  - BearerAuth: []
+paths:
+  /oauth/token:
+    post:
+      operationId: auth_getToken
+      tags:
+        - Auth
+      summary: Exchange client credentials for an access token
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client_id:
+                  type: string
+                client_secret:
+                  type: string
+                grant_type:
+                  type: string
+                  enum:
+                    - client_credentials
+              required:
+                - client_id
+                - client_secret
+                - grant_type
+      responses:
+        "200":
+          description: Successful token response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+  /resources:
+    get:
+      operationId: resources_list
+      tags:
+        - Resources
+      summary: List all resources
+      responses:
+        "200":
+          description: A list of resources
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Resource"
+  /resources/{resourceId}:
+    get:
+      operationId: resources_get
+      tags:
+        - Resources
+      summary: Get a resource by ID
+      parameters:
+        - name: resourceId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A single resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    BearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    TokenResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+        expires_in:
+          type: integer
+      required:
+        - access_token
+        - expires_in
+    Resource:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+      required:
+        - id
+        - name


### PR DESCRIPTION
## Description

Adds a minimal reference fixture demonstrating how to combine Basic Auth and OAuth client-credentials on the same API using `api.auth.any`, modeled on the pattern in `fern-demo/twilio-core-fern-config`.

## Changes Made

- Added `test-definitions/fern/apis/any-auth-basic-oauth-openapi/generators.yml`:
  - Two `auth-schemes`: `BasicAuth` (scheme: basic) and `OAuth` (scheme: oauth, type: client-credentials)
  - `api.auth.any` composing both so the SDK accepts either
  - OAuth `get-token` references `POST /oauth/token` with `client_id`/`client_secret` request properties
- Added `test-definitions/fern/apis/any-auth-basic-oauth-openapi/openapi.yml`:
  - `BasicAuth` (http/basic) and `BearerAuth` (http/bearer, backing OAuth) in `components.securitySchemes`
  - Both listed in the top-level `security` array
  - `POST /oauth/token` endpoint with `security: []` (unauthenticated) matching the `get-token` block
  - Two sample resource endpoints (`GET /resources`, `GET /resources/{resourceId}`) that inherit the global security

## Testing

- `fern check --api any-auth-basic-oauth-openapi` passes successfully

Link to Devin session: https://app.devin.ai/sessions/8addd46cd4f5409b92183ae9ab70fb88
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->