### PR TITLE
fix(cli): add pnpm 10+ workspace config compatibility for docs dev

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-pnpm10-docs-dev.yml
+++ b/packages/cli/cli/changes/unreleased/fix-pnpm10-docs-dev.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix `fern docs dev` failing with pnpm 10+ due to missing `packages` field
+    in generated `pnpm-workspace.yaml` and missing `-w` flag on `pnpm i esbuild`.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -568,13 +568,20 @@ export async function downloadBundle({
 
             const workspaceConfigPath = path.join(absolutePathToBundleFolder, "pnpm-workspace.yaml");
             if (!existsSync(workspaceConfigPath)) {
-                await writeFile(workspaceConfigPath, "onlyBuiltDependencies:\n  - esbuild\n");
+                // pnpm 10+ requires the `packages` field in pnpm-workspace.yaml
+                await writeFile(workspaceConfigPath, "packages: []\nonlyBuiltDependencies:\n  - esbuild\n");
+            } else {
+                // patch stale cached configs from previous runs that lack the `packages` field
+                const existingWorkspaceConfig = await readFile(workspaceConfigPath, "utf-8");
+                if (!existingWorkspaceConfig.includes("packages:")) {
+                    await writeFile(workspaceConfigPath, `packages: []\n${existingWorkspaceConfig}`);
+                }
             }
 
             try {
                 // install esbuild
                 logger.debug("Installing esbuild");
-                await loggingExeca(logger, "pnpm", ["i", "esbuild"], {
+                await loggingExeca(logger, "pnpm", ["i", "-w", "esbuild"], {
                     cwd: absolutePathToBundleFolder,
                     doNotPipeOutput: true
                 });
@@ -603,7 +610,7 @@ export async function downloadBundle({
                         try {
                             // Try installing esbuild again after upgrading corepack
                             logger.debug("Installing esbuild after upgrading corepack");
-                            await loggingExeca(logger, "pnpm", ["i", "esbuild"], {
+                            await loggingExeca(logger, "pnpm", ["i", "-w", "esbuild"], {
                                 cwd: absolutePathToBundleFolder,
                                 doNotPipeOutput: true
                             });


### PR DESCRIPTION
## Description
Customers on pnpm 10+/11 hit `ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION` ("packages field missing or empty") and `ERR_PNPM_ADDING_TO_ROOT` when running `fern docs dev`. Confirmed by two customers (Bigcommerce, Cohere).

pnpm 10+ requires a `packages` field in `pnpm-workspace.yaml` and a `-w` (workspace-root) flag when adding dependencies at the workspace root. The docs-preview bootstrap generated a `pnpm-workspace.yaml` without `packages` and ran `pnpm i esbuild` without `-w`.

## Changes Made
- Generate `pnpm-workspace.yaml` with `packages: []` (required by pnpm 10+)
- Add an else branch that patches stale cached configs from previous runs that lack the `packages` field
- Add `-w` to both `pnpm i esbuild` invocations

## Testing
Reproduced and verified locally against pnpm **10.0.0** (strict) and **11.0.6** (current):

| Scenario | Result |
|---|---|
| Old config (no `packages:`) + `pnpm i esbuild` | ❌ `ERROR packages field missing or empty` |
| `packages: []` added but **no `-w`** | ❌ `ERR_PNPM_ADDING_TO_ROOT` |
| Full fix: `packages: []` + `pnpm i -w esbuild` | ✅ installs successfully (pnpm 10 & 11) |

Reproducing both errors in sequence proves both halves of the fix are necessary — fixing only the workspace config surfaces the second error.

- [x] Manual testing completed (pnpm 10.0.0 + 11.0.6)
- [x] `pnpm run check` (biome) passes
- [x] `pnpm turbo run compile --filter @fern-api/docs-preview` passes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->