### PR TITLE
feat(cli): annotate PR URLs in GitHub Actions when SDK generation creates a PR

### DIFF
--- a/packages/cli/cli-logger/src/__test__/githubAnnotations.test.ts
+++ b/packages/cli/cli-logger/src/__test__/githubAnnotations.test.ts
@@ -89,6 +89,19 @@ describe("renderGithubAnnotation", () => {
         expect(renderGithubAnnotation("warning", "deprecated")).toBe("::warning::deprecated\n");
     });
 
+    it("renders ::notice:: level", () => {
+        expect(renderGithubAnnotation("notice", "https://github.com/org/repo/pull/42")).toBe(
+            "::notice::https://github.com/org/repo/pull/42\n"
+        );
+    });
+
+    it("renders ::notice:: with title and file properties", () => {
+        const out = renderGithubAnnotation("notice", "https://github.com/org/repo/pull/42", {
+            title: "my-generator (group=sdk) → PR created"
+        });
+        expect(out).toBe("::notice title=my-generator (group=sdk) → PR created::https://github.com/org/repo/pull/42\n");
+    });
+
     it("formats file/line/title properties in reading order (file, line, title)", () => {
         const out = renderGithubAnnotation("error", "boom", {
             file: "fern/generators.yml",

--- a/packages/cli/cli-logger/src/githubAnnotations.ts
+++ b/packages/cli/cli-logger/src/githubAnnotations.ts
@@ -3,7 +3,7 @@ import { LogLevel } from "@fern-api/logger";
 
 import { Log } from "./Log.js";
 
-export type GithubAnnotationLevel = "error" | "warning";
+export type GithubAnnotationLevel = "error" | "warning" | "notice";
 
 /**
  * Properties supported by GitHub Actions `::error/warning file=...,line=...,title=...::message`

--- a/packages/cli/cli/changes/unreleased/github-actions-pr-annotations.yml
+++ b/packages/cli/cli/changes/unreleased/github-actions-pr-annotations.yml
@@ -1,0 +1,5 @@
+- summary: |
+    When running inside GitHub Actions, SDK generation PR URLs are now surfaced as
+    `::notice::` annotations in the workflow run page and appended to the step summary.
+    Previously, PR URLs were only visible in debug-level log output.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/github-actions-pr-annotations.yml
+++ b/packages/cli/cli/changes/unreleased/github-actions-pr-annotations.yml
@@ -1,5 +1,7 @@
 - summary: |
-    When running inside GitHub Actions, SDK generation PR URLs are now surfaced as
+    When running inside GitHub Actions, notable SDK generation events are now surfaced as
     `::notice::` annotations in the workflow run page and appended to the step summary.
-    Previously, PR URLs were only visible in debug-level log output.
+    Annotated events include PR creation, package publication (npm, PyPI, Maven, etc.),
+    no-changes-detected, and version tagging. Previously, these details were only visible
+    in debug-level log output.
   type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -36,6 +36,7 @@
     "@fern-api/api-workspace-validator": "workspace:*",
     "@fern-api/auth": "workspace:*",
     "@fern-api/casings-generator": "workspace:*",
+    "@fern-api/cli-logger": "workspace:*",
     "@fern-api/cli-source-resolver": "workspace:*",
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core": "workspace:*",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/emitPrUrlAnnotationAndSummary.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/emitPrUrlAnnotationAndSummary.test.ts
@@ -3,9 +3,20 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { emitPrUrlAnnotationAndSummary } from "../runRemoteGenerationForAPIWorkspace.js";
+import { emitGenerationAnnotations } from "../runRemoteGenerationForAPIWorkspace.js";
 
-describe("emitPrUrlAnnotationAndSummary", () => {
+const BASE_CONTEXT = {
+    pullRequestUrl: undefined,
+    publishTarget: undefined,
+    noChangesDetected: undefined,
+    version: undefined,
+    generatorName: "fernapi/fern-typescript-sdk",
+    groupName: "ts-sdk",
+    apiName: undefined,
+    isAutomation: false
+} as const;
+
+describe("emitGenerationAnnotations", () => {
     const originalGithubActions = process.env.GITHUB_ACTIONS;
     const originalStepSummary = process.env.GITHUB_STEP_SUMMARY;
     let stdoutSpy: ReturnType<typeof vi.spyOn>;
@@ -30,38 +41,28 @@ describe("emitPrUrlAnnotationAndSummary", () => {
         stdoutSpy.mockRestore();
     });
 
-    it("does nothing when pullRequestUrl is undefined", async () => {
+    it("does nothing when no notable events occurred", async () => {
         process.env.GITHUB_ACTIONS = "true";
-        await emitPrUrlAnnotationAndSummary({
-            pullRequestUrl: undefined,
-            generatorName: "fernapi/fern-typescript-sdk",
-            groupName: "ts-sdk",
-            apiName: undefined,
-            isAutomation: false
-        });
+        await emitGenerationAnnotations({ ...BASE_CONTEXT });
         expect(stdoutSpy).not.toHaveBeenCalled();
     });
 
     it("does nothing when not running in GitHub Actions", async () => {
         delete process.env.GITHUB_ACTIONS;
-        await emitPrUrlAnnotationAndSummary({
-            pullRequestUrl: "https://github.com/org/repo/pull/42",
-            generatorName: "fernapi/fern-typescript-sdk",
-            groupName: "ts-sdk",
-            apiName: undefined,
-            isAutomation: false
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            pullRequestUrl: "https://github.com/org/repo/pull/42"
         });
         expect(stdoutSpy).not.toHaveBeenCalled();
     });
 
-    it("emits a ::notice:: annotation with generator name and group in the title", async () => {
+    // ─── PR created ─────────────────────────────────────────
+
+    it("emits a ::notice:: annotation for PR created", async () => {
         process.env.GITHUB_ACTIONS = "true";
-        await emitPrUrlAnnotationAndSummary({
-            pullRequestUrl: "https://github.com/org/repo/pull/42",
-            generatorName: "fernapi/fern-typescript-sdk",
-            groupName: "ts-sdk",
-            apiName: undefined,
-            isAutomation: false
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            pullRequestUrl: "https://github.com/org/repo/pull/42"
         });
         expect(stdoutSpy).toHaveBeenCalledWith(
             "::notice title=fernapi/fern-typescript-sdk (group=ts-sdk) → PR created::https://github.com/org/repo/pull/42\n"
@@ -70,34 +71,162 @@ describe("emitPrUrlAnnotationAndSummary", () => {
 
     it("includes the api name in the title when present", async () => {
         process.env.GITHUB_ACTIONS = "true";
-        await emitPrUrlAnnotationAndSummary({
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
             pullRequestUrl: "https://github.com/org/repo/pull/42",
             generatorName: "fernapi/fern-python-sdk",
             groupName: "production",
-            apiName: "internal",
-            isAutomation: false
+            apiName: "internal"
         });
         expect(stdoutSpy).toHaveBeenCalledWith(
             "::notice title=fernapi/fern-python-sdk (group=production%2C api=internal) → PR created::https://github.com/org/repo/pull/42\n"
         );
     });
 
-    it("appends a markdown line to GITHUB_STEP_SUMMARY for non-automation runs", async () => {
+    // ─── Published to registry ──────────────────────────────
+
+    it("emits a ::notice:: annotation for package published", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            publishTarget: {
+                registry: "npm",
+                label: "npm",
+                version: "1.0.0",
+                url: "https://www.npmjs.com/package/@org/sdk/v/1.0.0"
+            }
+        });
+        expect(stdoutSpy).toHaveBeenCalledWith(
+            "::notice title=fernapi/fern-typescript-sdk (group=ts-sdk) → Published to npm::1.0.0 → https://www.npmjs.com/package/@org/sdk/v/1.0.0\n"
+        );
+    });
+
+    it("emits a ::notice:: annotation for PyPI publish", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            generatorName: "fernapi/fern-python-sdk",
+            groupName: "production",
+            publishTarget: {
+                registry: "pypi",
+                label: "PyPI",
+                version: "0.5.2",
+                url: "https://pypi.org/project/my-sdk/0.5.2/"
+            }
+        });
+        expect(stdoutSpy).toHaveBeenCalledWith(
+            "::notice title=fernapi/fern-python-sdk (group=production) → Published to PyPI::0.5.2 → https://pypi.org/project/my-sdk/0.5.2/\n"
+        );
+    });
+
+    // ─── No changes detected ────────────────────────────────
+
+    it("emits a ::notice:: annotation when no changes detected", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            noChangesDetected: true
+        });
+        expect(stdoutSpy).toHaveBeenCalledWith(
+            "::notice title=fernapi/fern-typescript-sdk (group=ts-sdk) → No changes detected::SDK repo is already up to date\n"
+        );
+    });
+
+    it("does not emit no-changes annotation when noChangesDetected is false", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            noChangesDetected: false
+        });
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    // ─── Version tagged ─────────────────────────────────────
+
+    it("emits a ::notice:: annotation for version when no PR or publish", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            version: "2.0.0"
+        });
+        expect(stdoutSpy).toHaveBeenCalledWith(
+            "::notice title=fernapi/fern-typescript-sdk (group=ts-sdk) → Version 2.0.0::Generated version 2.0.0\n"
+        );
+    });
+
+    it("does not emit standalone version annotation when PR is present", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            pullRequestUrl: "https://github.com/org/repo/pull/42",
+            version: "2.0.0"
+        });
+        // Should emit PR annotation but NOT a separate version annotation
+        expect(stdoutSpy).toHaveBeenCalledTimes(1);
+        expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("PR created"));
+    });
+
+    it("does not emit standalone version annotation when publishTarget is present", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            publishTarget: {
+                registry: "npm",
+                label: "npm",
+                version: "1.0.0",
+                url: "https://www.npmjs.com/package/@org/sdk/v/1.0.0"
+            },
+            version: "1.0.0"
+        });
+        // Should emit publish annotation but NOT a separate version annotation
+        expect(stdoutSpy).toHaveBeenCalledTimes(1);
+        expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("Published to npm"));
+    });
+
+    // ─── Multiple events at once ────────────────────────────
+
+    it("emits multiple annotations when both PR and publish occur", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitGenerationAnnotations({
+            ...BASE_CONTEXT,
+            pullRequestUrl: "https://github.com/org/repo/pull/42",
+            publishTarget: {
+                registry: "npm",
+                label: "npm",
+                version: "1.0.0",
+                url: "https://www.npmjs.com/package/@org/sdk/v/1.0.0"
+            },
+            version: "1.0.0"
+        });
+        expect(stdoutSpy).toHaveBeenCalledTimes(2);
+        expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("PR created"));
+        expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("Published to npm"));
+    });
+
+    // ─── Step summary ───────────────────────────────────────
+
+    it("appends markdown lines to GITHUB_STEP_SUMMARY for non-automation runs", async () => {
         process.env.GITHUB_ACTIONS = "true";
         const summaryPath = join(tmpdir(), `step-summary-${Date.now()}.md`);
         writeFileSync(summaryPath, "", "utf8");
         process.env.GITHUB_STEP_SUMMARY = summaryPath;
 
         try {
-            await emitPrUrlAnnotationAndSummary({
+            await emitGenerationAnnotations({
+                ...BASE_CONTEXT,
                 pullRequestUrl: "https://github.com/org/repo/pull/42",
-                generatorName: "fernapi/fern-typescript-sdk",
-                groupName: "ts-sdk",
-                apiName: undefined,
-                isAutomation: false
+                publishTarget: {
+                    registry: "npm",
+                    label: "npm",
+                    version: "1.0.0",
+                    url: "https://www.npmjs.com/package/@org/sdk/v/1.0.0"
+                }
             });
             const content = readFileSync(summaryPath, "utf8");
-            expect(content).toBe("🔀 **fernapi/fern-typescript-sdk** → [PR](https://github.com/org/repo/pull/42)\n");
+            expect(content).toContain("🔀 **fernapi/fern-typescript-sdk** → [PR](https://github.com/org/repo/pull/42)");
+            expect(content).toContain(
+                "📦 **fernapi/fern-typescript-sdk** → [npm 1.0.0](https://www.npmjs.com/package/@org/sdk/v/1.0.0)"
+            );
         } finally {
             try {
                 unlinkSync(summaryPath);
@@ -107,18 +236,16 @@ describe("emitPrUrlAnnotationAndSummary", () => {
         }
     });
 
-    it("skips the step summary for automation runs (the automation table already includes PR links)", async () => {
+    it("skips the step summary for automation runs", async () => {
         process.env.GITHUB_ACTIONS = "true";
         const summaryPath = join(tmpdir(), `step-summary-${Date.now()}.md`);
         writeFileSync(summaryPath, "", "utf8");
         process.env.GITHUB_STEP_SUMMARY = summaryPath;
 
         try {
-            await emitPrUrlAnnotationAndSummary({
+            await emitGenerationAnnotations({
+                ...BASE_CONTEXT,
                 pullRequestUrl: "https://github.com/org/repo/pull/42",
-                generatorName: "fernapi/fern-typescript-sdk",
-                groupName: "ts-sdk",
-                apiName: undefined,
                 isAutomation: true
             });
             // The annotation should still be emitted
@@ -126,6 +253,29 @@ describe("emitPrUrlAnnotationAndSummary", () => {
             // But the step summary should NOT be written
             const content = readFileSync(summaryPath, "utf8");
             expect(content).toBe("");
+        } finally {
+            try {
+                unlinkSync(summaryPath);
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    });
+
+    it("writes no-changes and version lines to step summary", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        const summaryPath = join(tmpdir(), `step-summary-${Date.now()}.md`);
+        writeFileSync(summaryPath, "", "utf8");
+        process.env.GITHUB_STEP_SUMMARY = summaryPath;
+
+        try {
+            await emitGenerationAnnotations({
+                ...BASE_CONTEXT,
+                noChangesDetected: true,
+                isAutomation: false
+            });
+            const content = readFileSync(summaryPath, "utf8");
+            expect(content).toContain("✅ **fernapi/fern-typescript-sdk** → No changes detected");
         } finally {
             try {
                 unlinkSync(summaryPath);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/emitPrUrlAnnotationAndSummary.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/emitPrUrlAnnotationAndSummary.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync, unlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { emitPrUrlAnnotationAndSummary } from "../runRemoteGenerationForAPIWorkspace.js";
+
+describe("emitPrUrlAnnotationAndSummary", () => {
+    const originalGithubActions = process.env.GITHUB_ACTIONS;
+    const originalStepSummary = process.env.GITHUB_STEP_SUMMARY;
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        delete process.env.GITHUB_ACTIONS;
+        delete process.env.GITHUB_STEP_SUMMARY;
+        stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        if (originalGithubActions === undefined) {
+            delete process.env.GITHUB_ACTIONS;
+        } else {
+            process.env.GITHUB_ACTIONS = originalGithubActions;
+        }
+        if (originalStepSummary === undefined) {
+            delete process.env.GITHUB_STEP_SUMMARY;
+        } else {
+            process.env.GITHUB_STEP_SUMMARY = originalStepSummary;
+        }
+        stdoutSpy.mockRestore();
+    });
+
+    it("does nothing when pullRequestUrl is undefined", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitPrUrlAnnotationAndSummary({
+            pullRequestUrl: undefined,
+            generatorName: "fernapi/fern-typescript-sdk",
+            groupName: "ts-sdk",
+            apiName: undefined,
+            isAutomation: false
+        });
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when not running in GitHub Actions", async () => {
+        delete process.env.GITHUB_ACTIONS;
+        await emitPrUrlAnnotationAndSummary({
+            pullRequestUrl: "https://github.com/org/repo/pull/42",
+            generatorName: "fernapi/fern-typescript-sdk",
+            groupName: "ts-sdk",
+            apiName: undefined,
+            isAutomation: false
+        });
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it("emits a ::notice:: annotation with generator name and group in the title", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitPrUrlAnnotationAndSummary({
+            pullRequestUrl: "https://github.com/org/repo/pull/42",
+            generatorName: "fernapi/fern-typescript-sdk",
+            groupName: "ts-sdk",
+            apiName: undefined,
+            isAutomation: false
+        });
+        expect(stdoutSpy).toHaveBeenCalledWith(
+            "::notice title=fernapi/fern-typescript-sdk (group=ts-sdk) → PR created::https://github.com/org/repo/pull/42\n"
+        );
+    });
+
+    it("includes the api name in the title when present", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await emitPrUrlAnnotationAndSummary({
+            pullRequestUrl: "https://github.com/org/repo/pull/42",
+            generatorName: "fernapi/fern-python-sdk",
+            groupName: "production",
+            apiName: "internal",
+            isAutomation: false
+        });
+        expect(stdoutSpy).toHaveBeenCalledWith(
+            "::notice title=fernapi/fern-python-sdk (group=production%2C api=internal) → PR created::https://github.com/org/repo/pull/42\n"
+        );
+    });
+
+    it("appends a markdown line to GITHUB_STEP_SUMMARY for non-automation runs", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        const summaryPath = join(tmpdir(), `step-summary-${Date.now()}.md`);
+        writeFileSync(summaryPath, "", "utf8");
+        process.env.GITHUB_STEP_SUMMARY = summaryPath;
+
+        try {
+            await emitPrUrlAnnotationAndSummary({
+                pullRequestUrl: "https://github.com/org/repo/pull/42",
+                generatorName: "fernapi/fern-typescript-sdk",
+                groupName: "ts-sdk",
+                apiName: undefined,
+                isAutomation: false
+            });
+            const content = readFileSync(summaryPath, "utf8");
+            expect(content).toBe("🔀 **fernapi/fern-typescript-sdk** → [PR](https://github.com/org/repo/pull/42)\n");
+        } finally {
+            try {
+                unlinkSync(summaryPath);
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    });
+
+    it("skips the step summary for automation runs (the automation table already includes PR links)", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        const summaryPath = join(tmpdir(), `step-summary-${Date.now()}.md`);
+        writeFileSync(summaryPath, "", "utf8");
+        process.env.GITHUB_STEP_SUMMARY = summaryPath;
+
+        try {
+            await emitPrUrlAnnotationAndSummary({
+                pullRequestUrl: "https://github.com/org/repo/pull/42",
+                generatorName: "fernapi/fern-typescript-sdk",
+                groupName: "ts-sdk",
+                apiName: undefined,
+                isAutomation: true
+            });
+            // The annotation should still be emitted
+            expect(stdoutSpy).toHaveBeenCalled();
+            // But the step summary should NOT be written
+            const content = readFileSync(summaryPath, "utf8");
+            expect(content).toBe("");
+        } finally {
+            try {
+                unlinkSync(summaryPath);
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -1,5 +1,6 @@
 import { validateAPIWorkspaceAndLogIssues } from "@fern-api/api-workspace-validator";
 import { FernToken } from "@fern-api/auth";
+import { renderGithubAnnotation, shouldEmitGithubAnnotations } from "@fern-api/cli-logger";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
@@ -9,8 +10,8 @@ import {
     AbstractAPIWorkspace,
     getBaseOpenAPIWorkspaceSettingsFromGeneratorInvocation
 } from "@fern-api/workspace-loader";
-
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
+import { appendFile } from "fs/promises";
 
 import { findGeneratorLineNumber, GeneratorOccurrenceTracker, getOutputRepoUrl } from "./automationMetadata.js";
 import { downloadSnippetsForTask } from "./downloadSnippetsForTask.js";
@@ -393,6 +394,14 @@ async function generateOne({
                 generatorsYmlLineNumber: lineNumber
             });
         }
+
+        await emitPrUrlAnnotationAndSummary({
+            pullRequestUrl: remoteTaskHandlerResponse?.pullRequestUrl,
+            generatorName: generatorInvocation.name,
+            groupName: generatorGroup.groupName,
+            apiName: workspace.workspaceName,
+            isAutomation: automation != null
+        });
     } catch (error) {
         if (automation == null) {
             throw error;
@@ -449,5 +458,56 @@ async function generateOne({
         interactiveTaskContext.failWithoutThrowing(message, error, {
             code: resolveErrorCode(error)
         });
+    }
+}
+
+/**
+ * Emits a GitHub Actions `::notice::` annotation and (for non-automation runs) appends a line
+ * to `$GITHUB_STEP_SUMMARY` when a generator produces a PR URL. This makes the PR URL visible
+ * in the GitHub Actions run page — currently the URL is buried in debug logs and easy to miss.
+ *
+ * For automation runs (`fern automations generate`), only the annotation is emitted; the step
+ * summary table already includes PR links via {@link reportGenerateResults}.
+ *
+ * Exported for testing.
+ */
+export async function emitPrUrlAnnotationAndSummary({
+    pullRequestUrl,
+    generatorName,
+    groupName,
+    apiName,
+    isAutomation
+}: {
+    pullRequestUrl: string | undefined;
+    generatorName: string;
+    groupName: string;
+    apiName: string | undefined;
+    isAutomation: boolean;
+}): Promise<void> {
+    if (pullRequestUrl == null) {
+        return;
+    }
+    if (!shouldEmitGithubAnnotations()) {
+        return;
+    }
+    const qualifiers: string[] = [`group=${groupName}`];
+    if (apiName != null && apiName.length > 0) {
+        qualifiers.push(`api=${apiName}`);
+    }
+    const title = `${generatorName} (${qualifiers.join(", ")}) → PR created`;
+    const annotation = renderGithubAnnotation("notice", pullRequestUrl, { title });
+    if (annotation != null) {
+        process.stdout.write(annotation);
+    }
+
+    if (!isAutomation) {
+        const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+        if (stepSummaryPath != null && stepSummaryPath.length > 0) {
+            try {
+                await appendFile(stepSummaryPath, `🔀 **${generatorName}** → [PR](${pullRequestUrl})\n`, "utf8");
+            } catch {
+                // Best-effort — don't fail generation for a step summary write error.
+            }
+        }
     }
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -15,6 +15,7 @@ import { appendFile } from "fs/promises";
 
 import { findGeneratorLineNumber, GeneratorOccurrenceTracker, getOutputRepoUrl } from "./automationMetadata.js";
 import { downloadSnippetsForTask } from "./downloadSnippetsForTask.js";
+import type { PublishTarget } from "./publishTarget.js";
 import type { AutomationRunOptions } from "./RemoteGeneratorRunRecorder.js";
 import { resolveAutoDiscoveredFernignorePath } from "./resolveAutoDiscoveredFernignorePath.js";
 import { runRemoteGenerationForGenerator } from "./runRemoteGenerationForGenerator.js";
@@ -395,8 +396,11 @@ async function generateOne({
             });
         }
 
-        await emitPrUrlAnnotationAndSummary({
+        await emitGenerationAnnotations({
             pullRequestUrl: remoteTaskHandlerResponse?.pullRequestUrl,
+            publishTarget: remoteTaskHandlerResponse?.publishTarget,
+            noChangesDetected: remoteTaskHandlerResponse?.noChangesDetected,
+            version: remoteTaskHandlerResponse?.actualVersion,
             generatorName: generatorInvocation.name,
             groupName: generatorGroup.groupName,
             apiName: workspace.workspaceName,
@@ -461,50 +465,97 @@ async function generateOne({
     }
 }
 
-/**
- * Emits a GitHub Actions `::notice::` annotation and (for non-automation runs) appends a line
- * to `$GITHUB_STEP_SUMMARY` when a generator produces a PR URL. This makes the PR URL visible
- * in the GitHub Actions run page — currently the URL is buried in debug logs and easy to miss.
- *
- * For automation runs (`fern automations generate`), only the annotation is emitted; the step
- * summary table already includes PR links via {@link reportGenerateResults}.
- *
- * Exported for testing.
- */
-export async function emitPrUrlAnnotationAndSummary({
-    pullRequestUrl,
-    generatorName,
-    groupName,
-    apiName,
-    isAutomation
-}: {
+interface GenerationAnnotationContext {
     pullRequestUrl: string | undefined;
+    publishTarget: PublishTarget | undefined;
+    noChangesDetected: boolean | undefined;
+    version: string | undefined;
     generatorName: string;
     groupName: string;
     apiName: string | undefined;
     isAutomation: boolean;
-}): Promise<void> {
-    if (pullRequestUrl == null) {
-        return;
-    }
+}
+
+/**
+ * Emits GitHub Actions `::notice::` annotations for notable generation events and (for
+ * non-automation runs) appends corresponding lines to `$GITHUB_STEP_SUMMARY`. This makes
+ * generation outcomes visible in the GitHub Actions run page — previously these details
+ * were only visible in debug-level log output.
+ *
+ * Events annotated:
+ * - PR created (with URL)
+ * - Package published to a registry (npm, PyPI, Maven, etc.)
+ * - No changes detected (SDK repo already up to date)
+ * - Version tagged
+ *
+ * For automation runs (`fern automations generate`), only annotations are emitted; the step
+ * summary table already includes these details via {@link reportGenerateResults}.
+ *
+ * Exported for testing.
+ */
+export async function emitGenerationAnnotations(ctx: GenerationAnnotationContext): Promise<void> {
     if (!shouldEmitGithubAnnotations()) {
         return;
     }
-    const qualifiers: string[] = [`group=${groupName}`];
-    if (apiName != null && apiName.length > 0) {
-        qualifiers.push(`api=${apiName}`);
-    }
-    const title = `${generatorName} (${qualifiers.join(", ")}) → PR created`;
-    const annotation = renderGithubAnnotation("notice", pullRequestUrl, { title });
-    if (annotation != null) {
-        process.stdout.write(annotation);
+
+    const notices: Array<{ event: string; body: string; summaryLine: string }> = [];
+
+    if (ctx.pullRequestUrl != null) {
+        notices.push({
+            event: "PR created",
+            body: ctx.pullRequestUrl,
+            summaryLine: `🔀 **${ctx.generatorName}** → [PR](${ctx.pullRequestUrl})`
+        });
     }
 
-    if (!isAutomation) {
+    if (ctx.publishTarget != null) {
+        notices.push({
+            event: `Published to ${ctx.publishTarget.label}`,
+            body: `${ctx.publishTarget.version} → ${ctx.publishTarget.url}`,
+            summaryLine: `📦 **${ctx.generatorName}** → [${ctx.publishTarget.label} ${ctx.publishTarget.version}](${ctx.publishTarget.url})`
+        });
+    }
+
+    if (ctx.noChangesDetected) {
+        notices.push({
+            event: "No changes detected",
+            body: "SDK repo is already up to date",
+            summaryLine: `✅ **${ctx.generatorName}** → No changes detected`
+        });
+    }
+
+    if (ctx.version != null && ctx.publishTarget == null && ctx.pullRequestUrl == null) {
+        notices.push({
+            event: `Version ${ctx.version}`,
+            body: `Generated version ${ctx.version}`,
+            summaryLine: `🏷️ **${ctx.generatorName}** → Version ${ctx.version}`
+        });
+    }
+
+    if (notices.length === 0) {
+        return;
+    }
+
+    const qualifiers: string[] = [`group=${ctx.groupName}`];
+    if (ctx.apiName != null && ctx.apiName.length > 0) {
+        qualifiers.push(`api=${ctx.apiName}`);
+    }
+    const prefix = `${ctx.generatorName} (${qualifiers.join(", ")})`;
+
+    for (const notice of notices) {
+        const title = `${prefix} → ${notice.event}`;
+        const annotation = renderGithubAnnotation("notice", notice.body, { title });
+        if (annotation != null) {
+            process.stdout.write(annotation);
+        }
+    }
+
+    if (!ctx.isAutomation) {
         const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY;
         if (stepSummaryPath != null && stepSummaryPath.length > 0) {
+            const lines = notices.map((n) => `${n.summaryLine}\n`).join("");
             try {
-                await appendFile(stepSummaryPath, `🔀 **${generatorName}** → [PR](${pullRequestUrl})\n`, "utf8");
+                await appendFile(stepSummaryPath, lines, "utf8");
             } catch (error: unknown) {
                 // Best-effort — don't fail generation for a step summary write error.
                 process.stderr.write(`[warn] Failed to append to GITHUB_STEP_SUMMARY: ${error}\n`);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -505,8 +505,9 @@ export async function emitPrUrlAnnotationAndSummary({
         if (stepSummaryPath != null && stepSummaryPath.length > 0) {
             try {
                 await appendFile(stepSummaryPath, `🔀 **${generatorName}** → [PR](${pullRequestUrl})\n`, "utf8");
-            } catch {
+            } catch (error: unknown) {
                 // Best-effort — don't fail generation for a step summary write error.
+                process.stderr.write(`[warn] Failed to append to GITHUB_STEP_SUMMARY: ${error}\n`);
             }
         }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6312,6 +6312,9 @@ importers:
       '@fern-api/casings-generator':
         specifier: workspace:*
         version: link:../../../../commons/casings-generator
+      '@fern-api/cli-logger':
+        specifier: workspace:*
+        version: link:../../../cli-logger
       '@fern-api/cli-source-resolver':
         specifier: workspace:*
         version: link:../../../cli-source-resolver


### PR DESCRIPTION
## Description

When the Fern CLI runs inside GitHub Actions, notable SDK generation events are now surfaced as `::notice::` annotations in the workflow run page **Annotations** panel. For non-automation runs (`fern generate`), corresponding lines are also appended to the GitHub step summary.

## Changes Made

Refactored `emitPrUrlAnnotationAndSummary` → `emitGenerationAnnotations` to emit individual `::notice::` annotations for each notable event:

- **PR created** — `::notice title=<gen> (group=<g>) → PR created::<url>`
- **Package published** — `::notice title=<gen> (group=<g>) → Published to npm::1.0.0 → <url>` (npm, PyPI, Maven, NuGet, RubyGems, crates.io)
- **No changes detected** — `::notice title=<gen> (group=<g>) → No changes detected::SDK repo is already up to date`
- **Version tagged** — `::notice title=<gen> (group=<g>) → Version 2.0.0::Generated version 2.0.0` (only emitted when neither PR nor publish occurred)

Step summary lines use matching emoji per event type: 🔀 PR, 📦 Published, ✅ No changes, 🏷️ Version.

Version annotation is suppressed when a PR or publish annotation already carries version context, avoiding noise.

For automation runs (`fern automations generate`), only annotations are emitted — the step summary table already includes these details via `reportGenerateResults`.

### Key implementation details

```typescript
// New consolidated function signature
interface GenerationAnnotationContext {
    pullRequestUrl: string | undefined;
    publishTarget: PublishTarget | undefined;
    noChangesDetected: boolean | undefined;
    version: string | undefined;
    generatorName: string;
    groupName: string;
    apiName: string | undefined;
    isAutomation: boolean;
}
export async function emitGenerationAnnotations(ctx: GenerationAnnotationContext): Promise<void>
```

Called from `generateOne()` — shared by both `fern generate` and `fern automations generate` code paths.

## Testing

- [x] Unit tests added/updated — 16 tests covering all event types, combinations, step summary writes, automation skip, and edge cases (268 tests total pass across both packages)
- [x] `pnpm compile` passes
- [x] `pnpm check:fix` passes

Link to Devin session: https://app.devin.ai/sessions/947e62a1a26841a8b90f55a7bf8a2d3e
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->