### PR TITLE
chore(typescript): upgrade oxc tooling to apps_v1.72.0

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -66,10 +66,10 @@ RUN corepack prepare yarn@1.22.22
 
 RUN pnpm add -g typescript@~5.7.2 \
   prettier@3.7.4 \
-  oxfmt@0.48.0 \
+  oxfmt@0.57.0 \
   @biomejs/biome@2.4.3 \
-  oxlint@1.63.0 \
-  oxlint-tsgolint@0.23.0 \
+  oxlint@1.72.0 \
+  oxlint-tsgolint@0.24.0 \
   @types/node@^18.19.70 \
   webpack@^5.97.1 \
   msw@2.11.2 \

--- a/generators/typescript/sdk/changes/unreleased/upgrade-oxc-1.72.0.yml
+++ b/generators/typescript/sdk/changes/unreleased/upgrade-oxc-1.72.0.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Upgrade oxc tooling: oxlint 1.69.0 → 1.72.0, oxfmt 0.54.0 → 0.57.0,
+    oxlint-tsgolint 0.23.0 → 0.24.0.
+  type: chore

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -80,10 +80,10 @@ RUN npm install -g pnpm@11.8.0 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \
-  oxfmt@0.54.0 \
+  oxfmt@0.57.0 \
   @biomejs/biome@2.4.10 \
-  oxlint@1.69.0 \
-  oxlint-tsgolint@0.23.0 \
+  oxlint@1.72.0 \
+  oxlint-tsgolint@0.24.0 \
   @types/node@^20.0.0 \
   ts-loader@^9.5.4 \
   webpack@^5.105.4 \

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -51,9 +51,9 @@ type COMMON_SCRIPTS = (typeof COMMON_SCRIPTS)[keyof typeof COMMON_SCRIPTS];
 const TOOL_VERSIONS = {
     BIOME: "2.4.10",
     PRETTIER: "3.8.1",
-    OXFMT: "0.54.0",
-    OXLINT: "1.69.0",
-    OXLINT_TSGOLINT: "0.23.0"
+    OXFMT: "0.57.0",
+    OXLINT: "1.72.0",
+    OXLINT_TSGOLINT: "0.24.0"
 } as const;
 
 export abstract class TypescriptProject {

--- a/seed/ts-sdk/simple-api/use-oxc/package.json
+++ b/seed/ts-sdk/simple-api/use-oxc/package.json
@@ -63,9 +63,9 @@
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
-        "oxlint": "1.69.0",
-        "oxlint-tsgolint": "0.23.0",
-        "oxfmt": "0.54.0"
+        "oxlint": "1.72.0",
+        "oxlint-tsgolint": "0.24.0",
+        "oxfmt": "0.57.0"
     },
     "browser": {
         "fs": false,

--- a/seed/ts-sdk/simple-api/use-oxfmt/package.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/package.json
@@ -64,7 +64,7 @@
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
-        "oxfmt": "0.54.0"
+        "oxfmt": "0.57.0"
     },
     "browser": {
         "fs": false,

--- a/seed/ts-sdk/simple-api/use-oxlint/package.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/package.json
@@ -64,8 +64,8 @@
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
-        "oxlint": "1.69.0",
-        "oxlint-tsgolint": "0.23.0"
+        "oxlint": "1.72.0",
+        "oxlint-tsgolint": "0.24.0"
     },
     "browser": {
         "fs": false,


### PR DESCRIPTION
## Description

Refs https://github.com/oxc-project/oxc/releases/tag/apps_v1.72.0

Upgrade oxc tooling versions to match the apps_v1.72.0 release.

## Changes Made

Version bumps across generator source, Dockerfiles, and seed output:

```
oxlint:          1.69.0 → 1.72.0
oxfmt:           0.54.0 → 0.57.0
oxlint-tsgolint: 0.23.0 → 0.24.0
```

- `generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts` — `TOOL_VERSIONS` constants
- `generators/typescript/sdk/cli/Dockerfile` — production image
- `docker/seed/Dockerfile.ts` — seed test image (also catches up oxfmt 0.48.0 → 0.57.0 and oxlint 1.63.0 → 1.72.0)
- `seed/ts-sdk/simple-api/use-oxc/package.json`, `use-oxlint/package.json`, `use-oxfmt/package.json` — generated seed fixtures

## Testing

- [x] Version strings verified against npm registry publish timestamps matching the apps_v1.72.0 release (2026-06-29)
- [ ] CI seed tests validate generated output

Link to Devin session: https://app.devin.ai/sessions/7b8a39846fb44303a274f6f2b731c411
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->