### PR TITLE
fix(typescript): use IterableIterator<T> in generated Headers.ts shim

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-headers-iterator-type.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-headers-iterator-type.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Use `IterableIterator<T>` instead of `HeadersIterator<T>` in the generated `Headers.ts` shim.
+    `HeadersIterator` was added in TypeScript 5.6; the previous annotations broke compilation on TS < 5.6.
+  type: fix

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/Headers.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/accept-header/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/alias/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/allof-inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/allof-inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/allof/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/allof/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/any-auth/always-send-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/api-wide-base-path-with-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/bytes-download/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/bytes-download/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/circular-references-extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/circular-references-extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/circular-references/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cli-multi-spec-namespaced/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cli-multi-spec/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cli-multi-spec/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/client-side-params/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/client-side-params/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/content-type/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/dollar-string-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/dollar-string-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/empty-clients/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/empty-clients/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/endpoint-security-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/errors/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/errors/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/output-src-only/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload-openapi/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/use-jest/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/folders/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/header-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/header-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/http-head/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inline-enum-type-name-override/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inline-enum-type-name-override/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/license/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/literal-user-agent/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/literal-user-agent/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/literal/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/literals-unions/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/literals-unions/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-content-type-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-content-type-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-url-environment-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/no-content-response/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/no-content-response/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/no-environment/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/no-retries/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/no-retries/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/null-type/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/null-type/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable-allof-extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable-optional/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable-request-body/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable-request-body/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/object/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/openapi-subtitle/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/openapi-subtitle/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/optional/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/package-yml/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination-uri-path/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/plain-text/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/public-object/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-param-name-conflict/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-param-name-conflict/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters-openapi/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/required-nullable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/required-nullable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/response-property/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/schemaless-request-body-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-url-templating/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-url-templating/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/bundle/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/jsr/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/naming/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-error-name-collision/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-extra-properties/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-path-param-body-conflict/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-path-param-body-conflict/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unions-with-local-date/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unions/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unions/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/url-form-encoded/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/validation/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/variables/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/version/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/webhook-audience/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/webhook-audience/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/webhooks/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket-multi-url/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/x-fern-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/x-fern-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10963](https://linear.app/buildwithfern/issue/FER-10963/typescript-generated-headersts-uses-headersiteratort-breaking)

The generated `core/fetcher/Headers.ts` shim uses `HeadersIterator<T>` as the return type for `entries()`, `keys()`, `values()`, and `[Symbol.iterator]()`. `HeadersIterator` was added to the TypeScript DOM lib in **5.6**; under earlier TS versions, compilation fails with 4× `TS2304: Cannot find name 'HeadersIterator'`.

## Changes Made
- Replaced `HeadersIterator<T>` → `IterableIterator<T>` in the source template (`generators/typescript/utils/core-utilities/src/core/fetcher/Headers.ts`)
- Updated all 223 seed snapshot `Headers.ts` files to match

```diff
- *entries(): HeadersIterator<[string, string]> { … }
- *keys(): HeadersIterator<string> { … }
- *values(): HeadersIterator<string> { … }
- [Symbol.iterator](): HeadersIterator<[string, string]> { … }
+ *entries(): IterableIterator<[string, string]> { … }
+ *keys(): IterableIterator<string> { … }
+ *values(): IterableIterator<string> { … }
+ [Symbol.iterator](): IterableIterator<[string, string]> { … }
```

`IterableIterator<T>` has the same semantics and has been in the TS lib since TS 2.x, so this is safe for all supported TS versions.

## Testing
- [x] `pnpm run check` passes (biome lint clean)
- [x] All 223 seed snapshot files updated consistently

Link to Devin session: https://app.devin.ai/sessions/c0d1811491b14be093b11d269a35e85d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->