### PR TITLE
fix(typescript): downgrade vitest from ^4.1.1 to ^3.2.6 for Node >=22 compatibility

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -73,7 +73,7 @@ RUN pnpm add -g typescript@~5.7.2 \
   @types/node@^18.19.70 \
   webpack@^5.97.1 \
   msw@2.11.2 \
-  vitest@^4.1.1
+  vitest@^3.2.6
 
 # Clean pnpm content-addressable store and corepack cache to reduce
 # image size. Patch pnpm's bundled undici to 6.27.0 to clear

--- a/generators/typescript/sdk/changes/unreleased/fix-vitest-node22-crash.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-vitest-node22-crash.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Downgrade pinned Vitest from ^4.1.1 to ^3.2.6 to fix ERR_PACKAGE_PATH_NOT_EXPORTED crash on Node >=22.
+  type: fix

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -88,7 +88,7 @@ RUN pnpm add -g typescript@~5.9.3 \
   ts-loader@^9.5.4 \
   webpack@^5.105.4 \
   msw@2.12.14 \
-  vitest@^4.1.1
+  vitest@^3.2.6
 
 # Clean pnpm content-addressable store and corepack cache to reduce
 # image size. Patch pnpm's bundled undici to 6.27.0 to clear

--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -262,7 +262,7 @@ export class TestGenerator {
                 });
                 break;
             case "vitest":
-                this.dependencyManager.addDependency("vitest", "^4.1.1", {
+                this.dependencyManager.addDependency("vitest", "^3.2.6", {
                     type: DependencyType.DEV
                 });
                 break;

--- a/generators/typescript/sdk/validator/warm-cache-package.json
+++ b/generators/typescript/sdk/validator/warm-cache-package.json
@@ -8,6 +8,6 @@
     "@types/node": "^20.0.0",
     "msw": "2.12.14",
     "typescript": "~5.9.3",
-    "vitest": "^4.1.1"
+    "vitest": "^3.2.6"
   }
 }

--- a/seed/ts-sdk/accept-header/package.json
+++ b/seed/ts-sdk/accept-header/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/alias-extends/package.json
+++ b/seed/ts-sdk/alias-extends/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/alias/package.json
+++ b/seed/ts-sdk/alias/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/allof-inline/package.json
+++ b/seed/ts-sdk/allof-inline/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/allof/package.json
+++ b/seed/ts-sdk/allof/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/any-auth/always-send-auth/package.json
+++ b/seed/ts-sdk/any-auth/always-send-auth/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/package.json
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/any-auth/no-custom-config/package.json
+++ b/seed/ts-sdk/any-auth/no-custom-config/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/api-wide-base-path-with-default/package.json
+++ b/seed/ts-sdk/api-wide-base-path-with-default/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/api-wide-base-path/package.json
+++ b/seed/ts-sdk/api-wide-base-path/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/audiences/no-custom-config/package.json
+++ b/seed/ts-sdk/audiences/no-custom-config/package.json
@@ -125,7 +125,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/audiences/with-partner-audience/package.json
+++ b/seed/ts-sdk/audiences/with-partner-audience/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/basic-auth-environment-variables/package.json
+++ b/seed/ts-sdk/basic-auth-environment-variables/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/basic-auth-pw-omitted/package.json
+++ b/seed/ts-sdk/basic-auth-pw-omitted/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/basic-auth/package.json
+++ b/seed/ts-sdk/basic-auth/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/bearer-token-environment-variable/package.json
+++ b/seed/ts-sdk/bearer-token-environment-variable/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/bytes-download/package.json
+++ b/seed/ts-sdk/bytes-download/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/bytes-upload/package.json
+++ b/seed/ts-sdk/bytes-upload/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/circular-references-advanced/package.json
+++ b/seed/ts-sdk/circular-references-advanced/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/circular-references-extends/package.json
+++ b/seed/ts-sdk/circular-references-extends/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/circular-references/package.json
+++ b/seed/ts-sdk/circular-references/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/cli-multi-spec-namespaced/package.json
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/cli-multi-spec/package.json
+++ b/seed/ts-sdk/cli-multi-spec/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/client-side-params/package.json
+++ b/seed/ts-sdk/client-side-params/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/content-type/package.json
+++ b/seed/ts-sdk/content-type/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/package.json
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/package.json
@@ -125,7 +125,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/package.json
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/package.json
@@ -136,7 +136,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/dollar-string-examples/package.json
+++ b/seed/ts-sdk/dollar-string-examples/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/empty-clients/package.json
+++ b/seed/ts-sdk/empty-clients/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/endpoint-security-auth/package.json
+++ b/seed/ts-sdk/endpoint-security-auth/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/package.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/enum/forward-compatible-enums/package.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums/package.json
@@ -103,7 +103,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/enum/no-custom-config/package.json
+++ b/seed/ts-sdk/enum/no-custom-config/package.json
@@ -103,7 +103,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/enum/serde/package.json
+++ b/seed/ts-sdk/enum/serde/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/error-property/no-custom-config/package.json
+++ b/seed/ts-sdk/error-property/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/error-property/union-utils/package.json
+++ b/seed/ts-sdk/error-property/union-utils/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/errors/package.json
+++ b/seed/ts-sdk/errors/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/examples/examples-with-api-reference/package.json
+++ b/seed/ts-sdk/examples/examples-with-api-reference/package.json
@@ -136,7 +136,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/examples/retain-original-casing/package.json
+++ b/seed/ts-sdk/examples/retain-original-casing/package.json
@@ -136,7 +136,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/package.json
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/package.json
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/package.json
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/package.json
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/multiple-exports/package.json
+++ b/seed/ts-sdk/exhaustive/multiple-exports/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/never-throw-errors/package.json
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/no-custom-config/package.json
+++ b/seed/ts-sdk/exhaustive/no-custom-config/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/node-fetch/package.json
+++ b/seed/ts-sdk/exhaustive/node-fetch/package.json
@@ -238,7 +238,7 @@
         "@types/node-fetch": "^2.6.12",
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/package-path/package.json
+++ b/seed/ts-sdk/exhaustive/package-path/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/package.json
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/serde-layer/package.json
+++ b/seed/ts-sdk/exhaustive/serde-layer/package.json
@@ -246,7 +246,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/package.json
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/package.json
@@ -235,7 +235,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/exhaustive/with-audiences/package.json
+++ b/seed/ts-sdk/exhaustive/with-audiences/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/extends/package.json
+++ b/seed/ts-sdk/extends/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/extra-properties/package.json
+++ b/seed/ts-sdk/extra-properties/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-download/file-download-response-headers/package.json
+++ b/seed/ts-sdk/file-download/file-download-response-headers/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-download/no-custom-config/package.json
+++ b/seed/ts-sdk/file-download/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-upload-openapi/package.json
+++ b/seed/ts-sdk/file-upload-openapi/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-upload/form-data-node16/package.json
+++ b/seed/ts-sdk/file-upload/form-data-node16/package.json
@@ -63,7 +63,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-upload/inline/package.json
+++ b/seed/ts-sdk/file-upload/inline/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-upload/no-custom-config/package.json
+++ b/seed/ts-sdk/file-upload/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/file-upload/serde/package.json
+++ b/seed/ts-sdk/file-upload/serde/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/folders/package.json
+++ b/seed/ts-sdk/folders/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/header-auth-environment-variable/package.json
+++ b/seed/ts-sdk/header-auth-environment-variable/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/header-auth/package.json
+++ b/seed/ts-sdk/header-auth/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/http-head/package.json
+++ b/seed/ts-sdk/http-head/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/idempotency-headers/package.json
+++ b/seed/ts-sdk/idempotency-headers/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/imdb/branded-string-aliases/package.json
+++ b/seed/ts-sdk/imdb/branded-string-aliases/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/imdb/no-custom-config/package.json
+++ b/seed/ts-sdk/imdb/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/imdb/omit-undefined/package.json
+++ b/seed/ts-sdk/imdb/omit-undefined/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/inferred-auth-explicit/package.json
+++ b/seed/ts-sdk/inferred-auth-explicit/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/inferred-auth-implicit-reference/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/inferred-auth-implicit/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/inline-enum-type-name-override/package.json
+++ b/seed/ts-sdk/inline-enum-type-name-override/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/license/package.json
+++ b/seed/ts-sdk/license/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/literal-user-agent/package.json
+++ b/seed/ts-sdk/literal-user-agent/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/literal/package.json
+++ b/seed/ts-sdk/literal/package.json
@@ -103,7 +103,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/literals-unions/package.json
+++ b/seed/ts-sdk/literals-unions/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/mixed-case/no-custom-config/package.json
+++ b/seed/ts-sdk/mixed-case/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/mixed-case/retain-original-casing/package.json
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/mixed-file-directory/package.json
+++ b/seed/ts-sdk/mixed-file-directory/package.json
@@ -92,7 +92,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/multi-content-type-examples/package.json
+++ b/seed/ts-sdk/multi-content-type-examples/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/multi-line-docs/package.json
+++ b/seed/ts-sdk/multi-line-docs/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/multi-url-environment-no-default/package.json
+++ b/seed/ts-sdk/multi-url-environment-no-default/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/multi-url-environment-reference/package.json
+++ b/seed/ts-sdk/multi-url-environment-reference/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/multi-url-environment/package.json
+++ b/seed/ts-sdk/multi-url-environment/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/multiple-request-bodies/package.json
+++ b/seed/ts-sdk/multiple-request-bodies/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/no-content-response/package.json
+++ b/seed/ts-sdk/no-content-response/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/no-environment/package.json
+++ b/seed/ts-sdk/no-environment/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/no-retries/package.json
+++ b/seed/ts-sdk/no-retries/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/null-type/package.json
+++ b/seed/ts-sdk/null-type/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/nullable-allof-extends/package.json
+++ b/seed/ts-sdk/nullable-allof-extends/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/nullable-optional/package.json
+++ b/seed/ts-sdk/nullable-optional/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/nullable-request-body/package.json
+++ b/seed/ts-sdk/nullable-request-body/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/nullable/package.json
+++ b/seed/ts-sdk/nullable/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-custom/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-custom/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-default/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-default/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/package.json
@@ -92,7 +92,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-openapi/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-reference/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-reference/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/package.json
@@ -125,7 +125,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/package.json
@@ -114,7 +114,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/oauth-client-credentials/serde/package.json
+++ b/seed/ts-sdk/oauth-client-credentials/serde/package.json
@@ -125,7 +125,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/object/package.json
+++ b/seed/ts-sdk/object/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/objects-with-imports/package.json
+++ b/seed/ts-sdk/objects-with-imports/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/package.json
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/openapi-subtitle/package.json
+++ b/seed/ts-sdk/openapi-subtitle/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/optional/package.json
+++ b/seed/ts-sdk/optional/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/package-yml/package.json
+++ b/seed/ts-sdk/package-yml/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/pagination-custom/package.json
+++ b/seed/ts-sdk/pagination-custom/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/pagination-uri-path/package.json
+++ b/seed/ts-sdk/pagination-uri-path/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/pagination/no-custom-config/package.json
+++ b/seed/ts-sdk/pagination/no-custom-config/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/pagination/page-index-semantics/package.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/path-parameters/no-custom-config/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/package.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/package.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/package.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/path-parameters/retain-original-casing/package.json
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/plain-text/package.json
+++ b/seed/ts-sdk/plain-text/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/package.json
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/property-access/no-custom-config/package.json
+++ b/seed/ts-sdk/property-access/no-custom-config/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/public-object/package.json
+++ b/seed/ts-sdk/public-object/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-param-name-conflict/package.json
+++ b/seed/ts-sdk/query-param-name-conflict/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/package.json
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters-openapi/package.json
+++ b/seed/ts-sdk/query-parameters-openapi/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/query-parameters/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/query-parameters/serde/package.json
+++ b/seed/ts-sdk/query-parameters/serde/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/package.json
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/request-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/request-parameters/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/package.json
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/required-nullable/package.json
+++ b/seed/ts-sdk/required-nullable/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/reserved-keywords/package.json
+++ b/seed/ts-sdk/reserved-keywords/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/response-property/package.json
+++ b/seed/ts-sdk/response-property/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/schemaless-request-body-examples/package.json
+++ b/seed/ts-sdk/schemaless-request-body-examples/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/server-sent-event-examples/package.json
+++ b/seed/ts-sdk/server-sent-event-examples/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/package.json
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/server-sent-events-resumable/package.json
+++ b/seed/ts-sdk/server-sent-events-resumable/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/server-sent-events/package.json
+++ b/seed/ts-sdk/server-sent-events/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/server-url-templating/package.json
+++ b/seed/ts-sdk/server-url-templating/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/package.json
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/allow-extra-fields/package.json
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/bundle/package.json
+++ b/seed/ts-sdk/simple-api/bundle/package.json
@@ -60,7 +60,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/custom-package-json/package.json
+++ b/seed/ts-sdk/simple-api/custom-package-json/package.json
@@ -72,7 +72,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/jsr/package.json
+++ b/seed/ts-sdk/simple-api/jsr/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/legacy-exports/package.json
+++ b/seed/ts-sdk/simple-api/legacy-exports/package.json
@@ -25,7 +25,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/naming-shorthand/package.json
+++ b/seed/ts-sdk/simple-api/naming-shorthand/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/naming/package.json
+++ b/seed/ts-sdk/simple-api/naming/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/no-custom-config/package.json
+++ b/seed/ts-sdk/simple-api/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/package.json
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3"

--- a/seed/ts-sdk/simple-api/no-scripts/package.json
+++ b/seed/ts-sdk/simple-api/no-scripts/package.json
@@ -56,7 +56,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/oidc-token/package.json
+++ b/seed/ts-sdk/simple-api/oidc-token/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/omit-fern-headers/package.json
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/use-oxc/package.json
+++ b/seed/ts-sdk/simple-api/use-oxc/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/use-oxfmt/package.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/use-oxlint/package.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/package.json
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/use-prettier/package.json
+++ b/seed/ts-sdk/simple-api/use-prettier/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-api/use-yarn/package.json
+++ b/seed/ts-sdk/simple-api/use-yarn/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/simple-fhir/package.json
+++ b/seed/ts-sdk/simple-fhir/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/single-url-environment-default/package.json
+++ b/seed/ts-sdk/single-url-environment-default/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/single-url-environment-no-default/package.json
+++ b/seed/ts-sdk/single-url-environment-no-default/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/streaming-parameter/package.json
+++ b/seed/ts-sdk/streaming-parameter/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/streaming/no-custom-config/package.json
+++ b/seed/ts-sdk/streaming/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/streaming/serde-layer/package.json
+++ b/seed/ts-sdk/streaming/serde-layer/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/trace/exhaustive/package.json
+++ b/seed/ts-sdk/trace/exhaustive/package.json
@@ -169,7 +169,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/trace/no-custom-config/package.json
+++ b/seed/ts-sdk/trace/no-custom-config/package.json
@@ -169,7 +169,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/trace/serde-no-throwing/package.json
+++ b/seed/ts-sdk/trace/serde-no-throwing/package.json
@@ -180,7 +180,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/trace/serde/package.json
+++ b/seed/ts-sdk/trace/serde/package.json
@@ -180,7 +180,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/ts-error-name-collision/package.json
+++ b/seed/ts-sdk/ts-error-name-collision/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/ts-express-casing/package.json
+++ b/seed/ts-sdk/ts-express-casing/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/ts-extra-properties/package.json
+++ b/seed/ts-sdk/ts-extra-properties/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/ts-inline-types/inline/package.json
+++ b/seed/ts-sdk/ts-inline-types/inline/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/ts-inline-types/no-inline/package.json
+++ b/seed/ts-sdk/ts-inline-types/no-inline/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/ts-path-param-body-conflict/package.json
+++ b/seed/ts-sdk/ts-path-param-body-conflict/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/package.json
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/package.json
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/package.json
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/union-query-parameters/package.json
+++ b/seed/ts-sdk/union-query-parameters/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/unions-with-local-date/package.json
+++ b/seed/ts-sdk/unions-with-local-date/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/unions/no-custom-config/package.json
+++ b/seed/ts-sdk/unions/no-custom-config/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/unions/package.json
+++ b/seed/ts-sdk/unions/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.12.14",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/unions/serde-layer/package.json
+++ b/seed/ts-sdk/unions/serde-layer/package.json
@@ -81,7 +81,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/unknown/no-custom-config/package.json
+++ b/seed/ts-sdk/unknown/no-custom-config/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/unknown/unknown-as-any/package.json
+++ b/seed/ts-sdk/unknown/unknown-as-any/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/url-form-encoded/package.json
+++ b/seed/ts-sdk/url-form-encoded/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/validation/package.json
+++ b/seed/ts-sdk/validation/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/variables/package.json
+++ b/seed/ts-sdk/variables/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/version-no-default/package.json
+++ b/seed/ts-sdk/version-no-default/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/version/package.json
+++ b/seed/ts-sdk/version/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/webhook-audience/package.json
+++ b/seed/ts-sdk/webhook-audience/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/webhooks/no-custom-config/package.json
+++ b/seed/ts-sdk/webhooks/no-custom-config/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/package.json
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/package.json
@@ -73,7 +73,7 @@
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
         "@types/ws": "^8.18.1",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/package.json
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/package.json
@@ -73,7 +73,7 @@
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
         "@types/ws": "^8.18.1",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/websocket-multi-url/package.json
+++ b/seed/ts-sdk/websocket-multi-url/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/websocket/no-serde/package.json
+++ b/seed/ts-sdk/websocket/no-serde/package.json
@@ -95,7 +95,7 @@
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
         "@types/ws": "^8.18.1",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/websocket/no-websocket-clients/package.json
+++ b/seed/ts-sdk/websocket/no-websocket-clients/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/websocket/serde/package.json
+++ b/seed/ts-sdk/websocket/serde/package.json
@@ -106,7 +106,7 @@
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
         "@types/ws": "^8.18.1",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",

--- a/seed/ts-sdk/x-fern-default/package.json
+++ b/seed/ts-sdk/x-fern-default/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^4.1.1",
+        "vitest": "^3.2.6",
         "msw": "2.11.2",
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11515

Vitest 4.1.9 (resolved from `^4.1.1`) crashes worker forks on Node ≥22 with `ERR_PACKAGE_PATH_NOT_EXPORTED` because it self-requires `vitest/suppress-warnings.cjs` which isn't in its `exports` map. This breaks the `test` CI step for every newly generated TypeScript SDK on `ubuntu-latest` (Node 22).

## Changes Made
- Downgrade pinned Vitest from `^4.1.1` to `^3.2.6` in `TestGenerator.ts` (the version emitted into generated SDK `package.json`)
- Update matching version in `docker/seed/Dockerfile.ts` and `generators/typescript/sdk/cli/Dockerfile` (pre-cached in Docker images)
- Update `generators/typescript/sdk/validator/warm-cache-package.json` (validator image warm cache)
- Update all 215 seed snapshot `package.json` files to reflect the new version
- Add unreleased changelog entry

Vitest 3.2.6 supports the `projects` config and `--project` CLI flag used by the generated `vitest.config.mts`, and passes all 422 generated tests on Node 22 and 26.

## Testing
- [x] Verified `projects` config compatibility with Vitest 3.2 (feature was introduced in 3.2.0)
- [x] Seed snapshots updated to match new generator output

Link to Devin session: https://app.devin.ai/sessions/a06b52ff56f143c9a5d5f1aedc95ee08
Requested by: @adidavid014
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->