### PR TITLE
feat(internal): [C#] Undocumented/extra parameters support

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/extra-parameters-support.yml
+++ b/generators/csharp/sdk/changes/unreleased/extra-parameters-support.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Add support for undocumented/extra parameters: AdditionalQueryParameters from
+    RequestOptions are now applied to all endpoints (previously only endpoints with
+    defined query parameters would merge them). Also add ADDITIONAL_BODY_PROPERTIES
+    feature to README generation.
+  type: feat

--- a/generators/csharp/sdk/features.yml
+++ b/generators/csharp/sdk/features.yml
@@ -60,6 +60,12 @@ features:
     description: |
       If you would like to send additional query parameters as part of the request, use the `AdditionalQueryParameters` request option.
 
+  - id: ADDITIONAL_BODY_PROPERTIES
+    advanced: true
+    description: |
+      If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+      This is only applied to JSON requests.
+
   - id: FORWARD_COMPATIBLE_ENUMS
     advanced: true
     description: |

--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -216,10 +216,10 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         rawClientReference: string,
         serviceId: ServiceId
     ) {
-        const queryParameterCodeBlock = endpointSignatureInfo.request?.getQueryParameterCodeBlock();
-        if (queryParameterCodeBlock != null) {
-            queryParameterCodeBlock.code.write(writer);
-        }
+        const queryParameterCodeBlock =
+            endpointSignatureInfo.request?.getQueryParameterCodeBlock() ??
+            this.getDefaultQueryParameterCodeBlock({ endpoint });
+        queryParameterCodeBlock.code.write(writer);
         const headerParameterCodeBlock =
             endpointSignatureInfo.request?.getHeaderParameterCodeBlock() ??
             this.getDefaultHeaderParameterCodeBlock({ endpoint });
@@ -235,7 +235,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             bodyReference: requestBodyCodeBlock?.requestBodyReference,
             pathParameterReferences: endpointSignatureInfo.pathParameterReferences,
             headerBagReference: headerParameterCodeBlock.headerParameterBagReference,
-            queryString: queryParameterCodeBlock?.queryStringReference,
+            queryString: queryParameterCodeBlock.queryStringReference,
             endpointRequest: endpointSignatureInfo.request
         });
         if (apiRequestCodeBlock.code) {
@@ -300,10 +300,10 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         }
 
         const body = this.csharp.codeblock((writer) => {
-            const queryParameterCodeBlock = endpointSignatureInfo.request?.getQueryParameterCodeBlock();
-            if (queryParameterCodeBlock != null) {
-                queryParameterCodeBlock.code.write(writer);
-            }
+            const queryParameterCodeBlock =
+                endpointSignatureInfo.request?.getQueryParameterCodeBlock() ??
+                this.getDefaultQueryParameterCodeBlock({ endpoint });
+            queryParameterCodeBlock.code.write(writer);
             const headerParameterCodeBlock =
                 endpointSignatureInfo.request?.getHeaderParameterCodeBlock() ??
                 this.getDefaultHeaderParameterCodeBlock({ endpoint });
@@ -319,7 +319,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                 bodyReference: requestBodyCodeBlock?.requestBodyReference,
                 pathParameterReferences: endpointSignatureInfo.pathParameterReferences,
                 headerBagReference: headerParameterCodeBlock.headerParameterBagReference,
-                queryString: queryParameterCodeBlock?.queryStringReference,
+                queryString: queryParameterCodeBlock.queryStringReference,
                 endpointRequest: endpointSignatureInfo.request
             });
             if (apiRequestCodeBlock.code) {
@@ -1458,10 +1458,10 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             throw GeneratorError.internalError("Internal error; a response type is required for pagination endpoints");
         }
 
-        const queryParameterCodeBlock = endpointSignatureInfo.request?.getQueryParameterCodeBlock();
-        if (queryParameterCodeBlock != null) {
-            queryParameterCodeBlock.code.write(writer);
-        }
+        const queryParameterCodeBlock =
+            endpointSignatureInfo.request?.getQueryParameterCodeBlock() ??
+            this.getDefaultQueryParameterCodeBlock({ endpoint });
+        queryParameterCodeBlock.code.write(writer);
         const headerParameterCodeBlock =
             endpointSignatureInfo.request?.getHeaderParameterCodeBlock() ??
             this.getDefaultHeaderParameterCodeBlock({ endpoint });
@@ -1478,7 +1478,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             bodyReference: requestBodyCodeBlock?.requestBodyReference,
             pathParameterReferences: endpointSignatureInfo.pathParameterReferences,
             headerBagReference: headerParameterCodeBlock.headerParameterBagReference,
-            queryString: queryParameterCodeBlock?.queryStringReference,
+            queryString: queryParameterCodeBlock.queryStringReference,
             endpointRequest: endpointSignatureInfo.request
         });
         if (apiRequestCodeBlock.code) {
@@ -1778,6 +1778,31 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         } else {
             return this.names.parameters.requestOptions;
         }
+    }
+
+    /**
+     * Generates query parameter code block for endpoints without a request parameter.
+     * This ensures AdditionalQueryParameters from RequestOptions are always applied.
+     */
+    private getDefaultQueryParameterCodeBlock({ endpoint }: { endpoint: HttpEndpoint }): {
+        code: ast.CodeBlock;
+        queryStringReference: string;
+    } {
+        const requestOptionsVar = this.getRequestOptionsParamNameForEndpoint({ endpoint });
+        const queryStringVar = "_queryString";
+
+        return {
+            code: this.csharp.codeblock((writer) => {
+                writer.write(
+                    `var ${queryStringVar} = new ${this.namespaces.qualifiedCore}.QueryStringBuilder.Builder(capacity: 0)`
+                );
+                writer.writeLine();
+                writer.write(`.MergeAdditional(${requestOptionsVar}?.AdditionalQueryParameters)`);
+                writer.writeLine();
+                writer.write(".Build();");
+            }),
+            queryStringReference: queryStringVar
+        };
     }
 
     /**

--- a/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -120,15 +120,15 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         snippets[FernGeneratorCli.StructuredFeatureId.Retries] = this.buildRetrySnippets();
         snippets[FernGeneratorCli.StructuredFeatureId.Timeouts] = this.buildTimeoutSnippets();
         snippets[ReadmeSnippetBuilder.EXCEPTION_HANDLING_FEATURE_ID] = this.buildExceptionHandlingSnippets();
-        // gRPC APIs don't support raw response access or additional query parameters
+        // gRPC APIs don't support raw response access, additional query parameters, or additional body properties
         if (!this.context.hasGrpcEndpoints()) {
             snippets[ReadmeSnippetBuilder.RAW_RESPONSE_FEATURE_ID] = this.buildRawResponseSnippets();
             snippets[ReadmeSnippetBuilder.ADDITIONAL_QUERY_PARAMETERS_FEATURE_ID] =
                 this.buildAdditionalQueryParametersSnippets();
+            snippets[ReadmeSnippetBuilder.ADDITIONAL_BODY_PROPERTIES_FEATURE_ID] =
+                this.buildAdditionalBodyPropertiesSnippets();
         }
         snippets[ReadmeSnippetBuilder.ADDITIONAL_HEADERS_FEATURE_ID] = this.buildAdditionalHeadersSnippets();
-        snippets[ReadmeSnippetBuilder.ADDITIONAL_BODY_PROPERTIES_FEATURE_ID] =
-            this.buildAdditionalBodyPropertiesSnippets();
         if (this.isPaginationEnabled) {
             snippets[FernGeneratorCli.StructuredFeatureId.Pagination] = this.buildPaginationSnippets();
         }

--- a/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -27,6 +27,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private static RAW_RESPONSE_FEATURE_ID: FernGeneratorCli.FeatureId = "RAW_RESPONSE";
     private static ADDITIONAL_HEADERS_FEATURE_ID: FernGeneratorCli.FeatureId = "ADDITIONAL_HEADERS";
     private static ADDITIONAL_QUERY_PARAMETERS_FEATURE_ID: FernGeneratorCli.FeatureId = "ADDITIONAL_QUERY_PARAMETERS";
+    private static ADDITIONAL_BODY_PROPERTIES_FEATURE_ID: FernGeneratorCli.FeatureId = "ADDITIONAL_BODY_PROPERTIES";
     private static ENVIRONMENTS_FEATURE_ID: FernGeneratorCli.FeatureId = "ENVIRONMENTS";
 
     private readonly context: SdkGeneratorContext;
@@ -126,6 +127,8 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
                 this.buildAdditionalQueryParametersSnippets();
         }
         snippets[ReadmeSnippetBuilder.ADDITIONAL_HEADERS_FEATURE_ID] = this.buildAdditionalHeadersSnippets();
+        snippets[ReadmeSnippetBuilder.ADDITIONAL_BODY_PROPERTIES_FEATURE_ID] =
+            this.buildAdditionalBodyPropertiesSnippets();
         if (this.isPaginationEnabled) {
             snippets[FernGeneratorCli.StructuredFeatureId.Pagination] = this.buildPaginationSnippets();
         }
@@ -280,6 +283,25 @@ var response = await ${this.getMethodCall(queryParameterEndpoint)}(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+`)
+        );
+    }
+
+    private buildAdditionalBodyPropertiesSnippets(): string[] {
+        const bodyPropertiesEndpoints = this.getEndpointsForFeature(
+            ReadmeSnippetBuilder.ADDITIONAL_BODY_PROPERTIES_FEATURE_ID
+        );
+        return bodyPropertiesEndpoints.map((bodyPropertiesEndpoint) =>
+            this.writeCode(`
+var response = await ${this.getMethodCall(bodyPropertiesEndpoint)}(
+    ...,
+    new ${this.requestOptionsName} {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/accept-header/.fern/metadata.json
+++ b/seed/csharp-sdk/accept-header/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/accept-header/README.md
+++ b/seed/csharp-sdk/accept-header/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.EndpointAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.EndpointAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Service/ServiceClient.cs
@@ -17,6 +17,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAccept.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAccept.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Delete,
                     Path = "/container/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/alias-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/alias-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/alias-extends/README.md
+++ b/seed/csharp-sdk/alias-extends/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.ExtendedInlineRequestBodyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.ExtendedInlineRequestBodyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtendsClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtendsClient.cs
@@ -34,6 +34,9 @@ public partial class SeedAliasExtendsClient : ISeedAliasExtendsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAliasExtends.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAliasExtends.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -47,6 +50,7 @@ public partial class SeedAliasExtendsClient : ISeedAliasExtendsClient
                     Method = HttpMethod.Post,
                     Path = "/extends/extended-inline-request-body",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/alias/.fern/metadata.json
+++ b/seed/csharp-sdk/alias/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/alias/README.md
+++ b/seed/csharp-sdk/alias/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/alias/src/SeedAlias/SeedAliasClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/SeedAliasClient.cs
@@ -34,6 +34,9 @@ public partial class SeedAliasClient : ISeedAliasClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAlias.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAlias.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class SeedAliasClient : ISeedAliasClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(typeId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/allof-inline/.fern/metadata.json
+++ b/seed/csharp-sdk/allof-inline/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/allof-inline/README.md
+++ b/seed/csharp-sdk/allof-inline/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -197,6 +198,23 @@ var response = await client.CreateRuleAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateRuleAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/allof-inline/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi/SeedApiClient.cs
@@ -117,6 +117,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -130,6 +133,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "rules",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -195,6 +199,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -207,6 +214,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -271,6 +279,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -283,6 +294,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "entities",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -347,6 +359,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +374,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "organizations",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -424,6 +440,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -437,6 +456,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "plants",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -503,6 +523,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -516,6 +539,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "trees",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/allof/.fern/metadata.json
+++ b/seed/csharp-sdk/allof/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/allof/README.md
+++ b/seed/csharp-sdk/allof/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -197,6 +198,23 @@ var response = await client.CreateRuleAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateRuleAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/allof/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/allof/src/SeedApi/SeedApiClient.cs
@@ -117,6 +117,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -130,6 +133,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "rules",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -195,6 +199,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -207,6 +214,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -271,6 +279,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -283,6 +294,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "entities",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -347,6 +359,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +374,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "organizations",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -424,6 +440,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -437,6 +456,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "plants",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -503,6 +523,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -516,6 +539,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "trees",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/any-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/any-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/any-auth/README.md
+++ b/seed/csharp-sdk/any-auth/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.Auth.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAnyAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAnyAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/User/UserClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/User/UserClient.cs
@@ -17,6 +17,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAnyAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAnyAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Post,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -93,6 +97,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAnyAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAnyAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -105,6 +112,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "admins",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/api-wide-base-path-with-default/README.md
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Widgets.CreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Widgets.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Widgets/WidgetsClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Widgets/WidgetsClient.cs
@@ -19,6 +19,9 @@ public partial class WidgetsClient : IWidgetsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class WidgetsClient : IWidgetsClient
                         ValueConvert.ToPathParameterString(apiVersion ?? "v1beta")
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/csharp-sdk/api-wide-base-path/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/api-wide-base-path/README.md
+++ b/seed/csharp-sdk/api-wide-base-path/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.PostAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.PostAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Service/ServiceClient.cs
@@ -20,6 +20,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApiWideBasePath.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApiWideBasePath.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -38,6 +41,7 @@ public partial class ServiceClient : IServiceClient
                         ValueConvert.ToPathParameterString(endpointParam),
                         ValueConvert.ToPathParameterString(resourceParam)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/audiences/.fern/metadata.json
+++ b/seed/csharp-sdk/audiences/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/audiences/README.md
+++ b/seed/csharp-sdk/audiences/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -197,6 +198,23 @@ var response = await client.Foo.FindAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Foo.FindAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedAudiences.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedAudiences.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/partner-path",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/README.md
+++ b/seed/csharp-sdk/basic-auth-environment-variables/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.BasicAuth.PostWithBasicAuthAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BasicAuth.PostWithBasicAuthAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/BasicAuth/BasicAuthClient.cs
@@ -17,6 +17,11 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuthEnvironmentVariables.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuthEnvironmentVariables.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                 {
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -116,6 +122,11 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuthEnvironmentVariables.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuthEnvironmentVariables.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -129,6 +140,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth-pw-omitted/README.md
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.BasicAuth.PostWithBasicAuthAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BasicAuth.PostWithBasicAuthAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/BasicAuth/BasicAuthClient.cs
@@ -17,6 +17,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuthPwOmitted.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuthPwOmitted.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                 {
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -116,6 +120,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuthPwOmitted.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuthPwOmitted.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -129,6 +136,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/basic-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/no-custom-config/README.md
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.BasicAuth.PostWithBasicAuthAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BasicAuth.PostWithBasicAuthAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
@@ -17,6 +17,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                 {
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -116,6 +120,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -129,6 +136,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/basic-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/unified-client-options/README.md
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -180,6 +181,23 @@ var response = await client.BasicAuth.PostWithBasicAuthAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BasicAuth.PostWithBasicAuthAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
@@ -17,6 +17,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                 {
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -116,6 +120,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -129,6 +136,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/wire-tests/README.md
+++ b/seed/csharp-sdk/basic-auth/wire-tests/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.BasicAuth.PostWithBasicAuthAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BasicAuth.PostWithBasicAuthAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/BasicAuth/BasicAuthClient.cs
@@ -17,6 +17,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                 {
                     Method = HttpMethod.Get,
                     Path = "basic-auth",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -116,6 +120,9 @@ public partial class BasicAuthClient : IBasicAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBasicAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBasicAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -129,6 +136,7 @@ public partial class BasicAuthClient : IBasicAuthClient
                     Method = HttpMethod.Post,
                     Path = "basic-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/README.md
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.GetWithBearerTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetWithBearerTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -17,6 +17,11 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBearerTokenEnvironmentVariable.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBearerTokenEnvironmentVariable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "apiKey",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/README.md
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.Service.GetWithBearerTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetWithBearerTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -17,6 +17,11 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBearerTokenEnvironmentVariable.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBearerTokenEnvironmentVariable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "apiKey",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/bytes-download/.fern/metadata.json
+++ b/seed/csharp-sdk/bytes-download/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bytes-download/README.md
+++ b/seed/csharp-sdk/bytes-download/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.SimpleAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.SimpleAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Service/ServiceClient.cs
@@ -16,6 +16,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBytesDownload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBytesDownload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Post,
                     Path = "snippet",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -78,6 +82,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBytesDownload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBytesDownload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -93,6 +100,7 @@ public partial class ServiceClient : IServiceClient
                         "download-content/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/csharp-sdk/bytes-upload/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bytes-upload/README.md
+++ b/seed/csharp-sdk/bytes-upload/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.Service.UploadAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.UploadAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/ServiceClient.cs
@@ -17,6 +17,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedBytesUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedBytesUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "upload-content",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/octet-stream",
                     Options = options,

--- a/seed/csharp-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references-advanced/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/.fern/metadata.json
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/README.md
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.V1.ListUsersAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.V1.ListUsersAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/V1/V1Client.cs
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/V1/V1Client.cs
@@ -18,6 +18,9 @@ public partial class V1Client : IV1Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class V1Client : IV1Client
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/cli-multi-spec/.fern/metadata.json
+++ b/seed/csharp-sdk/cli-multi-spec/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cli-multi-spec/README.md
+++ b/seed/csharp-sdk/cli-multi-spec/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.ListUsersAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.ListUsersAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/cli-multi-spec/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/cli-multi-spec/src/SeedApi/SeedApiClient.cs
@@ -34,6 +34,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -111,6 +115,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -126,6 +133,7 @@ public partial class SeedApiClient : ISeedApiClient
                         "users/{0}",
                         ValueConvert.ToPathParameterString(request.UserId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -190,6 +198,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -202,6 +213,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "invoices",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -267,6 +279,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -282,6 +297,7 @@ public partial class SeedApiClient : ISeedApiClient
                         "invoices/{0}",
                         ValueConvert.ToPathParameterString(request.InvoiceId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/client-side-params/.fern/metadata.json
+++ b/seed/csharp-sdk/client-side-params/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/client-side-params/README.md
+++ b/seed/csharp-sdk/client-side-params/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.Service.SearchResourcesAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.SearchResourcesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Service/ServiceClient.cs
@@ -453,6 +453,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedClientSideParams.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedClientSideParams.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -466,6 +469,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/api/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -532,6 +536,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedClientSideParams.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedClientSideParams.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -548,6 +555,7 @@ public partial class ServiceClient : IServiceClient
                         ValueConvert.ToPathParameterString(userId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -613,6 +621,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedClientSideParams.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedClientSideParams.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -628,6 +639,7 @@ public partial class ServiceClient : IServiceClient
                         "/api/users/{0}",
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/content-type/.fern/metadata.json
+++ b/seed/csharp-sdk/content-type/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/content-type/README.md
+++ b/seed/csharp-sdk/content-type/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.Service.PatchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.PatchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Service/ServiceClient.cs
@@ -17,6 +17,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedContentTypes.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedContentTypes.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/merge-patch+json",
                     Options = options,
@@ -71,6 +75,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedContentTypes.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedContentTypes.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -84,6 +91,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("complex/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/merge-patch+json",
                     Options = options,
@@ -125,6 +133,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedContentTypes.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedContentTypes.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -138,6 +149,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("named-mixed/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/merge-patch+json",
                     Options = options,
@@ -178,6 +190,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedContentTypes.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedContentTypes.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -191,6 +206,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "optional-merge-patch-test",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/merge-patch+json",
                     Options = options,
@@ -232,6 +248,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedContentTypes.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedContentTypes.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -245,6 +264,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("regular/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/csharp-sdk/cross-package-type-names/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cross-package-type-names/README.md
+++ b/seed/csharp-sdk/cross-package-type-names/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.Foo.FindAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Foo.FindAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/Service/ServiceClient.cs
@@ -18,6 +18,11 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCrossPackageTypeNames.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCrossPackageTypeNames.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +35,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/Service/ServiceClient.cs
@@ -18,6 +18,11 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCrossPackageTypeNames.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCrossPackageTypeNames.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +35,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/README.md
@@ -17,6 +17,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -142,6 +143,23 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.DataService.CheckAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/README.md
@@ -17,7 +17,6 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
-  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -143,23 +142,6 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
-        }
-    }
-);
-```
-
-### Additional Body Properties
-
-If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
-This is only applied to JSON requests.
-
-```csharp
-var response = await client.DataService.CheckAsync(
-    ...,
-    new RequestOptions {
-        AdditionalBodyProperties = new Dictionary<string, object>
-        {
-            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApiClient.cs
@@ -52,6 +52,9 @@ public partial class SeedApiClient : ISeedApiClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -64,6 +67,7 @@ public partial class SeedApiClient : ISeedApiClient
                         {
                             Method = HttpMethod.Post,
                             Path = "foo",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/README.md
@@ -17,6 +17,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -142,6 +143,23 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.DataService.CheckAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/README.md
@@ -17,7 +17,6 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
-  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -143,23 +142,6 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
-        }
-    }
-);
-```
-
-### Additional Body Properties
-
-If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
-This is only applied to JSON requests.
-
-```csharp
-var response = await client.DataService.CheckAsync(
-    ...,
-    new RequestOptions {
-        AdditionalBodyProperties = new Dictionary<string, object>
-        {
-            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApiClient.cs
@@ -37,6 +37,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -49,6 +52,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Post,
                     Path = "foo",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/.fern/metadata.json
@@ -6,8 +6,7 @@
     "package-id": "Seed.Client"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/README.md
@@ -17,6 +17,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -142,6 +143,23 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.DataService.CheckAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/README.md
@@ -17,7 +17,6 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
-  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -143,23 +142,6 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
-        }
-    }
-);
-```
-
-### Additional Body Properties
-
-If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
-This is only applied to JSON requests.
-
-```csharp
-var response = await client.DataService.CheckAsync(
-    ...,
-    new RequestOptions {
-        AdditionalBodyProperties = new Dictionary<string, object>
-        {
-            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApiClient.cs
@@ -37,6 +37,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -49,6 +52,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Post,
                     Path = "foo",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/.fern/metadata.json
@@ -8,8 +8,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/README.md
@@ -17,6 +17,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -142,6 +143,23 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.DataService.CheckAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/README.md
@@ -17,7 +17,6 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
-  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -143,23 +142,6 @@ var response = await client.DataService.CheckAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
-        }
-    }
-);
-```
-
-### Additional Body Properties
-
-If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
-This is only applied to JSON requests.
-
-```csharp
-var response = await client.DataService.CheckAsync(
-    ...,
-    new RequestOptions {
-        AdditionalBodyProperties = new Dictionary<string, object>
-        {
-            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApiClient.cs
@@ -37,6 +37,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -49,6 +52,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Post,
                     Path = "foo",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/README.md
@@ -16,6 +16,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -127,6 +128,23 @@ var response = await client.UserService.CreateAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.UserService.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/README.md
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/README.md
@@ -16,7 +16,6 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Retries](#retries)
   - [Timeouts](#timeouts)
   - [Additional Headers](#additional-headers)
-  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -128,23 +127,6 @@ var response = await client.UserService.CreateAsync(
         AdditionalHeaders = new Dictionary<string, string?>
         {
             { "X-Custom-Header", "custom-value" }
-        }
-    }
-);
-```
-
-### Additional Body Properties
-
-If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
-This is only applied to JSON requests.
-
-```csharp
-var response = await client.UserService.CreateAsync(
-    ...,
-    new RequestOptions {
-        AdditionalBodyProperties = new Dictionary<string, object>
-        {
-            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-inline-types": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/README.md
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -183,6 +184,23 @@ var response = await client.GetRootAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetRootAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/SeedObjectClient.cs
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/SeedObjectClient.cs
@@ -35,6 +35,9 @@ public partial class SeedObjectClient : ISeedObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObject.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObject.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +51,7 @@ public partial class SeedObjectClient : ISeedObjectClient
                     Method = HttpMethod.Post,
                     Path = "/root/root",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -114,6 +118,9 @@ public partial class SeedObjectClient : ISeedObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObject.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObject.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -127,6 +134,7 @@ public partial class SeedObjectClient : ISeedObjectClient
                     Method = HttpMethod.Post,
                     Path = "/root/discriminated-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -167,6 +175,9 @@ public partial class SeedObjectClient : ISeedObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObject.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObject.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -180,6 +191,7 @@ public partial class SeedObjectClient : ISeedObjectClient
                     Method = HttpMethod.Post,
                     Path = "/root/undiscriminated-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/.fern/metadata.json
@@ -8,8 +8,7 @@
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/README.md
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Contoso.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Contoso.cs
@@ -43,6 +43,9 @@ public partial class Contoso : IContoso
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -56,6 +59,7 @@ public partial class Contoso : IContoso
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class Contoso : IContoso
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -134,6 +141,7 @@ public partial class Contoso : IContoso
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/ScimConfiguration/ScimConfigurationClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/ScimConfiguration/ScimConfigurationClient.cs
@@ -20,6 +20,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -99,6 +103,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                     Method = HttpMethod.Post,
                     Path = "/scim-configuration/tokens",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -190,6 +201,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration/users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/System/SystemClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/System/SystemClient.cs
@@ -19,6 +19,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -187,6 +198,7 @@ public partial class SystemClient : ISystemClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/.fern/metadata.json
@@ -7,8 +7,7 @@
     "experimental-dotnet-format": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/README.md
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/ScimConfiguration/ScimConfigurationClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/ScimConfiguration/ScimConfigurationClient.cs
@@ -17,6 +17,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -107,6 +114,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                     Method = HttpMethod.Post,
                     Path = "/scim-configuration/tokens",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -171,6 +179,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -183,6 +194,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration/users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollisionClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollisionClient.cs
@@ -43,6 +43,9 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -56,6 +59,7 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -134,6 +141,7 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/System/SystemClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/System/SystemClient.cs
@@ -18,6 +18,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +100,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -174,6 +182,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -186,6 +197,7 @@ public partial class SystemClient : ISystemClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/.fern/metadata.json
@@ -9,8 +9,7 @@
     "experimental-fully-qualified-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/README.md
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.cs
@@ -43,6 +43,9 @@ public partial class Contoso : IContoso
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -56,6 +59,7 @@ public partial class Contoso : IContoso
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class Contoso : IContoso
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -134,6 +141,7 @@ public partial class Contoso : IContoso
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/ScimConfiguration/ScimConfigurationClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/ScimConfiguration/ScimConfigurationClient.cs
@@ -20,6 +20,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -99,6 +103,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                     Method = HttpMethod.Post,
                     Path = "/scim-configuration/tokens",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -190,6 +201,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration/users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/System/SystemClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/System/SystemClient.cs
@@ -19,6 +19,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -187,6 +198,7 @@ public partial class SystemClient : ISystemClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/.fern/metadata.json
@@ -8,8 +8,7 @@
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/README.md
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/ContosoClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/ContosoClient.cs
@@ -43,6 +43,9 @@ public partial class ContosoClient : IContosoClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -56,6 +59,7 @@ public partial class ContosoClient : IContosoClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class ContosoClient : IContosoClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -134,6 +141,7 @@ public partial class ContosoClient : IContosoClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/ScimConfiguration/ScimConfigurationClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/ScimConfiguration/ScimConfigurationClient.cs
@@ -20,6 +20,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -99,6 +103,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                     Method = HttpMethod.Post,
                     Path = "/scim-configuration/tokens",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -190,6 +201,7 @@ public partial class ScimConfigurationClient : IScimConfigurationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/scim-configuration/users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/System/SystemClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/System/SystemClient.cs
@@ -19,6 +19,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class SystemClient : ISystemClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class SystemClient : ISystemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new Contoso.Net.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new Contoso.Net.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -187,6 +198,7 @@ public partial class SystemClient : ISystemClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/.fern/metadata.json
@@ -8,8 +8,7 @@
     "experimental-fully-qualified-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/README.md
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Tasktest.HelloAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Tasktest.HelloAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Tasktest/TasktestClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Tasktest/TasktestClient.cs
@@ -16,6 +16,11 @@ public partial class TasktestClient : ITasktestClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new global::Seed.CsharpNamespaceConflict.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new global::Seed.CsharpNamespaceConflict.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class TasktestClient : ITasktestClient
                 {
                     Method = HttpMethod.Get,
                     Path = "hello",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/README.md
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client._.CreateCatalogAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client._.CreateCatalogAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/_/Client.cs
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/_/Client.cs
@@ -18,6 +18,9 @@ public partial class Client : IClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class Client : IClient
                     Method = HttpMethod.Post,
                     Path = "catalog",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class Client : IClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class Client : IClient
                     Method = HttpMethod.Post,
                     Path = "activity",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/csharp-readonly-request/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-readonly-request/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-readonly-request/README.md
+++ b/seed/csharp-sdk/csharp-readonly-request/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -193,6 +194,23 @@ var response = await client.BatchCreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BatchCreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequestClient.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequestClient.cs
@@ -35,6 +35,11 @@ public partial class SeedCsharpReadonlyRequestClient : ISeedCsharpReadonlyReques
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCsharpReadonlyRequest.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCsharpReadonlyRequest.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +53,7 @@ public partial class SeedCsharpReadonlyRequestClient : ISeedCsharpReadonlyReques
                     Method = HttpMethod.Post,
                     Path = "/vendors/batch",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-system-collision/system-client/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/.fern/metadata.json
@@ -6,8 +6,7 @@
     "client-class-name": "System"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/README.md
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -186,6 +187,23 @@ var response = await client.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/System.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/System.cs
@@ -35,6 +35,11 @@ public partial class System : ISystem
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCsharpSystemCollision.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCsharpSystemCollision.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +53,7 @@ public partial class System : ISystem
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -113,6 +119,11 @@ public partial class System : ISystem
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCsharpSystemCollision.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCsharpSystemCollision.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -126,6 +137,7 @@ public partial class System : ISystem
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -191,6 +203,11 @@ public partial class System : ISystem
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCsharpSystemCollision.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCsharpSystemCollision.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -204,6 +221,7 @@ public partial class System : ISystem
                     Method = HttpMethod.Post,
                     Path = "/users/empty",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/README.md
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.GetTimeZoneAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetTimeZoneAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntitiesClient.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntitiesClient.cs
@@ -34,6 +34,9 @@ public partial class SeedCsharpXmlEntitiesClient : ISeedCsharpXmlEntitiesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedCsharpXmlEntities.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedCsharpXmlEntities.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class SeedCsharpXmlEntitiesClient : ISeedCsharpXmlEntitiesClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/timezone",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/dollar-string-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/empty-clients/.fern/metadata.json
+++ b/seed/csharp-sdk/empty-clients/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/endpoint-security-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/endpoint-security-auth/README.md
+++ b/seed/csharp-sdk/endpoint-security-auth/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -191,6 +192,23 @@ var response = await client.Auth.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/User/UserClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/User/UserClient.cs
@@ -17,6 +17,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -93,6 +97,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -105,6 +112,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -169,6 +177,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -181,6 +192,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -245,6 +257,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -257,6 +272,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -321,6 +337,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -333,6 +352,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -397,6 +417,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -409,6 +432,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -473,6 +497,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEndpointSecurityAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEndpointSecurityAuth.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -485,6 +512,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/enum/forward-compatible-enums/.fern/metadata.json
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/enum/forward-compatible-enums/README.md
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -185,6 +186,23 @@ var response = await client.Headers.SendAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Headers.SendAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Headers/HeadersClient.cs
@@ -17,6 +17,9 @@ public partial class HeadersClient : IHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add("operand", request.Operand)
             .Add("maybeOperand", request.MaybeOperand)
@@ -33,6 +36,7 @@ public partial class HeadersClient : IHeadersClient
                 {
                     Method = HttpMethod.Post,
                     Path = "headers",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
@@ -17,6 +17,9 @@ public partial class InlinedRequestClient : IInlinedRequestClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class InlinedRequestClient : IInlinedRequestClient
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
@@ -17,6 +17,9 @@ public partial class MultipartFormClient : IMultipartFormClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -27,6 +30,7 @@ public partial class MultipartFormClient : IMultipartFormClient
         {
             Method = HttpMethod.Post,
             Path = "multipart",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/PathParam/PathParamClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/PathParam/PathParamClient.cs
@@ -19,6 +19,9 @@ public partial class PathParamClient : IPathParamClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class PathParamClient : IPathParamClient
                         ValueConvert.ToPathParameterString(operand),
                         ValueConvert.ToPathParameterString(operandOrColor)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/enum/plain-enums/.fern/metadata.json
+++ b/seed/csharp-sdk/enum/plain-enums/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-forward-compatible-enums": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/enum/plain-enums/README.md
+++ b/seed/csharp-sdk/enum/plain-enums/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.Headers.SendAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Headers.SendAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Headers/HeadersClient.cs
@@ -17,6 +17,9 @@ public partial class HeadersClient : IHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add("operand", request.Operand)
             .Add("maybeOperand", request.MaybeOperand)
@@ -33,6 +36,7 @@ public partial class HeadersClient : IHeadersClient
                 {
                     Method = HttpMethod.Post,
                     Path = "headers",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/InlinedRequest/InlinedRequestClient.cs
@@ -17,6 +17,9 @@ public partial class InlinedRequestClient : IInlinedRequestClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class InlinedRequestClient : IInlinedRequestClient
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/MultipartForm/MultipartFormClient.cs
@@ -17,6 +17,9 @@ public partial class MultipartFormClient : IMultipartFormClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -27,6 +30,7 @@ public partial class MultipartFormClient : IMultipartFormClient
         {
             Method = HttpMethod.Post,
             Path = "multipart",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/PathParam/PathParamClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/PathParam/PathParamClient.cs
@@ -19,6 +19,9 @@ public partial class PathParamClient : IPathParamClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedEnum.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedEnum.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class PathParamClient : IPathParamClient
                         ValueConvert.ToPathParameterString(operand),
                         ValueConvert.ToPathParameterString(operandOrColor)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/error-property/.fern/metadata.json
+++ b/seed/csharp-sdk/error-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/error-property/README.md
+++ b/seed/csharp-sdk/error-property/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.PropertyBasedError.ThrowErrorAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.PropertyBasedError.ThrowErrorAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/PropertyBasedError/PropertyBasedErrorClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/PropertyBasedError/PropertyBasedErrorClient.cs
@@ -17,6 +17,9 @@ public partial class PropertyBasedErrorClient : IPropertyBasedErrorClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedErrorProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedErrorProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class PropertyBasedErrorClient : IPropertyBasedErrorClient
                 {
                     Method = HttpMethod.Get,
                     Path = "property-based-error",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/errors/.fern/metadata.json
+++ b/seed/csharp-sdk/errors/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/errors/README.md
+++ b/seed/csharp-sdk/errors/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Simple.FooWithoutEndpointErrorAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Simple.FooWithoutEndpointErrorAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/errors/src/SeedErrors/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Simple/SimpleClient.cs
@@ -18,6 +18,9 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedErrors.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedErrors.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class SimpleClient : ISimpleClient
                     Method = HttpMethod.Post,
                     Path = "foo1",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -142,6 +146,9 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedErrors.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedErrors.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -155,6 +162,7 @@ public partial class SimpleClient : ISimpleClient
                     Method = HttpMethod.Post,
                     Path = "foo2",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -278,6 +286,9 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedErrors.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedErrors.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -291,6 +302,7 @@ public partial class SimpleClient : ISimpleClient
                     Method = HttpMethod.Post,
                     Path = "foo3",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/examples/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/examples/no-custom-config/README.md
+++ b/seed/csharp-sdk/examples/no-custom-config/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -191,6 +192,23 @@ var response = await client.EchoAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.EchoAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
@@ -19,6 +19,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ServiceClient : IServiceClient
                         "/file/notification/{0}",
                         ValueConvert.ToPathParameterString(notificationId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Service/ServiceClient.cs
@@ -20,6 +20,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add("X-File-API-Version", request.XFileApiVersion)
             .Add(_client.Options.Headers)
@@ -33,6 +36,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/file/{0}", ValueConvert.ToPathParameterString(filename)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/Service/ServiceClient.cs
@@ -19,6 +19,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/check/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -69,6 +73,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -81,6 +88,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/ping",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamplesClient.cs
@@ -55,6 +55,9 @@ public partial class SeedExamplesClient : ISeedExamplesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -68,6 +71,7 @@ public partial class SeedExamplesClient : ISeedExamplesClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -133,6 +137,9 @@ public partial class SeedExamplesClient : ISeedExamplesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -146,6 +153,7 @@ public partial class SeedExamplesClient : ISeedExamplesClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/movie/{0}", ValueConvert.ToPathParameterString(movieId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -257,6 +265,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -270,6 +281,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/big-entity",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -335,6 +347,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -348,6 +363,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/refresh-token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/csharp-sdk/examples/readme-config/.fern/metadata.json
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/examples/readme-config/README.md
+++ b/seed/csharp-sdk/examples/readme-config/README.md
@@ -25,6 +25,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -246,6 +247,23 @@ var response = await client.Service.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/Service/ServiceClient.cs
@@ -19,6 +19,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ServiceClient : IServiceClient
                         "/file/notification/{0}",
                         ValueConvert.ToPathParameterString(notificationId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Service/ServiceClient.cs
@@ -20,6 +20,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add("X-File-API-Version", request.XFileApiVersion)
             .Add(_client.Options.Headers)
@@ -33,6 +36,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/file/{0}", ValueConvert.ToPathParameterString(filename)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/Service/ServiceClient.cs
@@ -19,6 +19,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/check/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -69,6 +73,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -81,6 +88,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/ping",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamplesClient.cs
@@ -55,6 +55,9 @@ public partial class SeedExamplesClient : ISeedExamplesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -68,6 +71,7 @@ public partial class SeedExamplesClient : ISeedExamplesClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -133,6 +137,9 @@ public partial class SeedExamplesClient : ISeedExamplesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -146,6 +153,7 @@ public partial class SeedExamplesClient : ISeedExamplesClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/movie/{0}", ValueConvert.ToPathParameterString(movieId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -257,6 +265,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -270,6 +281,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/big-entity",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -335,6 +347,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExamples.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExamples.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -348,6 +363,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/refresh-token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/.fern/metadata.json
@@ -6,8 +6,7 @@
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/README.md
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -21,6 +21,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -101,6 +105,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -114,6 +121,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -181,6 +189,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -194,6 +205,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -274,6 +289,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -356,6 +375,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -423,6 +443,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -436,6 +459,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -505,6 +529,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -518,6 +545,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +615,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -600,6 +631,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -19,6 +19,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json",
                     Options = options,
@@ -72,6 +76,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json; charset=utf-8",
                     Options = options,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -20,6 +20,9 @@ public partial class EnumClient : IEnumClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class EnumClient : IEnumClient
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -20,6 +20,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -179,6 +187,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -277,6 +292,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -357,6 +376,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -22,6 +22,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +378,7 @@ public partial class ObjectClient : IObjectClient
                         ValueConvert.ToPathParameterString(string_)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +448,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +464,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -510,6 +534,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -523,6 +550,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -590,6 +618,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +634,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -672,6 +704,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -685,6 +720,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-map-of-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -754,6 +790,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -767,6 +806,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -836,6 +876,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -849,6 +892,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-nested-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -918,6 +962,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -931,6 +978,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -21,6 +21,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -36,6 +39,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -101,6 +105,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -116,6 +123,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -415,6 +423,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -431,6 +442,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -496,6 +508,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -512,6 +527,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -578,6 +594,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -594,6 +613,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -825,6 +845,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -840,6 +863,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path-bool/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -905,6 +929,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -920,6 +947,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -19,6 +19,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -188,6 +199,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -253,6 +265,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -266,6 +281,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -331,6 +347,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -344,6 +363,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -409,6 +429,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -422,6 +445,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -487,6 +511,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -500,6 +527,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -565,6 +593,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -578,6 +609,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -643,6 +675,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -656,6 +691,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -19,6 +19,9 @@ public partial class PutClient : IPutClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class PutClient : IPutClient
                 {
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -20,6 +20,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -18,6 +18,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -170,6 +178,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -182,6 +193,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -246,6 +258,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -258,6 +273,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -23,6 +23,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -36,6 +39,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -123,6 +127,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-Custom-Header", request.XCustomHeader)
             .Add(_client.Options.Headers)
@@ -137,6 +144,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/array-body-with-headers",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -20,6 +20,9 @@ public partial class NoAuthClient : INoAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class NoAuthClient : INoAuthClient
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -19,6 +19,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -107,6 +114,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -18,6 +18,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
             .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -33,6 +36,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/README.md
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -32,6 +32,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -45,6 +48,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/list-of-primitives",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -123,6 +127,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -136,6 +143,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/list-of-objects",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -212,6 +220,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -225,6 +236,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/set-of-primitives",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -301,6 +313,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -314,6 +329,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/set-of-objects",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -392,6 +408,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -405,6 +424,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/map-prim-to-prim",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -483,6 +503,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -496,6 +519,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/map-prim-to-object",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -574,6 +598,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -587,6 +614,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/map-prim-to-union",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -665,6 +693,9 @@ public partial class ContainerClient : IContainerClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -678,6 +709,7 @@ public partial class ContainerClient : IContainerClient
                             Method = HttpMethod.Post,
                             Path = "/container/opt-objects",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -30,6 +30,9 @@ public partial class ContentTypeClient : IContentTypeClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -43,6 +46,7 @@ public partial class ContentTypeClient : IContentTypeClient
                             Method = HttpMethod.Post,
                             Path = "/foo/bar",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             ContentType = "application/json-patch+json",
                             Options = options,
@@ -88,6 +92,9 @@ public partial class ContentTypeClient : IContentTypeClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -101,6 +108,7 @@ public partial class ContentTypeClient : IContentTypeClient
                             Method = HttpMethod.Post,
                             Path = "/foo/baz",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             ContentType = "application/json-patch+json; charset=utf-8",
                             Options = options,

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -31,6 +31,9 @@ public partial class EnumClient : IEnumClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -44,6 +47,7 @@ public partial class EnumClient : IEnumClient
                             Method = HttpMethod.Post,
                             Path = "/enum",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -31,6 +31,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                                 "/http-methods/{0}",
                                 ValueConvert.ToPathParameterString(id)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -120,6 +124,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -133,6 +140,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                             Method = HttpMethod.Post,
                             Path = "/http-methods",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -210,6 +218,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -226,6 +237,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                                 ValueConvert.ToPathParameterString(id)
                             ),
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -303,6 +315,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -319,6 +334,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                                 ValueConvert.ToPathParameterString(id)
                             ),
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -395,6 +411,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -410,6 +429,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                                 "/http-methods/{0}",
                                 ValueConvert.ToPathParameterString(id)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -33,6 +33,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-optional-field",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -124,6 +128,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -137,6 +144,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-required-field",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -213,6 +221,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -226,6 +237,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-map-of-map",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -302,6 +314,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -315,6 +330,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-nested-with-optional-field",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -394,6 +410,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -410,6 +429,7 @@ public partial class ObjectClient : IObjectClient
                                 ValueConvert.ToPathParameterString(string_)
                             ),
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -488,6 +508,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -501,6 +524,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-nested-with-required-field-list",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -579,6 +603,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -592,6 +619,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-unknown-field",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -670,6 +698,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -683,6 +714,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-documented-unknown-type",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -761,6 +793,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -774,6 +809,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-map-of-documented-unknown-type",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -852,6 +888,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -865,6 +904,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -944,6 +984,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -957,6 +1000,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-required-nested-object",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -1035,6 +1079,9 @@ public partial class ObjectClient : IObjectClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -1048,6 +1095,7 @@ public partial class ObjectClient : IObjectClient
                             Method = HttpMethod.Post,
                             Path = "/object/get-and-return-with-datetime-like-string",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -31,6 +31,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class ParamsClient : IParamsClient
                                 "/params/path/{0}",
                                 ValueConvert.ToPathParameterString(param)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -120,6 +124,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -135,6 +142,7 @@ public partial class ParamsClient : IParamsClient
                                 "/params/path/{0}",
                                 ValueConvert.ToPathParameterString(request.Param)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -463,6 +471,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -479,6 +490,7 @@ public partial class ParamsClient : IParamsClient
                                 ValueConvert.ToPathParameterString(param)
                             ),
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -553,6 +565,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -569,6 +584,7 @@ public partial class ParamsClient : IParamsClient
                                 ValueConvert.ToPathParameterString(request.Param)
                             ),
                             Body = request.Body,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -644,6 +660,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -660,6 +679,7 @@ public partial class ParamsClient : IParamsClient
                                 ValueConvert.ToPathParameterString(param)
                             ),
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -924,6 +944,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -939,6 +962,7 @@ public partial class ParamsClient : IParamsClient
                                 "/params/path-bool/{0}",
                                 ValueConvert.ToPathParameterString(param)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -1013,6 +1037,9 @@ public partial class ParamsClient : IParamsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -1028,6 +1055,7 @@ public partial class ParamsClient : IParamsClient
                                 "/params/path/{0}",
                                 ValueConvert.ToPathParameterString(param)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -30,6 +30,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -43,6 +46,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/string",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -117,6 +121,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -130,6 +137,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/integer",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -204,6 +212,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -217,6 +228,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/long",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -291,6 +303,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -304,6 +319,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/double",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -378,6 +394,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -391,6 +410,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/boolean",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -465,6 +485,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -478,6 +501,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/datetime",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -552,6 +576,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -565,6 +592,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/date",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -639,6 +667,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -652,6 +683,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/uuid",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -726,6 +758,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -739,6 +774,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                             Method = HttpMethod.Post,
                             Path = "/primitive/base64",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -30,6 +30,9 @@ public partial class PutClient : IPutClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -45,6 +48,7 @@ public partial class PutClient : IPutClient
                                 "{0}",
                                 ValueConvert.ToPathParameterString(request.Id)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -31,6 +31,9 @@ public partial class UnionClient : IUnionClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -44,6 +47,7 @@ public partial class UnionClient : IUnionClient
                             Method = HttpMethod.Post,
                             Path = "/union",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -29,6 +29,9 @@ public partial class UrlsClient : IUrlsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -41,6 +44,7 @@ public partial class UrlsClient : IUrlsClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/urls/MixedCase",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -114,6 +118,9 @@ public partial class UrlsClient : IUrlsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -126,6 +133,7 @@ public partial class UrlsClient : IUrlsClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/urls/no-ending-slash",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -199,6 +207,9 @@ public partial class UrlsClient : IUrlsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -211,6 +222,7 @@ public partial class UrlsClient : IUrlsClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/urls/with-ending-slash/",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -284,6 +296,9 @@ public partial class UrlsClient : IUrlsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -296,6 +311,7 @@ public partial class UrlsClient : IUrlsClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/urls/with_underscores",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -32,6 +32,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -45,6 +48,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                             Method = HttpMethod.Post,
                             Path = "/req-bodies/object",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -145,6 +149,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add("X-Custom-Header", request.XCustomHeader)
                     .Add(_client.Options.Headers)
@@ -159,6 +166,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                             Method = HttpMethod.Post,
                             Path = "/req-bodies/array-body-with-headers",
                             Body = request.Body,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -29,6 +29,9 @@ public partial class NoAuthClient : INoAuthClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -42,6 +45,7 @@ public partial class NoAuthClient : INoAuthClient
                             Method = HttpMethod.Post,
                             Path = "/no-auth",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -29,6 +29,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -41,6 +44,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/no-req-body",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -116,6 +120,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -128,6 +135,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                         {
                             Method = HttpMethod.Post,
                             Path = "/no-req-body",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -28,6 +28,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
                     .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
                     .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -43,6 +46,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                             Method = HttpMethod.Post,
                             Path = "/test-headers/custom-header",
                             Body = request.Body,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/.fern/metadata.json
@@ -6,8 +6,7 @@
     "generate-error-types": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/README.md
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -21,6 +21,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -101,6 +105,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -114,6 +121,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -181,6 +189,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -194,6 +205,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -274,6 +289,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -356,6 +375,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -423,6 +443,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -436,6 +459,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -505,6 +529,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -518,6 +545,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +615,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -600,6 +631,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -19,6 +19,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json",
                     Options = options,
@@ -72,6 +76,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json; charset=utf-8",
                     Options = options,

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -20,6 +20,9 @@ public partial class EnumClient : IEnumClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class EnumClient : IEnumClient
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -20,6 +20,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -179,6 +187,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -277,6 +292,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -357,6 +376,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -22,6 +22,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +378,7 @@ public partial class ObjectClient : IObjectClient
                         ValueConvert.ToPathParameterString(string_)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +448,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +464,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -510,6 +534,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -523,6 +550,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -590,6 +618,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +634,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -672,6 +704,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -685,6 +720,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-map-of-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -754,6 +790,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -767,6 +806,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -836,6 +876,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -849,6 +892,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-nested-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -918,6 +962,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -931,6 +978,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -20,6 +20,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -414,6 +422,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -430,6 +441,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -495,6 +507,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -511,6 +526,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -577,6 +593,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -593,6 +612,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -824,6 +844,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -839,6 +862,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path-bool/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -904,6 +928,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -919,6 +946,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -19,6 +19,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -188,6 +199,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -253,6 +265,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -266,6 +281,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -331,6 +347,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -344,6 +363,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -409,6 +429,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -422,6 +445,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -487,6 +511,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -500,6 +527,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -565,6 +593,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -578,6 +609,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -643,6 +675,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -656,6 +691,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -19,6 +19,9 @@ public partial class PutClient : IPutClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class PutClient : IPutClient
                 {
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -20,6 +20,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -18,6 +18,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -170,6 +178,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -182,6 +193,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -246,6 +258,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -258,6 +273,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -21,6 +21,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -99,6 +103,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-Custom-Header", request.XCustomHeader)
             .Add(_client.Options.Headers)
@@ -113,6 +120,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/array-body-with-headers",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -18,6 +18,9 @@ public partial class NoAuthClient : INoAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class NoAuthClient : INoAuthClient
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -18,6 +18,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -17,6 +17,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
             .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -32,6 +35,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/.fern/metadata.json
@@ -6,8 +6,7 @@
     "root-namespace-for-core-classes": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/README.md
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -21,6 +21,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -101,6 +105,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -114,6 +121,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -181,6 +189,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -194,6 +205,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -274,6 +289,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -356,6 +375,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -423,6 +443,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -436,6 +459,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -505,6 +529,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -518,6 +545,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +615,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -600,6 +631,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -19,6 +19,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json",
                     Options = options,
@@ -72,6 +76,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json; charset=utf-8",
                     Options = options,

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -20,6 +20,9 @@ public partial class EnumClient : IEnumClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class EnumClient : IEnumClient
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -20,6 +20,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -179,6 +187,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -277,6 +292,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -357,6 +376,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -22,6 +22,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +378,7 @@ public partial class ObjectClient : IObjectClient
                         ValueConvert.ToPathParameterString(string_)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +448,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +464,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -510,6 +534,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -523,6 +550,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -590,6 +618,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +634,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -672,6 +704,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -685,6 +720,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-map-of-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -754,6 +790,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -767,6 +806,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -836,6 +876,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -849,6 +892,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-nested-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -918,6 +962,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -931,6 +978,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -20,6 +20,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -414,6 +422,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -430,6 +441,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -495,6 +507,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -511,6 +526,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -577,6 +593,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -593,6 +612,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -824,6 +844,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -839,6 +862,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path-bool/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -904,6 +928,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -919,6 +946,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -19,6 +19,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -188,6 +199,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -253,6 +265,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -266,6 +281,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -331,6 +347,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -344,6 +363,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -409,6 +429,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -422,6 +445,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -487,6 +511,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -500,6 +527,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -565,6 +593,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -578,6 +609,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -643,6 +675,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -656,6 +691,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -19,6 +19,9 @@ public partial class PutClient : IPutClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class PutClient : IPutClient
                 {
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -20,6 +20,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -18,6 +18,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -170,6 +178,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -182,6 +193,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -246,6 +258,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -258,6 +273,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -21,6 +21,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-Custom-Header", request.XCustomHeader)
             .Add(_client.Options.Headers)
@@ -135,6 +142,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/array-body-with-headers",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -18,6 +18,9 @@ public partial class NoAuthClient : INoAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class NoAuthClient : INoAuthClient
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -18,6 +18,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -17,6 +17,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
             .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -32,6 +35,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/oidc-token/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/oidc-token/README.md
+++ b/seed/csharp-sdk/exhaustive/oidc-token/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -21,6 +21,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -101,6 +105,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -114,6 +121,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -181,6 +189,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -194,6 +205,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -274,6 +289,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -356,6 +375,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -423,6 +443,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -436,6 +459,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -505,6 +529,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -518,6 +545,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +615,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -600,6 +631,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -19,6 +19,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json",
                     Options = options,
@@ -72,6 +76,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json; charset=utf-8",
                     Options = options,

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -20,6 +20,9 @@ public partial class EnumClient : IEnumClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class EnumClient : IEnumClient
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -20,6 +20,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -179,6 +187,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -277,6 +292,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -357,6 +376,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -22,6 +22,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +378,7 @@ public partial class ObjectClient : IObjectClient
                         ValueConvert.ToPathParameterString(string_)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +448,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +464,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -510,6 +534,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -523,6 +550,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -590,6 +618,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +634,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -672,6 +704,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -685,6 +720,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-map-of-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -754,6 +790,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -767,6 +806,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -836,6 +876,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -849,6 +892,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-nested-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -918,6 +962,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -931,6 +978,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -20,6 +20,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -414,6 +422,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -430,6 +441,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -495,6 +507,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -511,6 +526,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -577,6 +593,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -593,6 +612,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -824,6 +844,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -839,6 +862,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path-bool/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -904,6 +928,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -919,6 +946,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -19,6 +19,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -188,6 +199,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -253,6 +265,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -266,6 +281,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -331,6 +347,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -344,6 +363,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -409,6 +429,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -422,6 +445,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -487,6 +511,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -500,6 +527,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -565,6 +593,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -578,6 +609,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -643,6 +675,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -656,6 +691,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -19,6 +19,9 @@ public partial class PutClient : IPutClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class PutClient : IPutClient
                 {
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -20,6 +20,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -18,6 +18,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -170,6 +178,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -182,6 +193,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -246,6 +258,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -258,6 +273,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -21,6 +21,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-Custom-Header", request.XCustomHeader)
             .Add(_client.Options.Headers)
@@ -135,6 +142,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/array-body-with-headers",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -18,6 +18,9 @@ public partial class NoAuthClient : INoAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class NoAuthClient : INoAuthClient
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -18,6 +18,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/oidc-token/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -17,6 +17,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
             .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -32,6 +35,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/.fern/metadata.json
@@ -6,8 +6,7 @@
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/README.md
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -21,6 +21,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -101,6 +105,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -114,6 +121,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -181,6 +189,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -194,6 +205,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -274,6 +289,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -356,6 +375,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -423,6 +443,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -436,6 +459,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -505,6 +529,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -518,6 +545,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +615,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -600,6 +631,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -19,6 +19,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json",
                     Options = options,
@@ -72,6 +76,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json; charset=utf-8",
                     Options = options,

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -20,6 +20,9 @@ public partial class EnumClient : IEnumClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class EnumClient : IEnumClient
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -20,6 +20,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -179,6 +187,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -277,6 +292,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -357,6 +376,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -22,6 +22,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +378,7 @@ public partial class ObjectClient : IObjectClient
                         ValueConvert.ToPathParameterString(string_)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +448,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +464,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -510,6 +534,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -523,6 +550,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -590,6 +618,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +634,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -672,6 +704,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -685,6 +720,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-map-of-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -754,6 +790,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -767,6 +806,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -836,6 +876,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -849,6 +892,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-nested-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -918,6 +962,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -931,6 +978,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -20,6 +20,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -414,6 +422,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -430,6 +441,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -495,6 +507,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -511,6 +526,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -577,6 +593,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -593,6 +612,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -824,6 +844,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -839,6 +862,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path-bool/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -904,6 +928,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -919,6 +946,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -19,6 +19,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -188,6 +199,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -253,6 +265,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -266,6 +281,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -331,6 +347,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -344,6 +363,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -409,6 +429,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -422,6 +445,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -487,6 +511,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -500,6 +527,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -565,6 +593,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -578,6 +609,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -643,6 +675,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -656,6 +691,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -19,6 +19,9 @@ public partial class PutClient : IPutClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class PutClient : IPutClient
                 {
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -20,6 +20,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -18,6 +18,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -170,6 +178,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -182,6 +193,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -246,6 +258,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -258,6 +273,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -21,6 +21,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-Custom-Header", request.XCustomHeader)
             .Add(_client.Options.Headers)
@@ -135,6 +142,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/array-body-with-headers",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -18,6 +18,9 @@ public partial class NoAuthClient : INoAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class NoAuthClient : INoAuthClient
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -18,6 +18,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -17,6 +17,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
             .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -32,6 +35,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/README.md
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -199,6 +200,23 @@ var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsyn
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Container/ContainerClient.cs
@@ -20,6 +20,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/list-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-primitives",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/set-of-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -355,6 +374,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-prim",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -422,6 +442,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -435,6 +458,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -504,6 +528,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -517,6 +544,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/map-prim-to-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -584,6 +612,9 @@ public partial class ContainerClient : IContainerClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -597,6 +628,7 @@ public partial class ContainerClient : IContainerClient
                     Method = HttpMethod.Post,
                     Path = "/container/opt-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/ContentType/ContentTypeClient.cs
@@ -19,6 +19,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/bar",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json",
                     Options = options,
@@ -72,6 +76,9 @@ public partial class ContentTypeClient : IContentTypeClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ContentTypeClient : IContentTypeClient
                     Method = HttpMethod.Post,
                     Path = "/foo/baz",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json-patch+json; charset=utf-8",
                     Options = options,

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Enum/EnumClient.cs
@@ -20,6 +20,9 @@ public partial class EnumClient : IEnumClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class EnumClient : IEnumClient
                     Method = HttpMethod.Post,
                     Path = "/enum",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/HttpMethods/HttpMethodsClient.cs
@@ -20,6 +20,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                     Method = HttpMethod.Post,
                     Path = "/http-methods",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -179,6 +187,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -261,6 +273,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -277,6 +292,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -342,6 +358,9 @@ public partial class HttpMethodsClient : IHttpMethodsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -357,6 +376,7 @@ public partial class HttpMethodsClient : IHttpMethodsClient
                         "/http-methods/{0}",
                         ValueConvert.ToPathParameterString(id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Object/ObjectClient.cs
@@ -22,6 +22,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -180,6 +188,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-map-of-map",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -260,6 +272,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -273,6 +288,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-optional-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -343,6 +359,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -359,6 +378,7 @@ public partial class ObjectClient : IObjectClient
                         ValueConvert.ToPathParameterString(string_)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +448,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +464,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-nested-with-required-field-list",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -510,6 +534,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -523,6 +550,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-unknown-field",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -590,6 +618,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +634,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -672,6 +704,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -685,6 +720,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-map-of-documented-unknown-type",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -754,6 +790,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -767,6 +806,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-mixed-required-and-optional-fields",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -836,6 +876,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -849,6 +892,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-required-nested-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -918,6 +962,9 @@ public partial class ObjectClient : IObjectClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -931,6 +978,7 @@ public partial class ObjectClient : IObjectClient
                     Method = HttpMethod.Post,
                     Path = "/object/get-and-return-with-datetime-like-string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Params/ParamsClient.cs
@@ -20,6 +20,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -115,6 +122,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -414,6 +422,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -430,6 +441,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -495,6 +507,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -511,6 +526,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(request.Param)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -577,6 +593,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -593,6 +612,7 @@ public partial class ParamsClient : IParamsClient
                         ValueConvert.ToPathParameterString(param)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -824,6 +844,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -839,6 +862,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path-bool/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -904,6 +928,9 @@ public partial class ParamsClient : IParamsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -919,6 +946,7 @@ public partial class ParamsClient : IParamsClient
                         "/params/path/{0}",
                         ValueConvert.ToPathParameterString(param)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Primitive/PrimitiveClient.cs
@@ -19,6 +19,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/string",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/integer",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -188,6 +199,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/long",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -253,6 +265,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -266,6 +281,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/double",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -331,6 +347,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -344,6 +363,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/boolean",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -409,6 +429,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -422,6 +445,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/datetime",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -487,6 +511,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -500,6 +527,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/date",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -565,6 +593,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -578,6 +609,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/uuid",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -643,6 +675,9 @@ public partial class PrimitiveClient : IPrimitiveClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -656,6 +691,7 @@ public partial class PrimitiveClient : IPrimitiveClient
                     Method = HttpMethod.Post,
                     Path = "/primitive/base64",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Put/PutClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Put/PutClient.cs
@@ -19,6 +19,9 @@ public partial class PutClient : IPutClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class PutClient : IPutClient
                 {
                     Method = HttpMethod.Put,
                     Path = string.Format("{0}", ValueConvert.ToPathParameterString(request.Id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Union/UnionClient.cs
@@ -20,6 +20,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Urls/UrlsClient.cs
@@ -18,6 +18,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/MixedCase",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/no-ending-slash",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -170,6 +178,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -182,6 +193,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with-ending-slash/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -246,6 +258,9 @@ public partial class UrlsClient : IUrlsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -258,6 +273,7 @@ public partial class UrlsClient : IUrlsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/urls/with_underscores",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/InlinedRequests/InlinedRequestsClient.cs
@@ -21,6 +21,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -121,6 +125,9 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-Custom-Header", request.XCustomHeader)
             .Add(_client.Options.Headers)
@@ -135,6 +142,7 @@ public partial class InlinedRequestsClient : IInlinedRequestsClient
                     Method = HttpMethod.Post,
                     Path = "/req-bodies/array-body-with-headers",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/NoAuth/NoAuthClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/NoAuth/NoAuthClient.cs
@@ -18,6 +18,9 @@ public partial class NoAuthClient : INoAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class NoAuthClient : INoAuthClient
                     Method = HttpMethod.Post,
                     Path = "/no-auth",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/NoReqBody/NoReqBodyClient.cs
@@ -18,6 +18,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class NoReqBodyClient : INoReqBodyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -106,6 +113,7 @@ public partial class NoReqBodyClient : INoReqBodyClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/no-req-body",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/ReqWithHeaders/ReqWithHeadersClient.cs
@@ -17,6 +17,9 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExhaustive.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExhaustive.Core.HeadersBuilder.Builder()
             .Add("X-TEST-SERVICE-HEADER", request.XTestServiceHeader)
             .Add("X-TEST-ENDPOINT-HEADER", request.XTestEndpointHeader)
@@ -32,6 +35,7 @@ public partial class ReqWithHeadersClient : IReqWithHeadersClient
                     Method = HttpMethod.Post,
                     Path = "/test-headers/custom-header",
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/extends/.fern/metadata.json
+++ b/seed/csharp-sdk/extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/extends/README.md
+++ b/seed/csharp-sdk/extends/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.ExtendedInlineRequestBodyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.ExtendedInlineRequestBodyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/extends/src/SeedExtends/SeedExtendsClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/SeedExtendsClient.cs
@@ -34,6 +34,9 @@ public partial class SeedExtendsClient : ISeedExtendsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExtends.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExtends.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -47,6 +50,7 @@ public partial class SeedExtendsClient : ISeedExtendsClient
                     Method = HttpMethod.Post,
                     Path = "/extends/extended-inline-request-body",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/extra-properties/.fern/metadata.json
+++ b/seed/csharp-sdk/extra-properties/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/extra-properties/README.md
+++ b/seed/csharp-sdk/extra-properties/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -188,6 +189,23 @@ var response = await client.User.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/User/UserClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedExtraProperties.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedExtraProperties.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class UserClient : IUserClient
                     Method = HttpMethod.Post,
                     Path = "/user",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/file-download/.fern/metadata.json
+++ b/seed/csharp-sdk/file-download/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-download/README.md
+++ b/seed/csharp-sdk/file-download/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.SimpleAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.SimpleAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Service/ServiceClient.cs
@@ -16,6 +16,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileDownload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileDownload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/snippet",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -66,6 +70,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileDownload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileDownload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -78,6 +85,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Post,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/file-upload-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-upload-openapi/README.md
+++ b/seed/csharp-sdk/file-upload-openapi/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.FileUploadExample.UploadFileAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.FileUploadExample.UploadFileAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/FileUploadExample/FileUploadExampleClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/FileUploadExample/FileUploadExampleClient.cs
@@ -18,6 +18,9 @@ public partial class FileUploadExampleClient : IFileUploadExampleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class FileUploadExampleClient : IFileUploadExampleClient
         {
             Method = HttpMethod.Post,
             Path = "upload-file",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };

--- a/seed/csharp-sdk/file-upload/.fern/metadata.json
+++ b/seed/csharp-sdk/file-upload/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-upload/README.md
+++ b/seed/csharp-sdk/file-upload/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Service.JustFileAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.JustFileAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -85,6 +89,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -95,6 +102,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/just-file",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -250,6 +258,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -260,6 +271,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/with-content-type",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -307,6 +319,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -317,6 +332,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/with-form-encoding",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -363,6 +379,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -373,6 +392,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -443,6 +463,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -453,6 +476,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/optional-args",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -524,6 +548,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -534,6 +561,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/inline-type",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -601,6 +629,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -611,6 +642,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/with-json-property",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -678,6 +710,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -688,6 +723,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/with-ref-body",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -758,6 +794,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -770,6 +809,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/snippet",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -809,6 +849,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedFileUpload.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedFileUpload.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -819,6 +862,7 @@ public partial class ServiceClient : IServiceClient
         {
             Method = HttpMethod.Post,
             Path = "/with-literal-enum",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };

--- a/seed/csharp-sdk/folders/.fern/metadata.json
+++ b/seed/csharp-sdk/folders/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/folders/README.md
+++ b/seed/csharp-sdk/folders/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.FooAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.FooAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/folders/src/SeedApi/A/B/BClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/B/BClient.cs
@@ -17,6 +17,9 @@ public partial class BClient : IBClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class BClient : IBClient
                 {
                     Method = HttpMethod.Post,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/folders/src/SeedApi/A/C/CClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/C/CClient.cs
@@ -17,6 +17,9 @@ public partial class CClient : ICClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class CClient : ICClient
                 {
                     Method = HttpMethod.Post,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
@@ -20,6 +20,9 @@ public partial class FolderClient : IFolderClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class FolderClient : IFolderClient
                 {
                     Method = HttpMethod.Post,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/service",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -69,6 +73,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -82,6 +89,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "/service",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/folders/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/SeedApiClient.cs
@@ -41,6 +41,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -53,6 +56,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Post,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/csharp-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/README.md
+++ b/seed/csharp-sdk/header-auth-environment-variable/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.GetWithBearerTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetWithBearerTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Service/ServiceClient.cs
@@ -17,6 +17,11 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedHeaderTokenEnvironmentVariable.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedHeaderTokenEnvironmentVariable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "apiKey",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/header-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/header-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/header-auth/README.md
+++ b/seed/csharp-sdk/header-auth/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.GetWithBearerTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetWithBearerTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Service/ServiceClient.cs
@@ -17,6 +17,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedHeaderToken.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedHeaderToken.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "apiKey",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/http-head/.fern/metadata.json
+++ b/seed/csharp-sdk/http-head/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/http-head/README.md
+++ b/seed/csharp-sdk/http-head/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.User.HeadAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.HeadAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/User/UserClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedHttpHead.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedHttpHead.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Head,
                     Path = "/users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/csharp-sdk/idempotency-headers/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/idempotency-headers/README.md
+++ b/seed/csharp-sdk/idempotency-headers/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Payment.CreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Payment.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Payment/PaymentClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Payment/PaymentClient.cs
@@ -18,6 +18,9 @@ public partial class PaymentClient : IPaymentClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedIdempotencyHeaders.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedIdempotencyHeaders.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class PaymentClient : IPaymentClient
                     Method = HttpMethod.Post,
                     Path = "/payment",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class PaymentClient : IPaymentClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedIdempotencyHeaders.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedIdempotencyHeaders.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class PaymentClient : IPaymentClient
                         "/payment/{0}",
                         ValueConvert.ToPathParameterString(paymentId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/imdb/exception-class-names/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/exception-class-names/.fern/metadata.json
@@ -7,8 +7,7 @@
     "base-exception-class-name": "CustomException"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/README.md
+++ b/seed/csharp-sdk/imdb/exception-class-names/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Imdb/ImdbClient.cs
@@ -18,6 +18,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ImdbClient : IImdbClient
                     Method = HttpMethod.Post,
                     Path = "movies/create-movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ImdbClient : IImdbClient
                         "movies/{0}",
                         ValueConvert.ToPathParameterString(request.MovieId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/imdb/exported-client-class-name/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/.fern/metadata.json
@@ -8,8 +8,7 @@
     "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/README.md
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Imdb/ImdbClient.cs
@@ -18,6 +18,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ImdbClient : IImdbClient
                     Method = HttpMethod.Post,
                     Path = "movies/create-movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ImdbClient : IImdbClient
                         "movies/{0}",
                         ValueConvert.ToPathParameterString(request.MovieId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/README.md
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Imdb/ImdbClient.cs
@@ -18,6 +18,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ImdbClient : IImdbClient
                     Method = HttpMethod.Post,
                     Path = "movies/create-movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ImdbClient : IImdbClient
                         "movies/{0}",
                         ValueConvert.ToPathParameterString(request.MovieId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/imdb/extra-dependencies/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/extra-dependencies/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/README.md
+++ b/seed/csharp-sdk/imdb/extra-dependencies/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Imdb/ImdbClient.cs
@@ -18,6 +18,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ImdbClient : IImdbClient
                     Method = HttpMethod.Post,
                     Path = "movies/create-movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ImdbClient : IImdbClient
                         "movies/{0}",
                         ValueConvert.ToPathParameterString(request.MovieId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/imdb/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/README.md
+++ b/seed/csharp-sdk/imdb/include-exception-handler/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Imdb/ImdbClient.cs
@@ -29,6 +29,9 @@ public partial class ImdbClient : IImdbClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -42,6 +45,7 @@ public partial class ImdbClient : IImdbClient
                             Method = HttpMethod.Post,
                             Path = "movies/create-movie",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             ContentType = "application/json",
                             Options = options,
@@ -117,6 +121,9 @@ public partial class ImdbClient : IImdbClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -132,6 +139,7 @@ public partial class ImdbClient : IImdbClient
                                 "movies/{0}",
                                 ValueConvert.ToPathParameterString(request.MovieId)
                             ),
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/README.md
+++ b/seed/csharp-sdk/imdb/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Imdb/ImdbClient.cs
@@ -18,6 +18,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ImdbClient : IImdbClient
                     Method = HttpMethod.Post,
                     Path = "movies/create-movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ImdbClient : IImdbClient
                         "movies/{0}",
                         ValueConvert.ToPathParameterString(request.MovieId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/imdb/omit-fern-headers/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
     "omit-fern-headers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/omit-fern-headers/README.md
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Imdb.CreateMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Imdb.CreateMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Imdb/ImdbClient.cs
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Imdb/ImdbClient.cs
@@ -18,6 +18,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ImdbClient : IImdbClient
                     Method = HttpMethod.Post,
                     Path = "movies/create-movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ImdbClient : IImdbClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ImdbClient : IImdbClient
                         "movies/{0}",
                         ValueConvert.ToPathParameterString(request.MovieId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/README.md
+++ b/seed/csharp-sdk/inferred-auth-explicit/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -186,6 +187,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthExplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthExplicit.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -32,6 +35,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthExplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthExplicit.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -111,6 +118,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/Api/ApiClient.cs
@@ -17,6 +17,9 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthExplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthExplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,9 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthExplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthExplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Simple/SimpleClient.cs
@@ -16,6 +16,9 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthExplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthExplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/README.md
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Auth.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Auth/AuthClient.cs
@@ -18,6 +18,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitApiKey.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitApiKey.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.ApiKey)
             .Add(_client.Options.Headers)
@@ -31,6 +36,7 @@ public partial class AuthClient : IAuthClient
                 {
                     Method = HttpMethod.Post,
                     Path = "/token",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitApiKey.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitApiKey.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitApiKey.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitApiKey.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitApiKey.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitApiKey.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -186,6 +187,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Auth/AuthClient.cs
@@ -18,6 +18,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitNoExpiry.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitNoExpiry.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -32,6 +37,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +103,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitNoExpiry.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitNoExpiry.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -111,6 +122,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitNoExpiry.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitNoExpiry.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitNoExpiry.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitNoExpiry.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicitNoExpiry.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicitNoExpiry.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/README.md
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -185,6 +186,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +100,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
@@ -17,6 +17,9 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,9 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
@@ -16,6 +16,9 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/README.md
+++ b/seed/csharp-sdk/inferred-auth-implicit/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -186,6 +187,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -32,6 +35,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -111,6 +118,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/Api/ApiClient.cs
@@ -17,6 +17,9 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,9 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Simple/SimpleClient.cs
@@ -16,6 +16,9 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedInferredAuthImplicit.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedInferredAuthImplicit.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/inline-enum-type-name-override/.fern/metadata.json
+++ b/seed/csharp-sdk/inline-enum-type-name-override/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inline-enum-type-name-override/README.md
+++ b/seed/csharp-sdk/inline-enum-type-name-override/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Reporting.LoadAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Reporting.LoadAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/inline-enum-type-name-override/src/SeedApi/Reporting/ReportingClient.cs
+++ b/seed/csharp-sdk/inline-enum-type-name-override/src/SeedApi/Reporting/ReportingClient.cs
@@ -17,6 +17,9 @@ public partial class ReportingClient : IReportingClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ReportingClient : IReportingClient
                     Method = HttpMethod.Post,
                     Path = "load",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/license/custom-license/.fern/metadata.json
+++ b/seed/csharp-sdk/license/custom-license/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/license/custom-license/README.md
+++ b/seed/csharp-sdk/license/custom-license/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicenseClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicenseClient.cs
@@ -33,6 +33,9 @@ public partial class SeedLicenseClient : ISeedLicenseClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLicense.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLicense.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -45,6 +48,7 @@ public partial class SeedLicenseClient : ISeedLicenseClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/license/mit-license/.fern/metadata.json
+++ b/seed/csharp-sdk/license/mit-license/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/license/mit-license/README.md
+++ b/seed/csharp-sdk/license/mit-license/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicenseClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicenseClient.cs
@@ -33,6 +33,9 @@ public partial class SeedLicenseClient : ISeedLicenseClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLicense.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLicense.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -45,6 +48,7 @@ public partial class SeedLicenseClient : ISeedLicenseClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal-user-agent/.fern/metadata.json
+++ b/seed/csharp-sdk/literal-user-agent/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal-user-agent/README.md
+++ b/seed/csharp-sdk/literal-user-agent/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.PingAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.PingAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/SeedLiteralUserAgentClient.cs
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/SeedLiteralUserAgentClient.cs
@@ -45,6 +45,9 @@ public partial class SeedLiteralUserAgentClient : ISeedLiteralUserAgentClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteralUserAgent.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteralUserAgent.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -57,6 +60,7 @@ public partial class SeedLiteralUserAgentClient : ISeedLiteralUserAgentClient
                 {
                     Method = HttpMethod.Get,
                     Path = "ping",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal/no-custom-config/README.md
+++ b/seed/csharp-sdk/literal/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.Headers.SendAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Headers.SendAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Headers/HeadersClient.cs
@@ -18,6 +18,9 @@ public partial class HeadersClient : IHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add("X-Endpoint-Version", request.EndpointVersion)
             .Add("X-Async", request.Async)
@@ -33,6 +36,7 @@ public partial class HeadersClient : IHeadersClient
                     Method = HttpMethod.Post,
                     Path = "headers",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -18,6 +18,9 @@ public partial class InlinedClient : IInlinedClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class InlinedClient : IInlinedClient
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Path/PathClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Path/PathClient.cs
@@ -18,6 +18,9 @@ public partial class PathClient : IPathClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class PathClient : IPathClient
                 {
                     Method = HttpMethod.Post,
                     Path = string.Format("path/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -18,6 +18,9 @@ public partial class ReferenceClient : IReferenceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ReferenceClient : IReferenceClient
                     Method = HttpMethod.Post,
                     Path = "reference",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
@@ -6,8 +6,7 @@
     "generate-literals": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal/readonly-constants/README.md
+++ b/seed/csharp-sdk/literal/readonly-constants/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.Headers.SendAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Headers.SendAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Headers/HeadersClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Headers/HeadersClient.cs
@@ -18,6 +18,9 @@ public partial class HeadersClient : IHeadersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add("X-Endpoint-Version", request.EndpointVersion)
             .Add("X-Async", request.Async)
@@ -33,6 +36,7 @@ public partial class HeadersClient : IHeadersClient
                     Method = HttpMethod.Post,
                     Path = "headers",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -18,6 +18,9 @@ public partial class InlinedClient : IInlinedClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class InlinedClient : IInlinedClient
                     Method = HttpMethod.Post,
                     Path = "inlined",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Path/PathClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Path/PathClient.cs
@@ -18,6 +18,9 @@ public partial class PathClient : IPathClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class PathClient : IPathClient
                 {
                     Method = HttpMethod.Post,
                     Path = string.Format("path/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -18,6 +18,9 @@ public partial class ReferenceClient : IReferenceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedLiteral.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedLiteral.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ReferenceClient : IReferenceClient
                     Method = HttpMethod.Post,
                     Path = "reference",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/literals-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/literals-unions/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-case/.fern/metadata.json
+++ b/seed/csharp-sdk/mixed-case/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-case/README.md
+++ b/seed/csharp-sdk/mixed-case/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Service.GetResourceAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetResourceAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMixedCase.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMixedCase.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class ServiceClient : IServiceClient
                         "/resource/{0}",
                         ValueConvert.ToPathParameterString(resourceId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/csharp-sdk/mixed-file-directory/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-file-directory/README.md
+++ b/seed/csharp-sdk/mixed-file-directory/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Organization.CreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Organization.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Organization/OrganizationClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Organization/OrganizationClient.cs
@@ -18,6 +18,9 @@ public partial class OrganizationClient : IOrganizationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMixedFileDirectory.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMixedFileDirectory.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class OrganizationClient : IOrganizationClient
                     Method = HttpMethod.Post,
                     Path = "/organizations/",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-content-type-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-content-type-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-content-type-examples/README.md
+++ b/seed/csharp-sdk/multi-content-type-examples/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Clients.CreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Clients.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multi-content-type-examples/src/SeedApi/Clients/ClientsClient.cs
+++ b/seed/csharp-sdk/multi-content-type-examples/src/SeedApi/Clients/ClientsClient.cs
@@ -18,6 +18,9 @@ public partial class ClientsClient : IClientsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ClientsClient : IClientsClient
                     Method = HttpMethod.Post,
                     Path = "clients",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-line-docs/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-line-docs/README.md
+++ b/seed/csharp-sdk/multi-line-docs/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.User.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/User/UserClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiLineDocs.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiLineDocs.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -69,6 +73,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiLineDocs.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiLineDocs.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -82,6 +89,7 @@ public partial class UserClient : IUserClient
                     Method = HttpMethod.Post,
                     Path = "users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/README.md
+++ b/seed/csharp-sdk/multi-url-environment-no-default/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.Ec2.BootInstanceAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Ec2.BootInstanceAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Ec2/Ec2Client.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Ec2/Ec2Client.cs
@@ -17,6 +17,11 @@ public partial class Ec2Client : IEc2Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiUrlEnvironmentNoDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiUrlEnvironmentNoDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +36,7 @@ public partial class Ec2Client : IEc2Client
                     Method = HttpMethod.Post,
                     Path = "/ec2/boot",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/S3/S3Client.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/S3/S3Client.cs
@@ -18,6 +18,11 @@ public partial class S3Client : IS3Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiUrlEnvironmentNoDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiUrlEnvironmentNoDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +37,7 @@ public partial class S3Client : IS3Client
                     Method = HttpMethod.Post,
                     Path = "/s3/presigned-url",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment-reference/README.md
+++ b/seed/csharp-sdk/multi-url-environment-reference/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -192,6 +193,23 @@ var response = await client.Auth.GettokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GettokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "oauth/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Files/FilesClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Files/FilesClient.cs
@@ -18,6 +18,9 @@ public partial class FilesClient : IFilesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class FilesClient : IFilesClient
                     Method = HttpMethod.Post,
                     Path = "files/content",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Items/ItemsClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Items/ItemsClient.cs
@@ -17,6 +17,9 @@ public partial class ItemsClient : IItemsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class ItemsClient : IItemsClient
                     BaseUrl = _client.Options.Environment.Base,
                     Method = HttpMethod.Get,
                     Path = "items",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/.fern/metadata.json
@@ -6,8 +6,7 @@
     "environment-class-name": "CustomEnvironment"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/README.md
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.Ec2.BootInstanceAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Ec2.BootInstanceAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
@@ -17,6 +17,9 @@ public partial class Ec2Client : IEc2Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiUrlEnvironment.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiUrlEnvironment.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class Ec2Client : IEc2Client
                     Method = HttpMethod.Post,
                     Path = "/ec2/boot",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/S3/S3Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/S3/S3Client.cs
@@ -18,6 +18,9 @@ public partial class S3Client : IS3Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiUrlEnvironment.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiUrlEnvironment.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class S3Client : IS3Client
                     Method = HttpMethod.Post,
                     Path = "/s3/presigned-url",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/.fern/metadata.json
@@ -6,8 +6,7 @@
     "pascal-case-environments": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/README.md
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.Ec2.BootInstanceAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Ec2.BootInstanceAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Ec2/Ec2Client.cs
@@ -17,6 +17,9 @@ public partial class Ec2Client : IEc2Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiUrlEnvironment.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiUrlEnvironment.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class Ec2Client : IEc2Client
                     Method = HttpMethod.Post,
                     Path = "/ec2/boot",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/S3/S3Client.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/S3/S3Client.cs
@@ -18,6 +18,9 @@ public partial class S3Client : IS3Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedMultiUrlEnvironment.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedMultiUrlEnvironment.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class S3Client : IS3Client
                     Method = HttpMethod.Post,
                     Path = "/s3/presigned-url",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/csharp-sdk/multiple-request-bodies/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multiple-request-bodies/README.md
+++ b/seed/csharp-sdk/multiple-request-bodies/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.UploadJsonDocumentAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.UploadJsonDocumentAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApiClient.cs
@@ -46,6 +46,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -59,6 +62,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "documents/upload",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -129,6 +133,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -142,6 +149,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "documents/upload",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/pdf",
                     Options = options,

--- a/seed/csharp-sdk/no-content-response/.fern/metadata.json
+++ b/seed/csharp-sdk/no-content-response/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-content-response/README.md
+++ b/seed/csharp-sdk/no-content-response/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Contacts.CreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Contacts.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/no-content-response/src/SeedApi/Contacts/ContactsClient.cs
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi/Contacts/ContactsClient.cs
@@ -18,6 +18,9 @@ public partial class ContactsClient : IContactsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ContactsClient : IContactsClient
                     Method = HttpMethod.Post,
                     Path = "contacts",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -97,6 +101,9 @@ public partial class ContactsClient : IContactsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -112,6 +119,7 @@ public partial class ContactsClient : IContactsClient
                         "contacts/{0}",
                         ValueConvert.ToPathParameterString(request.Id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/no-environment/.fern/metadata.json
+++ b/seed/csharp-sdk/no-environment/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-environment/README.md
+++ b/seed/csharp-sdk/no-environment/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Dummy.GetDummyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Dummy.GetDummyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Dummy/DummyClient.cs
@@ -17,6 +17,9 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNoEnvironment.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNoEnvironment.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class DummyClient : IDummyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "dummy",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/no-retries/.fern/metadata.json
+++ b/seed/csharp-sdk/no-retries/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-retries/README.md
+++ b/seed/csharp-sdk/no-retries/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Retries.GetUsersAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Retries.GetUsersAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Retries/RetriesClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Retries/RetriesClient.cs
@@ -17,6 +17,9 @@ public partial class RetriesClient : IRetriesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNoRetries.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNoRetries.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class RetriesClient : IRetriesClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/null-type/.fern/metadata.json
+++ b/seed/csharp-sdk/null-type/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/null-type/README.md
+++ b/seed/csharp-sdk/null-type/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.Conversations.OutboundCallAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Conversations.OutboundCallAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/null-type/src/SeedApi/Conversations/ConversationsClient.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi/Conversations/ConversationsClient.cs
@@ -18,6 +18,9 @@ public partial class ConversationsClient : IConversationsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ConversationsClient : IConversationsClient
                     Method = HttpMethod.Post,
                     Path = "conversations/outbound-call",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/null-type/src/SeedApi/Users/UsersClient.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi/Users/UsersClient.cs
@@ -18,6 +18,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class UsersClient : IUsersClient
                         "users/{0}",
                         ValueConvert.ToPathParameterString(request.Id)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-allof-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-allof-extends/README.md
+++ b/seed/csharp-sdk/nullable-allof-extends/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.CreateTestAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateTestAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApiClient.cs
@@ -34,6 +34,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "test",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -111,6 +115,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -124,6 +131,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "test",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/README.md
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -194,6 +195,23 @@ var response = await client.NullableOptional.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.NullableOptional.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
@@ -18,6 +18,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         "/api/users/{0}",
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -98,6 +102,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -111,6 +118,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -177,6 +185,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         ValueConvert.ToPathParameterString(userId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +440,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +456,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/profiles/complex",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -506,6 +522,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -521,6 +540,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         "/api/profiles/complex/{0}",
                         ValueConvert.ToPathParameterString(profileId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +607,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +626,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         ValueConvert.ToPathParameterString(profileId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -668,6 +692,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -681,6 +708,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/test/deserialization",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -835,6 +863,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -850,6 +881,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         "/api/users/{0}/notifications",
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -916,6 +948,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -932,6 +967,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         ValueConvert.ToPathParameterString(userId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -997,6 +1033,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1010,6 +1049,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/search",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/README.md
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -194,6 +195,23 @@ var response = await client.NullableOptional.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.NullableOptional.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/NullableOptional/NullableOptionalClient.cs
@@ -18,6 +18,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         "/api/users/{0}",
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -98,6 +102,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -111,6 +118,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -177,6 +185,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         ValueConvert.ToPathParameterString(userId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -428,6 +440,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -441,6 +456,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/profiles/complex",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -506,6 +522,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -521,6 +540,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         "/api/profiles/complex/{0}",
                         ValueConvert.ToPathParameterString(profileId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -587,6 +607,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -603,6 +626,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         ValueConvert.ToPathParameterString(profileId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -668,6 +692,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -681,6 +708,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/test/deserialization",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -832,6 +860,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -847,6 +878,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         "/api/users/{0}/notifications",
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -913,6 +945,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -929,6 +964,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                         ValueConvert.ToPathParameterString(userId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -994,6 +1030,9 @@ public partial class NullableOptionalClient : INullableOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullableOptional.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullableOptional.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1007,6 +1046,7 @@ public partial class NullableOptionalClient : INullableOptionalClient
                     Method = HttpMethod.Post,
                     Path = "/api/search",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-request-body/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-request-body/README.md
+++ b/seed/csharp-sdk/nullable-request-body/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.TestGroup.TestMethodNameAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.TestGroup.TestMethodNameAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/README.md
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -192,6 +193,23 @@ var response = await client.Nullable.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Nullable.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Nullable/NullableClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Nullable/NullableClient.cs
@@ -104,6 +104,9 @@ public partial class NullableClient : INullableClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullable.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -117,6 +120,7 @@ public partial class NullableClient : INullableClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -182,6 +186,9 @@ public partial class NullableClient : INullableClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullable.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +202,7 @@ public partial class NullableClient : INullableClient
                     Method = HttpMethod.Delete,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/nullable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/README.md
+++ b/seed/csharp-sdk/nullable/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -192,6 +193,23 @@ var response = await client.Nullable.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Nullable.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Nullable/NullableClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Nullable/NullableClient.cs
@@ -104,6 +104,9 @@ public partial class NullableClient : INullableClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullable.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -117,6 +120,7 @@ public partial class NullableClient : INullableClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -182,6 +186,9 @@ public partial class NullableClient : INullableClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedNullable.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedNullable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +202,7 @@ public partial class NullableClient : INullableClient
                     Method = HttpMethod.Delete,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -187,6 +188,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -18,6 +18,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +102,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +120,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-default/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.Auth.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Auth/AuthClient.cs
@@ -18,6 +18,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentialsDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentialsDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentialsDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentialsDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentialsDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentialsDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentialsDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentialsDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -185,6 +186,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Auth/AuthClient.cs
@@ -18,6 +18,12 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsEnvironmentVariables.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsEnvironmentVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -32,6 +38,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +104,12 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsEnvironmentVariables.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsEnvironmentVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -111,6 +124,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/Api/ApiClient.cs
@@ -17,6 +17,12 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsEnvironmentVariables.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsEnvironmentVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -30,6 +36,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,12 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsEnvironmentVariables.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsEnvironmentVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -30,6 +36,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Simple/SimpleClient.cs
@@ -16,6 +16,12 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsEnvironmentVariables.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsEnvironmentVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -29,6 +35,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -185,6 +186,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
@@ -18,6 +18,10 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -32,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +102,10 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -111,6 +120,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
@@ -17,6 +17,10 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -30,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
@@ -16,6 +16,10 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -29,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -187,6 +188,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Auth/AuthClient.cs
@@ -18,6 +18,10 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -32,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +102,10 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -111,6 +120,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Nested/Api/ApiClient.cs
@@ -17,6 +17,10 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -30,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Simple/SimpleClient.cs
@@ -16,6 +16,10 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsMandatoryAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsMandatoryAuth.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -29,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -186,6 +187,23 @@ var response = await client.Auth.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -19,6 +19,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +37,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.Identity.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Identity.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Identity/IdentityClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Identity/IdentityClient.cs
@@ -18,6 +18,9 @@ public partial class IdentityClient : IIdentityClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class IdentityClient : IIdentityClient
                     Method = HttpMethod.Post,
                     Path = "identity/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Plants/PlantsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Plants/PlantsClient.cs
@@ -17,6 +17,9 @@ public partial class PlantsClient : IPlantsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class PlantsClient : IPlantsClient
                 {
                     Method = HttpMethod.Get,
                     Path = "plants",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class PlantsClient : IPlantsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class PlantsClient : IPlantsClient
                         "plants/{0}",
                         ValueConvert.ToPathParameterString(request.PlantId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.Auth.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Auth/AuthClient.cs
@@ -18,6 +18,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentialsReference.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentialsReference.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentialsReference.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentialsReference.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -185,6 +186,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Auth/AuthClient.cs
@@ -18,6 +18,10 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsWithVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsWithVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -32,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +102,10 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsWithVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsWithVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -111,6 +120,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/Api/ApiClient.cs
@@ -17,6 +17,10 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsWithVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsWithVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -30,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,10 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsWithVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsWithVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -30,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Service/ServiceClient.cs
@@ -17,6 +17,10 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsWithVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsWithVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -33,6 +37,7 @@ public partial class ServiceClient : IServiceClient
                         "/service/{0}",
                         ValueConvert.ToPathParameterString(endpointParam)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Simple/SimpleClient.cs
@@ -16,6 +16,10 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedOauthClientCredentialsWithVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedOauthClientCredentialsWithVariables.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -29,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -185,6 +186,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -29,6 +29,11 @@ public partial class AuthClient : IAuthClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+                    capacity: 0
+                )
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -42,6 +47,7 @@ public partial class AuthClient : IAuthClient
                             Method = HttpMethod.Post,
                             Path = "/token",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             ContentType = "application/x-www-form-urlencoded",
                             Options = options,
@@ -117,6 +123,11 @@ public partial class AuthClient : IAuthClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+                    capacity: 0
+                )
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -130,6 +141,7 @@ public partial class AuthClient : IAuthClient
                             Method = HttpMethod.Post,
                             Path = "/token",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             ContentType = "application/x-www-form-urlencoded",
                             Options = options,

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -28,6 +28,11 @@ public partial class ApiClient : IApiClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+                    capacity: 0
+                )
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -40,6 +45,7 @@ public partial class ApiClient : IApiClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/nested/get-something",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -28,6 +28,11 @@ public partial class ApiClient : IApiClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+                    capacity: 0
+                )
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -40,6 +45,7 @@ public partial class ApiClient : IApiClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/nested-no-auth/get-something",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -27,6 +27,11 @@ public partial class SimpleClient : ISimpleClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+                    capacity: 0
+                )
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -39,6 +44,7 @@ public partial class SimpleClient : ISimpleClient
                         {
                             Method = HttpMethod.Get,
                             Path = "/get-something",
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -185,6 +186,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Auth/AuthClient.cs
@@ -18,6 +18,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +36,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/x-www-form-urlencoded",
                     Options = options,
@@ -97,6 +103,11 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +121,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/x-www-form-urlencoded",
                     Options = options,

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/Api/ApiClient.cs
@@ -17,6 +17,11 @@ public partial class ApiClient : IApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class ApiClient : IApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/nested-no-auth/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Simple/SimpleClient.cs
@@ -16,6 +16,11 @@ public partial class SimpleClient : ISimpleClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedOauthClientCredentials.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedOauthClientCredentials.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +33,7 @@ public partial class SimpleClient : ISimpleClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/get-something",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/object/.fern/metadata.json
+++ b/seed/csharp-sdk/object/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/csharp-sdk/objects-with-imports/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/openapi-request-body-ref/.fern/metadata.json
+++ b/seed/csharp-sdk/openapi-request-body-ref/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/openapi-request-body-ref/README.md
+++ b/seed/csharp-sdk/openapi-request-body-ref/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Vendor.CreateVendorAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Vendor.CreateVendorAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Catalog/CatalogClient.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Catalog/CatalogClient.cs
@@ -18,6 +18,9 @@ public partial class CatalogClient : ICatalogClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class CatalogClient : ICatalogClient
         {
             Method = HttpMethod.Post,
             Path = "catalog/images",
+            QueryString = _queryString,
             Headers = _headers,
             Options = options,
         };
@@ -95,6 +99,9 @@ public partial class CatalogClient : ICatalogClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class CatalogClient : ICatalogClient
                         "catalog/images/{0}",
                         ValueConvert.ToPathParameterString(request.ImageId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/TeamMember/TeamMemberClient.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/TeamMember/TeamMemberClient.cs
@@ -18,6 +18,9 @@ public partial class TeamMemberClient : ITeamMemberClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class TeamMemberClient : ITeamMemberClient
                         ValueConvert.ToPathParameterString(request.TeamMemberId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Vendor/VendorClient.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Vendor/VendorClient.cs
@@ -18,6 +18,9 @@ public partial class VendorClient : IVendorClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class VendorClient : IVendorClient
                         ValueConvert.ToPathParameterString(request.VendorId)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -100,6 +104,9 @@ public partial class VendorClient : IVendorClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add("idempotency_key", request.IdempotencyKey)
             .Add(_client.Options.Headers)
@@ -114,6 +121,7 @@ public partial class VendorClient : IVendorClient
                     Method = HttpMethod.Post,
                     Path = "vendors",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/openapi-subtitle/.fern/metadata.json
+++ b/seed/csharp-sdk/openapi-subtitle/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/openapi-subtitle/README.md
+++ b/seed/csharp-sdk/openapi-subtitle/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.ListPlantsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.ListPlantsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/openapi-subtitle/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/openapi-subtitle/src/SeedApi/SeedApiClient.cs
@@ -34,6 +34,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -46,6 +49,7 @@ public partial class SeedApiClient : ISeedApiClient
                 {
                     Method = HttpMethod.Get,
                     Path = "plants",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -111,6 +115,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -126,6 +133,7 @@ public partial class SeedApiClient : ISeedApiClient
                         "plants/{0}",
                         ValueConvert.ToPathParameterString(request.PlantId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/optional/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/optional/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/optional/no-custom-config/README.md
+++ b/seed/csharp-sdk/optional/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.Optional.SendOptionalBodyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Optional.SendOptionalBodyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Optional/OptionalClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Optional/OptionalClient.cs
@@ -18,6 +18,9 @@ public partial class OptionalClient : IOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObjectsWithImports.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObjectsWithImports.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class OptionalClient : IOptionalClient
                     Method = HttpMethod.Post,
                     Path = "send-optional-body",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +100,9 @@ public partial class OptionalClient : IOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObjectsWithImports.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObjectsWithImports.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class OptionalClient : IOptionalClient
                     Method = HttpMethod.Post,
                     Path = "send-optional-typed-body",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class OptionalClient : IOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObjectsWithImports.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObjectsWithImports.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class OptionalClient : IOptionalClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/.fern/metadata.json
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/.fern/metadata.json
@@ -6,8 +6,7 @@
     "simplify-object-dictionaries": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/README.md
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.Optional.SendOptionalBodyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Optional.SendOptionalBodyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Optional/OptionalClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Optional/OptionalClient.cs
@@ -18,6 +18,9 @@ public partial class OptionalClient : IOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObjectsWithImports.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObjectsWithImports.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class OptionalClient : IOptionalClient
                     Method = HttpMethod.Post,
                     Path = "send-optional-body",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +100,9 @@ public partial class OptionalClient : IOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObjectsWithImports.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObjectsWithImports.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class OptionalClient : IOptionalClient
                     Method = HttpMethod.Post,
                     Path = "send-optional-typed-body",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class OptionalClient : IOptionalClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedObjectsWithImports.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedObjectsWithImports.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -195,6 +206,7 @@ public partial class OptionalClient : IOptionalClient
                         ValueConvert.ToPathParameterString(id)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/package-yml/.fern/metadata.json
+++ b/seed/csharp-sdk/package-yml/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/package-yml/README.md
+++ b/seed/csharp-sdk/package-yml/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.EchoAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.EchoAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYmlClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYmlClient.cs
@@ -39,6 +39,9 @@ public partial class SeedPackageYmlClient : ISeedPackageYmlClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPackageYml.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPackageYml.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -52,6 +55,7 @@ public partial class SeedPackageYmlClient : ISeedPackageYmlClient
                     Method = HttpMethod.Post,
                     Path = string.Format("/{0}/", ValueConvert.ToPathParameterString(id)),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPackageYml.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPackageYml.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class ServiceClient : IServiceClient
                         ValueConvert.ToPathParameterString(id),
                         ValueConvert.ToPathParameterString(nestedId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination-custom/README.md
+++ b/seed/csharp-sdk/pagination-custom/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -202,6 +203,23 @@ var response = await client.Users.ListWithCustomPagerAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Users.ListWithCustomPagerAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination-uri-path/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination-uri-path/README.md
+++ b/seed/csharp-sdk/pagination-uri-path/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Users.ListWithUriPaginationAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Users.ListWithUriPaginationAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Users/UsersClient.cs
@@ -19,6 +19,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPaginationUriPath.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPaginationUriPath.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class UsersClient : IUsersClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/users/uri",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -99,6 +103,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPaginationUriPath.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPaginationUriPath.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -111,6 +118,7 @@ public partial class UsersClient : IUsersClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/users/path",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
@@ -7,8 +7,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/README.md
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -223,6 +224,23 @@ var response = await client.Complex.SearchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Complex.SearchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
@@ -42,6 +42,9 @@ public partial class ComplexClient : IComplexClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -58,6 +61,7 @@ public partial class ComplexClient : IComplexClient
                                 ValueConvert.ToPathParameterString(index)
                             ),
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             ContentType = "application/json",
                             Options = options,

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -259,6 +259,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -272,6 +275,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                             Method = HttpMethod.Post,
                             Path = "/inline-users",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -579,6 +583,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -592,6 +599,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                             Method = HttpMethod.Post,
                             Path = "/inline-users",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
@@ -258,6 +258,9 @@ public partial class UsersClient : IUsersClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -271,6 +274,7 @@ public partial class UsersClient : IUsersClient
                             Method = HttpMethod.Post,
                             Path = "/users",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -369,6 +373,9 @@ public partial class UsersClient : IUsersClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -382,6 +389,7 @@ public partial class UsersClient : IUsersClient
                             Method = HttpMethod.Post,
                             Path = "/users/top-level-cursor",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },
@@ -690,6 +698,9 @@ public partial class UsersClient : IUsersClient
         return await _client
             .Options.ExceptionHandler.TryCatchAsync(async () =>
             {
+                var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+                    .MergeAdditional(options?.AdditionalQueryParameters)
+                    .Build();
                 var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
                     .Add(_client.Options.Headers)
                     .Add(_client.Options.AdditionalHeaders)
@@ -703,6 +714,7 @@ public partial class UsersClient : IUsersClient
                             Method = HttpMethod.Post,
                             Path = "/users",
                             Body = request,
+                            QueryString = _queryString,
                             Headers = _headers,
                             Options = options,
                         },

--- a/seed/csharp-sdk/pagination/custom-pager/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/custom-pager/.fern/metadata.json
@@ -6,8 +6,7 @@
     "custom-pager-name": "MyPager"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/custom-pager/README.md
+++ b/seed/csharp-sdk/pagination/custom-pager/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -223,6 +224,23 @@ var response = await client.Complex.SearchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Complex.SearchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
@@ -31,6 +31,9 @@ public partial class ComplexClient : IComplexClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -47,6 +50,7 @@ public partial class ComplexClient : IComplexClient
                         ValueConvert.ToPathParameterString(index)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -229,6 +229,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -242,6 +245,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -522,6 +526,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -535,6 +542,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
@@ -228,6 +228,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -241,6 +244,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -330,6 +334,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -343,6 +350,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users/top-level-cursor",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -623,6 +631,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -636,6 +647,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/README.md
+++ b/seed/csharp-sdk/pagination/no-custom-config/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -223,6 +224,23 @@ var response = await client.Complex.SearchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Complex.SearchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
@@ -31,6 +31,9 @@ public partial class ComplexClient : IComplexClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -47,6 +50,7 @@ public partial class ComplexClient : IComplexClient
                         ValueConvert.ToPathParameterString(index)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -229,6 +229,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -242,6 +245,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -522,6 +526,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -535,6 +542,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
@@ -228,6 +228,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -241,6 +244,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -330,6 +334,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -343,6 +350,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users/top-level-cursor",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -623,6 +631,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -636,6 +647,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination/page-index-semantics/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/page-index-semantics/.fern/metadata.json
@@ -6,8 +6,7 @@
     "offset-semantics": "page-index"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/page-index-semantics/README.md
+++ b/seed/csharp-sdk/pagination/page-index-semantics/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -223,6 +224,23 @@ var response = await client.Complex.SearchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Complex.SearchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Complex/ComplexClient.cs
@@ -31,6 +31,9 @@ public partial class ComplexClient : IComplexClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -47,6 +50,7 @@ public partial class ComplexClient : IComplexClient
                         ValueConvert.ToPathParameterString(index)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -229,6 +229,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -242,6 +245,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -522,6 +526,9 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -535,6 +542,7 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                     Method = HttpMethod.Post,
                     Path = "/inline-users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Users/UsersClient.cs
@@ -228,6 +228,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -241,6 +244,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -330,6 +334,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -343,6 +350,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users/top-level-cursor",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -623,6 +631,9 @@ public partial class UsersClient : IUsersClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPagination.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPagination.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -636,6 +647,7 @@ public partial class UsersClient : IUsersClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/README.md
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.User.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Organizations/OrganizationsClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Organizations/OrganizationsClient.cs
@@ -19,6 +19,9 @@ public partial class OrganizationsClient : IOrganizationsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class OrganizationsClient : IOrganizationsClient
                         ValueConvert.ToPathParameterString(tenantId),
                         ValueConvert.ToPathParameterString(organizationId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class OrganizationsClient : IOrganizationsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -117,6 +124,7 @@ public partial class OrganizationsClient : IOrganizationsClient
                         ValueConvert.ToPathParameterString(request.OrganizationId),
                         ValueConvert.ToPathParameterString(request.UserId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(request.TenantId),
                         ValueConvert.ToPathParameterString(request.UserId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -100,6 +104,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -116,6 +123,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(tenantId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -181,6 +189,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -198,6 +209,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(request.UserId)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -349,6 +361,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -366,6 +381,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(request.UserId),
                         ValueConvert.ToPathParameterString(request.Version)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -431,6 +447,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -449,6 +468,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(request.Version),
                         ValueConvert.ToPathParameterString(request.Thought)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "inline-path-parameters": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/README.md
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -183,6 +184,23 @@ var response = await client.User.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Organizations/OrganizationsClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Organizations/OrganizationsClient.cs
@@ -19,6 +19,9 @@ public partial class OrganizationsClient : IOrganizationsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class OrganizationsClient : IOrganizationsClient
                         ValueConvert.ToPathParameterString(tenantId),
                         ValueConvert.ToPathParameterString(organizationId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -103,6 +107,9 @@ public partial class OrganizationsClient : IOrganizationsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -120,6 +127,7 @@ public partial class OrganizationsClient : IOrganizationsClient
                         ValueConvert.ToPathParameterString(organizationId),
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/User/UserClient.cs
@@ -20,6 +20,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -36,6 +39,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(tenantId),
                         ValueConvert.ToPathParameterString(userId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -102,6 +106,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -118,6 +125,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(tenantId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -185,6 +193,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -202,6 +213,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(userId)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -358,6 +370,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -375,6 +390,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(userId),
                         ValueConvert.ToPathParameterString(version)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -444,6 +460,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPathParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPathParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -462,6 +481,7 @@ public partial class UserClient : IUserClient
                         ValueConvert.ToPathParameterString(version),
                         ValueConvert.ToPathParameterString(thought)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/plain-text/.fern/metadata.json
+++ b/seed/csharp-sdk/plain-text/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/plain-text/README.md
+++ b/seed/csharp-sdk/plain-text/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.GetTextAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetTextAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Service/ServiceClient.cs
@@ -16,6 +16,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPlainText.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPlainText.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Post,
                     Path = "text",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -73,6 +77,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPlainText.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPlainText.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "csv",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -130,6 +138,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPlainText.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPlainText.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -142,6 +153,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "xml",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/property-access/.fern/metadata.json
+++ b/seed/csharp-sdk/property-access/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/property-access/README.md
+++ b/seed/csharp-sdk/property-access/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -189,6 +190,23 @@ var response = await client.CreateUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccessClient.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccessClient.cs
@@ -35,6 +35,9 @@ public partial class SeedPropertyAccessClient : ISeedPropertyAccessClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPropertyAccess.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPropertyAccess.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +51,7 @@ public partial class SeedPropertyAccessClient : ISeedPropertyAccessClient
                     Method = HttpMethod.Post,
                     Path = "/users",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/public-object/.fern/metadata.json
+++ b/seed/csharp-sdk/public-object/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Service/ServiceClient.cs
@@ -16,6 +16,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedPublicObject.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedPublicObject.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -28,6 +31,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/helloworld.txt",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/csharp-sdk/query-param-name-conflict/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-param-name-conflict/README.md
+++ b/seed/csharp-sdk/query-param-name-conflict/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.BulkUpdateTasksAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.BulkUpdateTasksAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/README.md
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -236,6 +237,23 @@ var response = await client.SearchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.SearchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters-openapi/README.md
+++ b/seed/csharp-sdk/query-parameters-openapi/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -236,6 +237,23 @@ var response = await client.SearchAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.SearchAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/query-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters/README.md
+++ b/seed/csharp-sdk/query-parameters/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -229,6 +230,23 @@ var response = await client.User.GetUsernameAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetUsernameAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/request-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/README.md
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.User.CreateUsernameAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.CreateUsernameAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/User/UserClient.cs
@@ -132,6 +132,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedRequestParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedRequestParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -145,6 +148,7 @@ public partial class UserClient : IUserClient
                     Method = HttpMethod.Post,
                     Path = "/user/username-optional",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/request-parameters/with-defaults/.fern/metadata.json
+++ b/seed/csharp-sdk/request-parameters/with-defaults/.fern/metadata.json
@@ -8,8 +8,7 @@
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/README.md
+++ b/seed/csharp-sdk/request-parameters/with-defaults/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -184,6 +185,23 @@ var response = await client.User.CreateUsernameAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.CreateUsernameAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/UserClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/UserClient.cs
@@ -132,6 +132,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedRequestParameters.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedRequestParameters.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -145,6 +148,7 @@ public partial class UserClient : IUserClient
                     Method = HttpMethod.Post,
                     Path = "/user/username-optional",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/README.md
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -182,6 +183,23 @@ var response = await client.GetFooAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetFooAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApiClient.cs
@@ -124,6 +124,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add("X-Idempotency-Key", request.XIdempotencyKey)
             .Add(_client.Options.Headers)
@@ -138,6 +141,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("foo/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/required-nullable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/README.md
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -182,6 +183,23 @@ var response = await client.GetFooAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetFooAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApiClient.cs
@@ -121,6 +121,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add("X-Idempotency-Key", request.XIdempotencyKey)
             .Add(_client.Options.Headers)
@@ -135,6 +138,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethodExtensions.Patch,
                     Path = string.Format("foo/{0}", ValueConvert.ToPathParameterString(id)),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/csharp-sdk/reserved-keywords/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/reserved-keywords/README.md
+++ b/seed/csharp-sdk/reserved-keywords/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Package.TestAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Package.TestAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/response-property/.fern/metadata.json
+++ b/seed/csharp-sdk/response-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/response-property/README.md
+++ b/seed/csharp-sdk/response-property/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.GetMovieAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.GetMovieAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Service/ServiceClient.cs
@@ -18,6 +18,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +100,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -174,6 +182,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -187,6 +198,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -252,6 +264,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -265,6 +280,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -330,6 +346,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -343,6 +362,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -408,6 +428,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -421,6 +444,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -486,6 +510,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedResponseProperty.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedResponseProperty.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -499,6 +526,7 @@ public partial class ServiceClient : IServiceClient
                     Method = HttpMethod.Post,
                     Path = "movie",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/schemaless-request-body-examples/README.md
+++ b/seed/csharp-sdk/schemaless-request-body-examples/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -195,6 +196,23 @@ var response = await client.CreatePlantAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreatePlantAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/SeedApiClient.cs
@@ -35,6 +35,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +51,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "plants",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -113,6 +117,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -129,6 +136,7 @@ public partial class SeedApiClient : ISeedApiClient
                         ValueConvert.ToPathParameterString(request.PlantId)
                     ),
                     Body = request.Body,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -197,6 +205,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -210,6 +221,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "plants/with-schema",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-event-examples/README.md
+++ b/seed/csharp-sdk/server-sent-event-examples/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Completions.StreamAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Completions.StreamAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Completions/CompletionsClient.cs
@@ -20,6 +20,9 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEvents.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEvents.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -131,6 +135,9 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEvents.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEvents.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -144,6 +151,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream-events",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -244,6 +252,9 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEvents.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEvents.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -257,6 +268,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream-events-discriminant-in-data",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -353,6 +365,9 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEvents.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEvents.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -366,6 +381,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream-events-context-protocol",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-openapi/README.md
+++ b/seed/csharp-sdk/server-sent-events-openapi/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -182,6 +183,23 @@ var response = await client.StreamProtocolNoCollisionAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.StreamProtocolNoCollisionAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/SeedApiClient.cs
@@ -39,6 +39,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -52,6 +55,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/protocol-no-collision",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -124,6 +128,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -137,6 +144,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/protocol-collision",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -209,6 +217,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -222,6 +233,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/data-context",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -294,6 +306,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -307,6 +322,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/no-context",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -379,6 +395,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -392,6 +411,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/protocol-with-flat-schema",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -464,6 +484,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -477,6 +500,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/data-context-with-envelope-schema",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -551,6 +575,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -564,6 +591,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/oas-spec-native",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -636,6 +664,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -649,6 +680,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-condition",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -717,6 +749,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -730,6 +765,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-condition",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -798,6 +834,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -811,6 +850,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-shared-schema",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -879,6 +919,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -892,6 +935,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-shared-schema",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -958,6 +1002,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -971,6 +1018,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "validate-completion",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -1039,6 +1087,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1052,6 +1103,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -1118,6 +1170,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1131,6 +1186,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-union",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -1197,6 +1253,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1210,6 +1269,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "validate-union-request",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -1279,6 +1339,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1292,6 +1355,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-nullable-condition",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -1363,6 +1427,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1376,6 +1443,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-nullable-condition",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,
@@ -1444,6 +1512,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -1457,6 +1528,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "stream/x-fern-streaming-sse-only",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-resumable/README.md
+++ b/seed/csharp-sdk/server-sent-events-resumable/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Completions.StreamAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Completions.StreamAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Completions/CompletionsClient.cs
@@ -20,6 +20,11 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEventsResumable.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEventsResumable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +38,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -111,6 +117,11 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEventsResumable.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEventsResumable.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -124,6 +135,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream-non-resumable",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events/README.md
+++ b/seed/csharp-sdk/server-sent-events/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Completions.StreamAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Completions.StreamAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Completions/CompletionsClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Completions/CompletionsClient.cs
@@ -20,6 +20,9 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEvents.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEvents.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -111,6 +115,9 @@ public partial class CompletionsClient : ICompletionsClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedServerSentEvents.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedServerSentEvents.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -124,6 +131,7 @@ public partial class CompletionsClient : ICompletionsClient
                     Method = HttpMethod.Post,
                     Path = "stream-no-terminator",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/csharp-sdk/server-url-templating/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-url-templating/README.md
+++ b/seed/csharp-sdk/server-url-templating/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -192,6 +193,23 @@ var response = await client.GetTokenAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetTokenAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApiClient.cs
@@ -34,6 +34,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -47,6 +50,7 @@ public partial class SeedApiClient : ISeedApiClient
                     BaseUrl = _client.Options.Environment.Base,
                     Method = HttpMethod.Get,
                     Path = "users",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -112,6 +116,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -128,6 +135,7 @@ public partial class SeedApiClient : ISeedApiClient
                         "users/{0}",
                         ValueConvert.ToPathParameterString(request.UserId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -193,6 +201,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -207,6 +218,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "auth/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/json",
                     Options = options,

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/.fern/metadata.json
@@ -11,8 +11,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/README.md
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.User.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedSimpleApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedSimpleApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/simple-api/custom-output-path/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/custom-output-path/.fern/metadata.json
@@ -6,8 +6,7 @@
     "output-path": "custom-src"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/README.md
+++ b/seed/csharp-sdk/simple-api/custom-output-path/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.User.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedSimpleApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedSimpleApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/simple-api/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/README.md
+++ b/seed/csharp-sdk/simple-api/no-custom-config/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.User.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedSimpleApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedSimpleApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/simple-api/use-sln-format/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/use-sln-format/.fern/metadata.json
@@ -6,8 +6,7 @@
     "sln-format": "sln"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/use-sln-format/README.md
+++ b/seed/csharp-sdk/simple-api/use-sln-format/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.User.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/User/UserClient.cs
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedSimpleApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedSimpleApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-fhir/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-fhir/README.md
+++ b/seed/csharp-sdk/simple-fhir/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.GetAccountAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetAccountAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApiClient.cs
@@ -35,6 +35,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -50,6 +53,7 @@ public partial class SeedApiClient : ISeedApiClient
                         "account/{0}",
                         ValueConvert.ToPathParameterString(accountId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/csharp-sdk/single-url-environment-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/single-url-environment-default/README.md
+++ b/seed/csharp-sdk/single-url-environment-default/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.Dummy.GetDummyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Dummy.GetDummyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Dummy/DummyClient.cs
@@ -17,6 +17,11 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedSingleUrlEnvironmentDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedSingleUrlEnvironmentDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class DummyClient : IDummyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "dummy",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/README.md
+++ b/seed/csharp-sdk/single-url-environment-no-default/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -190,6 +191,23 @@ var response = await client.Dummy.GetDummyAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Dummy.GetDummyAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Dummy/DummyClient.cs
@@ -17,6 +17,11 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedSingleUrlEnvironmentNoDefault.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedSingleUrlEnvironmentNoDefault.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +34,7 @@ public partial class DummyClient : IDummyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "dummy",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming-parameter/README.md
+++ b/seed/csharp-sdk/streaming-parameter/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Dummy.GenerateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Dummy.GenerateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Dummy/DummyClient.cs
@@ -19,6 +19,9 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedStreaming.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedStreaming.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class DummyClient : IDummyClient
                     Method = HttpMethod.Post,
                     Path = "generate",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/no-custom-config/README.md
+++ b/seed/csharp-sdk/streaming/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Dummy.GenerateStreamAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Dummy.GenerateStreamAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Dummy/DummyClient.cs
@@ -19,6 +19,9 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedStreaming.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedStreaming.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class DummyClient : IDummyClient
                     Method = HttpMethod.Post,
                     Path = "generate-stream",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedStreaming.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedStreaming.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class DummyClient : IDummyClient
                     Method = HttpMethod.Post,
                     Path = "generate",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
@@ -6,8 +6,7 @@
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/README.md
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -181,6 +182,23 @@ var response = await client.Dummy.GenerateStreamAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Dummy.GenerateStreamAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Dummy/DummyClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Dummy/DummyClient.cs
@@ -19,6 +19,9 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedStreaming.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedStreaming.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class DummyClient : IDummyClient
                     Method = HttpMethod.Post,
                     Path = "generate-stream",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class DummyClient : IDummyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedStreaming.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedStreaming.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class DummyClient : IDummyClient
                     Method = HttpMethod.Post,
                     Path = "generate",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/.fern/metadata.json
+++ b/seed/csharp-sdk/trace/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/trace/README.md
+++ b/seed/csharp-sdk/trace/README.md
@@ -19,6 +19,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -194,6 +195,23 @@ var response = await client.Admin.UpdateTestSubmissionStatusAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Admin.UpdateTestSubmissionStatusAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/trace/src/SeedTrace/Admin/AdminClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Admin/AdminClient.cs
@@ -18,6 +18,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -34,6 +37,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(submissionId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -74,6 +78,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -90,6 +97,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(submissionId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -130,6 +138,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -146,6 +157,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(submissionId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -186,6 +198,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -202,6 +217,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(submissionId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -243,6 +259,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -260,6 +279,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(testCaseId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -301,6 +321,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -318,6 +341,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(testCaseId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -358,6 +382,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -374,6 +401,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(submissionId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -414,6 +442,9 @@ public partial class AdminClient : IAdminClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -430,6 +461,7 @@ public partial class AdminClient : IAdminClient
                         ValueConvert.ToPathParameterString(submissionId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/Homepage/HomepageClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Homepage/HomepageClient.cs
@@ -17,6 +17,9 @@ public partial class HomepageClient : IHomepageClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class HomepageClient : IHomepageClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/homepage-problems",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -94,6 +98,9 @@ public partial class HomepageClient : IHomepageClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -107,6 +114,7 @@ public partial class HomepageClient : IHomepageClient
                     Method = HttpMethod.Post,
                     Path = "/homepage-problems",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/Migration/MigrationClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Migration/MigrationClient.cs
@@ -18,6 +18,9 @@ public partial class MigrationClient : IMigrationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add("admin-key-header", request.AdminKeyHeader)
             .Add(_client.Options.Headers)
@@ -31,6 +34,7 @@ public partial class MigrationClient : IMigrationClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/migration-info/all",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/Playlist/PlaylistClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Playlist/PlaylistClient.cs
@@ -197,6 +197,9 @@ public partial class PlaylistClient : IPlaylistClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -213,6 +216,7 @@ public partial class PlaylistClient : IPlaylistClient
                         ValueConvert.ToPathParameterString(serviceParam),
                         ValueConvert.ToPathParameterString(playlistId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -280,6 +284,9 @@ public partial class PlaylistClient : IPlaylistClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -297,6 +304,7 @@ public partial class PlaylistClient : IPlaylistClient
                         ValueConvert.ToPathParameterString(playlistId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -363,6 +371,9 @@ public partial class PlaylistClient : IPlaylistClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -379,6 +390,7 @@ public partial class PlaylistClient : IPlaylistClient
                         ValueConvert.ToPathParameterString(serviceParam),
                         ValueConvert.ToPathParameterString(playlistId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Problem/ProblemClient.cs
@@ -18,6 +18,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class ProblemClient : IProblemClient
                     Method = HttpMethod.Post,
                     Path = "/problem-crud/create",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class ProblemClient : IProblemClient
                         ValueConvert.ToPathParameterString(problemId)
                     ),
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class ProblemClient : IProblemClient
                         "/problem-crud/delete/{0}",
                         ValueConvert.ToPathParameterString(problemId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -234,6 +246,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -247,6 +262,7 @@ public partial class ProblemClient : IProblemClient
                     Method = HttpMethod.Post,
                     Path = "/problem-crud/default-starter-files",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/Submission/SubmissionClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Submission/SubmissionClient.cs
@@ -18,6 +18,9 @@ public partial class SubmissionClient : ISubmissionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -33,6 +36,7 @@ public partial class SubmissionClient : ISubmissionClient
                         "/sessions/create-session/{0}",
                         ValueConvert.ToPathParameterString(language)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -98,6 +102,9 @@ public partial class SubmissionClient : ISubmissionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -113,6 +120,7 @@ public partial class SubmissionClient : ISubmissionClient
                         "/sessions/{0}",
                         ValueConvert.ToPathParameterString(sessionId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -178,6 +186,9 @@ public partial class SubmissionClient : ISubmissionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -193,6 +204,7 @@ public partial class SubmissionClient : ISubmissionClient
                         "/sessions/stop/{0}",
                         ValueConvert.ToPathParameterString(sessionId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -233,6 +245,9 @@ public partial class SubmissionClient : ISubmissionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -245,6 +260,7 @@ public partial class SubmissionClient : ISubmissionClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/sessions/execution-sessions-state",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/Sysprop/SyspropClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Sysprop/SyspropClient.cs
@@ -19,6 +19,9 @@ public partial class SyspropClient : ISyspropClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -35,6 +38,7 @@ public partial class SyspropClient : ISyspropClient
                         ValueConvert.ToPathParameterString(language),
                         ValueConvert.ToPathParameterString(numWarmInstances)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -73,6 +77,9 @@ public partial class SyspropClient : ISyspropClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -85,6 +92,7 @@ public partial class SyspropClient : ISyspropClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/sysprop/num-warm-instances",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/Problem/ProblemClient.cs
@@ -20,6 +20,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ProblemClient : IProblemClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/lightweight-problem-info",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -98,6 +102,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class ProblemClient : IProblemClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/problem-info",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -190,6 +201,7 @@ public partial class ProblemClient : IProblemClient
                         "/problems-v2/problem-info/{0}",
                         ValueConvert.ToPathParameterString(problemId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -256,6 +268,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -272,6 +287,7 @@ public partial class ProblemClient : IProblemClient
                         ValueConvert.ToPathParameterString(problemId),
                         ValueConvert.ToPathParameterString(problemVersion)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V2Client.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V2Client.cs
@@ -24,6 +24,9 @@ public partial class V2Client : IV2Client
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -36,6 +39,7 @@ public partial class V2Client : IV2Client
                 {
                     Method = HttpMethod.Get,
                     Path = "",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/Problem/ProblemClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/V2/V3/Problem/ProblemClient.cs
@@ -20,6 +20,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -32,6 +35,7 @@ public partial class ProblemClient : IProblemClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/lightweight-problem-info",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -98,6 +102,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -110,6 +117,7 @@ public partial class ProblemClient : IProblemClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/problems-v2/problem-info",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -175,6 +183,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -190,6 +201,7 @@ public partial class ProblemClient : IProblemClient
                         "/problems-v2/problem-info/{0}",
                         ValueConvert.ToPathParameterString(problemId)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -256,6 +268,9 @@ public partial class ProblemClient : IProblemClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedTrace.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedTrace.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -272,6 +287,7 @@ public partial class ProblemClient : IProblemClient
                         ValueConvert.ToPathParameterString(problemId),
                         ValueConvert.ToPathParameterString(problemVersion)
                     ),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/README.md
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.GetUnionAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.GetUnionAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponsePropertyClient.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponsePropertyClient.cs
@@ -35,6 +35,12 @@ public partial class SeedUndiscriminatedUnionWithResponsePropertyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedUndiscriminatedUnionWithResponseProperty.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedUndiscriminatedUnionWithResponseProperty.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -48,6 +54,7 @@ public partial class SeedUndiscriminatedUnionWithResponsePropertyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/union",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -112,6 +119,12 @@ public partial class SeedUndiscriminatedUnionWithResponsePropertyClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString =
+            new SeedUndiscriminatedUnionWithResponseProperty.Core.QueryStringBuilder.Builder(
+                capacity: 0
+            )
+                .MergeAdditional(options?.AdditionalQueryParameters)
+                .Build();
         var _headers =
             await new SeedUndiscriminatedUnionWithResponseProperty.Core.HeadersBuilder.Builder()
                 .Add(_client.Options.Headers)
@@ -125,6 +138,7 @@ public partial class SeedUndiscriminatedUnionWithResponsePropertyClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/unions",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/README.md
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Union.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Union.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
@@ -37,6 +37,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -50,6 +55,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -134,6 +140,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -146,6 +157,7 @@ public partial class UnionClient : IUnionClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/metadata",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -213,6 +225,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -226,6 +243,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Put,
                     Path = "/metadata",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -291,6 +309,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -304,6 +327,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/call",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -371,6 +395,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -384,6 +413,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/duplicate",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -462,6 +492,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -475,6 +510,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/nested",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -540,6 +576,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -553,6 +594,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/nested-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -618,6 +660,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -631,6 +678,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/aliased-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -698,6 +746,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -711,6 +764,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/with-base-properties",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -778,6 +832,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -791,6 +850,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/camel-case",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/README.md
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -177,6 +178,23 @@ var response = await client.Union.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Union.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/UnionClient.cs
@@ -18,6 +18,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +36,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +101,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -107,6 +118,7 @@ public partial class UnionClient : IUnionClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/metadata",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -172,6 +184,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -185,6 +202,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Put,
                     Path = "/metadata",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -250,6 +268,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -263,6 +286,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/call",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -328,6 +352,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -341,6 +370,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/duplicate",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -406,6 +436,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -419,6 +454,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/nested",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -484,6 +520,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -497,6 +538,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/nested-objects",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -562,6 +604,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -575,6 +622,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/aliased-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -640,6 +688,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -653,6 +706,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/with-base-properties",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -718,6 +772,11 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUndiscriminatedUnions.Core.QueryStringBuilder.Builder(
+            capacity: 0
+        )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUndiscriminatedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -731,6 +790,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethod.Post,
                     Path = "/camel-case",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/union-query-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/union-query-parameters/README.md
+++ b/seed/csharp-sdk/union-query-parameters/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -179,6 +180,23 @@ var response = await client.Events.SubscribeAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Events.SubscribeAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/csharp-sdk/unions-with-local-date/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions-with-local-date/README.md
+++ b/seed/csharp-sdk/unions-with-local-date/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Bigunion.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Bigunion.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -18,6 +18,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class BigunionClient : IBigunionClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class BigunionClient : IBigunionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -173,6 +181,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -186,6 +197,7 @@ public partial class BigunionClient : IBigunionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "/many",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Types/TypesClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Types/TypesClient.cs
@@ -18,6 +18,9 @@ public partial class TypesClient : ITypesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class TypesClient : ITypesClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/time/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class TypesClient : ITypesClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class TypesClient : ITypesClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "/time",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Union/UnionClient.cs
@@ -18,6 +18,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UnionClient : IUnionClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions/no-custom-config/README.md
+++ b/seed/csharp-sdk/unions/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Bigunion.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Bigunion.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -18,6 +18,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class BigunionClient : IBigunionClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/bigunion/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class BigunionClient : IBigunionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "/bigunion",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -173,6 +181,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -186,6 +197,7 @@ public partial class BigunionClient : IBigunionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "/bigunion/many",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Union/UnionClient.cs
@@ -18,6 +18,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UnionClient : IUnionClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unions/no-discriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use-discriminated-unions": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/README.md
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Bigunion.GetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Bigunion.GetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Bigunion/BigunionClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Bigunion/BigunionClient.cs
@@ -18,6 +18,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class BigunionClient : IBigunionClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/bigunion/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class BigunionClient : IBigunionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "/bigunion",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -173,6 +181,9 @@ public partial class BigunionClient : IBigunionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -186,6 +197,7 @@ public partial class BigunionClient : IBigunionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "/bigunion/many",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Union/UnionClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Union/UnionClient.cs
@@ -18,6 +18,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UnionClient : IUnionClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(id)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -95,6 +99,9 @@ public partial class UnionClient : IUnionClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnions.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnions.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -108,6 +115,7 @@ public partial class UnionClient : IUnionClient
                     Method = HttpMethodExtensions.Patch,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/unknown/.fern/metadata.json
+++ b/seed/csharp-sdk/unknown/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unknown/README.md
+++ b/seed/csharp-sdk/unknown/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Unknown.PostAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Unknown.PostAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Unknown/UnknownClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Unknown/UnknownClient.cs
@@ -18,6 +18,9 @@ public partial class UnknownClient : IUnknownClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnknownAsAny.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnknownAsAny.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -31,6 +34,7 @@ public partial class UnknownClient : IUnknownClient
                     Method = HttpMethod.Post,
                     Path = "",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -96,6 +100,9 @@ public partial class UnknownClient : IUnknownClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedUnknownAsAny.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedUnknownAsAny.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -109,6 +116,7 @@ public partial class UnknownClient : IUnknownClient
                     Method = HttpMethod.Post,
                     Path = "/with-object",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/README.md
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -178,6 +179,23 @@ var response = await client.SubmitFormDataAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.SubmitFormDataAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApiClient.cs
@@ -35,6 +35,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +51,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "submit",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/x-www-form-urlencoded",
                     Options = options,
@@ -114,6 +118,9 @@ public partial class SeedApiClient : ISeedApiClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedApi.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedApi.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -127,6 +134,7 @@ public partial class SeedApiClient : ISeedApiClient
                     Method = HttpMethod.Post,
                     Path = "token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     ContentType = "application/x-www-form-urlencoded",
                     Options = options,

--- a/seed/csharp-sdk/validation/.fern/metadata.json
+++ b/seed/csharp-sdk/validation/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/validation/README.md
+++ b/seed/csharp-sdk/validation/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
   - [Forward Compatible Enums](#forward-compatible-enums)
 - [Contributing](#contributing)
 
@@ -185,6 +186,23 @@ var response = await client.CreateAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.CreateAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/validation/src/SeedValidation/SeedValidationClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/SeedValidationClient.cs
@@ -35,6 +35,9 @@ public partial class SeedValidationClient : ISeedValidationClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedValidation.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedValidation.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -48,6 +51,7 @@ public partial class SeedValidationClient : ISeedValidationClient
                     Method = HttpMethod.Post,
                     Path = "/create",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/variables/.fern/metadata.json
+++ b/seed/csharp-sdk/variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/variables/README.md
+++ b/seed/csharp-sdk/variables/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Service.PostAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Service.PostAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/variables/src/SeedVariables/Service/ServiceClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Service/ServiceClient.cs
@@ -17,6 +17,9 @@ public partial class ServiceClient : IServiceClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedVariables.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedVariables.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class ServiceClient : IServiceClient
                 {
                     Method = HttpMethod.Post,
                     Path = string.Format("/{0}", ValueConvert.ToPathParameterString(endpointParam)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/version-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/version-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/version-no-default/README.md
+++ b/seed/csharp-sdk/version-no-default/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.User.GetUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/User/UserClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedVersion.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedVersion.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/version/.fern/metadata.json
+++ b/seed/csharp-sdk/version/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/version/README.md
+++ b/seed/csharp-sdk/version/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.User.GetUserAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.User.GetUserAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/version/src/SeedVersion/User/UserClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/User/UserClient.cs
@@ -18,6 +18,9 @@ public partial class UserClient : IUserClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedVersion.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedVersion.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -30,6 +33,7 @@ public partial class UserClient : IUserClient
                 {
                     Method = HttpMethod.Get,
                     Path = string.Format("/users/{0}", ValueConvert.ToPathParameterString(userId)),
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/csharp-sdk/webhook-audience/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/webhooks/.fern/metadata.json
+++ b/seed/csharp-sdk/webhooks/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/README.md
+++ b/seed/csharp-sdk/websocket-inferred-auth/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -186,6 +187,23 @@ var response = await client.Auth.GetTokenWithClientCredentialsAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Auth.GetTokenWithClientCredentialsAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Auth/AuthClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Auth/AuthClient.cs
@@ -18,6 +18,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedWebsocketAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedWebsocketAuth.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -32,6 +35,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },
@@ -97,6 +101,9 @@ public partial class AuthClient : IAuthClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedWebsocketAuth.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedWebsocketAuth.Core.HeadersBuilder.Builder()
             .Add("X-Api-Key", request.XApiKey)
             .Add(_client.Options.Headers)
@@ -111,6 +118,7 @@ public partial class AuthClient : IAuthClient
                     Method = HttpMethod.Post,
                     Path = "/token/refresh",
                     Body = request,
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-enable-websockets": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/no-custom-config/README.md
+++ b/seed/csharp-sdk/websocket/no-custom-config/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Status.GetStatusAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Status.GetStatusAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Status/StatusClient.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Status/StatusClient.cs
@@ -17,6 +17,9 @@ public partial class StatusClient : IStatusClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedWebsocket.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedWebsocket.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class StatusClient : IStatusClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/status",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
@@ -7,8 +7,7 @@
     "experimental-enable-websockets": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/with-websockets/README.md
+++ b/seed/csharp-sdk/websocket/with-websockets/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.Status.GetStatusAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.Status.GetStatusAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Status/StatusClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Status/StatusClient.cs
@@ -17,6 +17,9 @@ public partial class StatusClient : IStatusClient
         CancellationToken cancellationToken = default
     )
     {
+        var _queryString = new SeedWebsocket.Core.QueryStringBuilder.Builder(capacity: 0)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
         var _headers = await new SeedWebsocket.Core.HeadersBuilder.Builder()
             .Add(_client.Options.Headers)
             .Add(_client.Options.AdditionalHeaders)
@@ -29,6 +32,7 @@ public partial class StatusClient : IStatusClient
                 {
                     Method = HttpMethod.Get,
                     Path = "/status",
+                    QueryString = _queryString,
                     Headers = _headers,
                     Options = options,
                 },

--- a/seed/csharp-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/csharp-sdk/x-fern-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/x-fern-default/README.md
+++ b/seed/csharp-sdk/x-fern-default/README.md
@@ -18,6 +18,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
   - [Raw Response](#raw-response)
   - [Additional Headers](#additional-headers)
   - [Additional Query Parameters](#additional-query-parameters)
+  - [Additional Body Properties](#additional-body-properties)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -176,6 +177,23 @@ var response = await client.TestGetAsync(
         AdditionalQueryParameters = new Dictionary<string, string>
         {
             { "custom_param", "custom-value" }
+        }
+    }
+);
+```
+
+### Additional Body Properties
+
+If you would like to send additional body properties as part of the request, use the `AdditionalBodyProperties` request option.
+This is only applied to JSON requests.
+
+```csharp
+var response = await client.TestGetAsync(
+    ...,
+    new RequestOptions {
+        AdditionalBodyProperties = new Dictionary<string, object>
+        {
+            { "custom_field", "custom-value" }
         }
     }
 );

--- a/test-definitions/fern/apis/extra-properties/generators.yml
+++ b/test-definitions/fern/apis/extra-properties/generators.yml
@@ -20,3 +20,13 @@ groups:
           mode: push
           uri: fern-api/go-sdk-tests
           branch: extra-properties
+  csharp-sdk:
+    generators:
+      - name: fernapi/fern-csharp-sdk
+        version: latest
+        ir-version: v61
+        github:
+          token: ${GITHUB_TOKEN}
+          mode: push
+          uri: fern-api/csharp-sdk-tests
+          branch: extra-properties


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10194](https://linear.app/buildwithfern/issue/FER-10194/c-undocumentedextra-parameters-support)

The C# SDK generator already had infrastructure for extra/undocumented parameters (`AdditionalHeaders`, `AdditionalQueryParameters`, `AdditionalBodyProperties` on `RequestOptions`), but `AdditionalQueryParameters` was only applied to endpoints that had defined query parameters. Endpoints without defined query params silently ignored any additional query parameters passed via `RequestOptions`.

## Changes Made

- Added `getDefaultQueryParameterCodeBlock()` to `HttpEndpointGenerator.ts` — analogous to the existing `getDefaultHeaderParameterCodeBlock()`. When an endpoint has no defined query parameters (or no request object at all), this fallback builds a query string from just `AdditionalQueryParameters`:
  ```csharp
  var _queryString = new Core.QueryStringBuilder.Builder(capacity: 0)
      .MergeAdditional(options?.AdditionalQueryParameters)
      .Build();
  ```
- Applied this fallback in all 3 code paths that generate endpoint method bodies (unpaged, WithRawResponse, pagination)
- Added `ADDITIONAL_BODY_PROPERTIES` feature to `features.yml` and `ReadmeSnippetBuilder.ts` for README documentation (gated behind `!hasGrpcEndpoints()` since body properties only apply to JSON requests)
- Added `csharp-sdk` generator config to the `extra-properties` test fixture
- Added changelog entry
- [x] Updated README.md generator (if applicable)

## Testing
- [x] All 182 csharp-sdk seed test fixtures pass
- [x] Verified endpoints WITH defined query params are unchanged (existing `WrappedEndpointRequest` already includes `MergeAdditional`)
- [x] Verified endpoints WITHOUT defined query params now get the `AdditionalQueryParameters` builder
- [x] Verified gRPC fixture READMEs correctly exclude `Additional Body Properties` section
- [x] TypeScript compilation succeeds
- [x] All CI checks pass

Link to Devin session: https://app.devin.ai/sessions/f56bbbe1316f4773b0983ba5acff2cd3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->