### PR TITLE
fix(pydantic): include .gitignore.Template in pydantic-v2 dist bundle

### DIFF
--- a/generators/python-v2/pydantic-model/build.mjs
+++ b/generators/python-v2/pydantic-model/build.mjs
@@ -3,5 +3,6 @@ import { buildGenerator, getDirname } from "@fern-api/configs/build-utils.mjs";
 await buildGenerator(getDirname(import.meta.url), {
     tsupOptions: {
         external: ["@wasm-fmt/ruff_fmt"]
-    }
+    },
+    copy: { from: "../base/src/asIs", to: "dist/asIs" }
 });

--- a/generators/python-v2/sdk/build.mjs
+++ b/generators/python-v2/sdk/build.mjs
@@ -1,3 +1,5 @@
 import { buildGenerator, getDirname } from "@fern-api/configs/build-utils.mjs";
 
-await buildGenerator(getDirname(import.meta.url));
+await buildGenerator(getDirname(import.meta.url), {
+    copy: { from: "../base/src/asIs", to: "dist/asIs" }
+});

--- a/generators/python/sdk/changes/unreleased/fix-pydantic-v2-gitignore-template.yml
+++ b/generators/python/sdk/changes/unreleased/fix-pydantic-v2-gitignore-template.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix pydantic-v2 generator failing to find `.gitignore.Template` at runtime by
+    copying the `asIs` directory into the dist bundle.
+  type: fix


### PR DESCRIPTION
## Description

The pydantic-v2 generator's `version` fixture fails at runtime with:
```
Error: ENOENT: no such file or directory, open '/dist/asIs/.gitignore.Template'
```

`PythonProject.ts` uses `path.join(__dirname, 'asIs')` to locate template files, but esbuild bundles everything into `cli.cjs` — the `asIs` directory is never copied to `dist/`.

## Changes Made

- Added `copy: { from: "../base/src/asIs", to: "dist/asIs" }` to `generators/python-v2/pydantic-model/build.mjs` so the template files are copied into the dist bundle at build time
- Added the same `copy` option to `generators/python-v2/sdk/build.mjs` preventively (it doesn't use `getRawAsIsFiles()` yet, but will be ready when it does)
- Added unreleased changelog entry

The `buildGenerator` utility in `packages/configs/build-utils.mjs` already supports this `copy` pattern.

## Testing
- [ ] `pnpm seed:local test --generator pydantic-v2 --fixture version --skip-scripts` passes


Link to Devin session: https://app.devin.ai/sessions/c9ead6d68c304b31a06b41ed7f02eb39
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->