### PR TITLE
fix(cli-generator): graduate query-parameters-openapi seed tests from allowedFailures

### DIFF
--- a/seed/cli/seed.yml
+++ b/seed/cli/seed.yml
@@ -188,10 +188,10 @@ allowedFailures:
   - public-object
   - query-param-name-conflict
   - query-parameters
-  - query-parameters-openapi
-  - query-parameters-openapi:github-npm
   # query-parameters-openapi:no-custom-config graduated as a regression test
   # for embedded SDK asIs template resolution (FER-11453).
+  # query-parameters-openapi and query-parameters-openapi:github-npm graduated
+  # after the fernignore cleanup logic was fixed.
   - query-parameters-openapi-as-objects
   - request-parameters
   - required-nullable


### PR DESCRIPTION
## Description

The `query-parameters-openapi` and `query-parameters-openapi:github-npm` CLI generator seed test fixtures now pass reliably. The original `ENOTEMPTY: directory not empty, rmdir` error during directory cleanup was resolved by prior improvements to the fernignore cleanup logic in `LocalTaskHandler.copyGeneratedFilesWithFernIgnoreInTempRepo()`.

## Changes Made

- Removed `query-parameters-openapi` and `query-parameters-openapi:github-npm` from `allowedFailures` in `seed/cli/seed.yml`
- Added graduation comment for documentation

## Testing

- Ran `pnpm seed:local test --generator cli --fixture query-parameters-openapi --skip-scripts` — all 3 configs (`no-custom-config`, `github-npm`, `github-no-publish`) pass
- Generated output is identical to committed snapshot (no diffs)


Link to Devin session: https://app.devin.ai/sessions/5adf23d1dbaf47c89fc1da7a377eaadd
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->