### PR TITLE
fix(cli): strip CLI-only config keys before forwarding to generator containers

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-strip-user-agent-from-custom-config.yml
+++ b/packages/cli/cli/changes/unreleased/fix-strip-user-agent-from-custom-config.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Strip CLI-only config keys (e.g. `user-agent`) from the custom config
+    before forwarding to generator containers, preventing strict validation
+    errors in generators that reject unknown keys.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -1,4 +1,4 @@
-import { Spec } from "@fern-api/api-workspace-commons";
+import { Spec, stripCliConfigKeys } from "@fern-api/api-workspace-commons";
 import { Audiences, generatorsYml, SNIPPET_TEMPLATES_JSON_FILENAME } from "@fern-api/configuration";
 import { ContainerRunner } from "@fern-api/core-utils";
 import { AbsoluteFilePath, streamObjectToFile } from "@fern-api/fs-utils";
@@ -233,7 +233,7 @@ export async function writeFilesToDiskAndRunGenerator({
 
     const config = getGeneratorConfig({
         generatorInvocation,
-        customConfig: generatorInvocation.config,
+        customConfig: stripCliConfigKeys(generatorInvocation.config),
         workspaceName: workspace.definition.rootApiFile.contents.name,
         outputVersion: mappedOutputVersionOverride,
         organization,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -1,3 +1,4 @@
+import { stripCliConfigKeys } from "@fern-api/api-workspace-commons";
 import { FernToken } from "@fern-api/auth";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { createFiddleService, getFiddleOrigin, getIrVersionForGenerator } from "@fern-api/core";
@@ -191,7 +192,7 @@ async function createJob({
         id: generatorInvocation.name,
         version: generatorInvocation.version,
         outputMode: generatorInvocation.outputMode,
-        customConfig: generatorInvocation.config,
+        customConfig: stripCliConfigKeys(generatorInvocation.config),
         publishMetadata: generatorInvocation.publishMetadata
     };
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/getDynamicGeneratorConfig.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/getDynamicGeneratorConfig.ts
@@ -1,3 +1,4 @@
+import { stripCliConfigKeys } from "@fern-api/api-workspace-commons";
 import { generatorsYml } from "@fern-api/configuration";
 import { assertNever } from "@fern-api/core-utils";
 import { dynamic } from "@fern-api/ir-sdk";
@@ -17,7 +18,7 @@ export function getDynamicGeneratorConfig({
     return {
         apiName,
         organization,
-        customConfig: generatorInvocation.config,
+        customConfig: stripCliConfigKeys(generatorInvocation.config),
         outputConfig: outputConfig ?? dynamic.GeneratorOutputConfig.local()
     };
 }

--- a/packages/commons/api-workspace-commons/src/checkVersionExists.ts
+++ b/packages/commons/api-workspace-commons/src/checkVersionExists.ts
@@ -80,6 +80,27 @@ export function getUserAgentTemplateFromGeneratorConfig(
     return undefined;
 }
 
+/** Config keys consumed by the CLI and not forwarded to generators. */
+const CLI_ONLY_CONFIG_KEYS: ReadonlySet<string> = new Set(["user-agent"]);
+
+/**
+ * Returns a copy of the generator's custom config with CLI-only keys removed.
+ * Generators validate their config strictly; CLI-consumed keys like `user-agent`
+ * must be stripped before forwarding.
+ */
+export function stripCliConfigKeys(config: unknown): unknown {
+    if (typeof config !== "object" || config === null) {
+        return config;
+    }
+    const filtered: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+        if (!CLI_ONLY_CONFIG_KEYS.has(key)) {
+            filtered[key] = value;
+        }
+    }
+    return filtered;
+}
+
 // ─── Constants ──────────────────────────────────────────────────────
 
 /** Timeout for registry HTTP calls (ms). Prevents slow registries from delaying generation start. */


### PR DESCRIPTION
## Description

Fixes generators failing with `pydantic_core.ValidationError: Extra inputs are not permitted` when the new `user-agent` template config (from #16795) is set in `generators.yml`. The CLI consumes `user-agent` at IR generation time but was also forwarding it in the raw `customConfig` to generator containers, which validate their config strictly.

## Changes Made

- Added `stripCliConfigKeys(config)` in `checkVersionExists.ts` — removes keys from a centralized `CLI_ONLY_CONFIG_KEYS` set (currently `["user-agent"]`; extensible for future CLI-only keys)
- Applied at all three `customConfig` forwarding points:
  - `runGenerator.ts` (local generation)
  - `createAndStartJob.ts` (remote generation via Fiddle)
  - `getDynamicGeneratorConfig.ts` (dynamic snippets)

## Testing

- Compilation of all 73 affected packages passes cleanly
- Biome format check passes
- No seed snapshot changes (function only strips keys at runtime, IR generation is unaffected)

Link to Devin session: https://app.devin.ai/sessions/f1d062b7e40f456e8e73ab75b3f96c5d
Requested by: @dvdaruri-art
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->