### PR TITLE
fix(python): respect httpx client timeout when custom httpx_client is provided

### DIFF
--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -310,11 +310,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -470,11 +471,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -599,11 +601,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -762,11 +765,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/generators/python/sdk/changes/unreleased/fix-httpx-client-timeout.yml
+++ b/generators/python/sdk/changes/unreleased/fix-httpx-client-timeout.yml
@@ -1,0 +1,8 @@
+- summary: |
+    When a custom `httpx.Client` or `httpx.AsyncClient` is passed to the generated SDK client,
+    the timeout configured on that httpx client is now respected. Previously, the SDK would
+    extract only the `read` timeout component and pass it explicitly to each request, which
+    overrode the full timeout configuration (including separate connect/read/write/pool timeouts).
+    Now, when no explicit `timeout` is provided to the SDK constructor, requests defer to the
+    httpx client's own timeout settings via `httpx.USE_CLIENT_DEFAULT`.
+  type: fix

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -1075,9 +1075,7 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                                 if isinstance(self._context.custom_config.timeout_in_seconds, int)
                                 else AST.Expression(AST.TypeHint.none())
                             ),
-                            right=AST.Expression(
-                                f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME}.timeout.read"
-                            ),
+                            right=AST.Expression(AST.TypeHint.none()),
                             test=AST.Expression(
                                 f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME} is None"
                             ),

--- a/seed/python-sdk/accept-header/.fern/metadata.json
+++ b/seed/python-sdk/accept-header/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/accept-header/src/seed/client.py
+++ b/seed/python-sdk/accept-header/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedAccept:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedAccept:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/accept-header/src/seed/core/http_client.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/alias-extends/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/alias-extends/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedAliasExtends:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -206,9 +204,7 @@ class AsyncSeedAliasExtends:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/.fern/metadata.json
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedAliasExtends:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -206,9 +204,7 @@ class AsyncSeedAliasExtends:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/alias/.fern/metadata.json
+++ b/seed/python-sdk/alias/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/alias/src/seed/client.py
+++ b/seed/python-sdk/alias/src/seed/client.py
@@ -65,9 +65,7 @@ class SeedAlias:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -197,9 +195,7 @@ class AsyncSeedAlias:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/alias/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/allof-inline/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/allof-inline/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/client.py
@@ -87,9 +87,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -470,9 +468,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/allof/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/allof/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/allof/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/client.py
@@ -87,9 +87,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -466,9 +464,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/any-auth/.fern/metadata.json
+++ b/seed/python-sdk/any-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/any-auth/src/seed/client.py
+++ b/seed/python-sdk/any-auth/src/seed/client.py
@@ -134,9 +134,7 @@ class SeedAnyAuth:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -364,9 +362,7 @@ class AsyncSeedAnyAuth:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/any-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/python-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/client.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -176,9 +174,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/python-sdk/api-wide-base-path/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/api-wide-base-path/src/seed/client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApiWideBasePath:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -176,9 +174,7 @@ class AsyncSeedApiWideBasePath:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/audiences/.fern/metadata.json
+++ b/seed/python-sdk/audiences/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/audiences/src/seed/client.py
+++ b/seed/python-sdk/audiences/src/seed/client.py
@@ -75,9 +75,7 @@ class SeedAudiences:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -200,9 +198,7 @@ class AsyncSeedAudiences:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/audiences/src/seed/core/http_client.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/python-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/client.py
@@ -75,9 +75,7 @@ class SeedBasicAuthEnvironmentVariables:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if username is None:
             raise ApiError(body="The client must be instantiated be either passing in username or setting USERNAME")
@@ -189,9 +187,7 @@ class AsyncSeedBasicAuthEnvironmentVariables:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if username is None:
             raise ApiError(body="The client must be instantiated be either passing in username or setting USERNAME")

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/.fern/metadata.json
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedBasicAuthPwOmitted:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -176,9 +174,7 @@ class AsyncSeedBasicAuthPwOmitted:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/basic-auth/.fern/metadata.json
+++ b/seed/python-sdk/basic-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/basic-auth/src/seed/client.py
+++ b/seed/python-sdk/basic-auth/src/seed/client.py
@@ -73,9 +73,7 @@ class SeedBasicAuth:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -183,9 +181,7 @@ class AsyncSeedBasicAuth:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/basic-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/python-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedBearerTokenEnvironmentVariable:
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
         version: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if api_key is None:
             raise ApiError(
@@ -191,9 +189,7 @@ class AsyncSeedBearerTokenEnvironmentVariable:
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
         version: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if api_key is None:
             raise ApiError(

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/bytes-download/.fern/metadata.json
+++ b/seed/python-sdk/bytes-download/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/bytes-download/src/seed/client.py
+++ b/seed/python-sdk/bytes-download/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedBytesDownload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedBytesDownload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/bytes-download/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/python-sdk/bytes-upload/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/bytes-upload/src/seed/client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedBytesUpload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedBytesUpload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/.fern/metadata.json
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/circular-references-extends/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/circular-references/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/circular-references/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/.fern/metadata.json
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/cli-multi-spec-namespaced/.fern/metadata.json
+++ b/seed/python-sdk/cli-multi-spec-namespaced/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/client.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/client.py
@@ -84,9 +84,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -216,9 +214,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_client.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/cli-multi-spec/.fern/metadata.json
+++ b/seed/python-sdk/cli-multi-spec/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/cli-multi-spec/src/seed/client.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/client.py
@@ -75,9 +75,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -284,9 +282,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/http_client.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/client-side-params/.fern/metadata.json
+++ b/seed/python-sdk/client-side-params/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/client-side-params/src/seed/client.py
+++ b/seed/python-sdk/client-side-params/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedClientSideParams:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedClientSideParams:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/client-side-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/content-type/.fern/metadata.json
+++ b/seed/python-sdk/content-type/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/content-type/src/seed/client.py
+++ b/seed/python-sdk/content-type/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedContentTypes:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedContentTypes:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/content-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/python-sdk/cross-package-type-names/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/cross-package-type-names/src/seed/client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedCrossPackageTypeNames:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -189,9 +187,7 @@ class AsyncSeedCrossPackageTypeNames:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/python-sdk/dollar-string-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/dollar-string-examples/src/seed/client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedDollarStringExamples:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedDollarStringExamples:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/empty-clients/.fern/metadata.json
+++ b/seed/python-sdk/empty-clients/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/empty-clients/src/seed/client.py
+++ b/seed/python-sdk/empty-clients/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedEmptyClients:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedEmptyClients:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/empty-clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/python-sdk/endpoint-security-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/endpoint-security-auth/src/seed/client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/client.py
@@ -134,9 +134,7 @@ class SeedEndpointSecurityAuth:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -364,9 +362,7 @@ class AsyncSeedEndpointSecurityAuth:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/enum/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/enum/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/enum/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/client.py
@@ -71,9 +71,7 @@ class SeedEnum:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -209,9 +207,7 @@ class AsyncSeedEnum:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/enum/real-enum-forward-compat/.fern/metadata.json
+++ b/seed/python-sdk/enum/real-enum-forward-compat/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/client.py
@@ -71,9 +71,7 @@ class SeedEnum:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -209,9 +207,7 @@ class AsyncSeedEnum:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/enum/real-enum/.fern/metadata.json
+++ b/seed/python-sdk/enum/real-enum/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/enum/real-enum/src/seed/client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/client.py
@@ -71,9 +71,7 @@ class SeedEnum:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -209,9 +207,7 @@ class AsyncSeedEnum:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/enum/strenum/.fern/metadata.json
+++ b/seed/python-sdk/enum/strenum/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/enum/strenum/src/seed/client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/client.py
@@ -71,9 +71,7 @@ class SeedEnum:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -209,9 +207,7 @@ class AsyncSeedEnum:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/error-property/.fern/metadata.json
+++ b/seed/python-sdk/error-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/error-property/src/seed/client.py
+++ b/seed/python-sdk/error-property/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedErrorProperty:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedErrorProperty:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/error-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/errors/.fern/metadata.json
+++ b/seed/python-sdk/errors/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/errors/src/seed/client.py
+++ b/seed/python-sdk/errors/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedErrors:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedErrors:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/errors/src/seed/core/http_client.py
+++ b/seed/python-sdk/errors/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/.fern/metadata.json
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/.fern/metadata.json
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/client.py
@@ -84,9 +84,7 @@ class SeedExamples:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -287,9 +285,7 @@ class AsyncSeedExamples:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/examples/client-filename/.fern/metadata.json
+++ b/seed/python-sdk/examples/client-filename/.fern/metadata.json
@@ -12,8 +12,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/examples/client-filename/src/seed/base_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/base_client.py
@@ -84,9 +84,7 @@ class BaseSeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -287,9 +285,7 @@ class AsyncBaseSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/examples/legacy-wire-tests/.fern/metadata.json
+++ b/seed/python-sdk/examples/legacy-wire-tests/.fern/metadata.json
@@ -7,8 +7,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/client.py
@@ -84,9 +84,7 @@ class SeedExamples:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -287,9 +285,7 @@ class AsyncSeedExamples:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/examples/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/examples/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/client.py
@@ -84,9 +84,7 @@ class SeedExamples:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -287,9 +285,7 @@ class AsyncSeedExamples:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/examples/omit-fern-headers/.fern/metadata.json
+++ b/seed/python-sdk/examples/omit-fern-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
     "omit_fern_headers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/client.py
@@ -84,9 +84,7 @@ class SeedExamples:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -287,9 +285,7 @@ class AsyncSeedExamples:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/examples/readme/.fern/metadata.json
+++ b/seed/python-sdk/examples/readme/.fern/metadata.json
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/examples/readme/src/seed/client.py
+++ b/seed/python-sdk/examples/readme/src/seed/client.py
@@ -84,9 +84,7 @@ class SeedExamples:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -287,9 +285,7 @@ class AsyncSeedExamples:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/examples/readme/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/additional_init_exports/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/additional_init_exports/.fern/metadata.json
@@ -14,8 +14,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/aliases_with_validation/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/aliases_without_validation/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/custom-transport/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/custom-transport/.fern/metadata.json
@@ -6,8 +6,7 @@
     "custom_transport": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/client.py
@@ -78,9 +78,7 @@ class SeedExhaustive:
         http_client: typing.Optional[httpx.BaseTransport] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -228,9 +226,7 @@ class AsyncSeedExhaustive:
         http_client: typing.Optional[httpx.AsyncBaseTransport] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/.fern/metadata.json
@@ -6,8 +6,7 @@
     "datetime_milliseconds": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/.fern/metadata.json
@@ -20,8 +20,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/eager-imports/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/eager-imports/.fern/metadata.json
@@ -6,8 +6,7 @@
     "lazy_imports": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -176,9 +174,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/extra_dependencies/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/extra_dependencies/.fern/metadata.json
@@ -20,8 +20,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/.fern/metadata.json
@@ -11,8 +11,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/five-second-timeout/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/five-second-timeout/.fern/metadata.json
@@ -6,8 +6,7 @@
     "timeout_in_seconds": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 5 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 5 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 5 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 5 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "follow_redirects_by_default": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/import-paths/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/import-paths/.fern/metadata.json
@@ -9,8 +9,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/improved_imports/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/improved_imports/.fern/metadata.json
@@ -6,8 +6,7 @@
     "improved_imports": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/infinite-timeout/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/infinite-timeout/.fern/metadata.json
@@ -6,8 +6,7 @@
     "timeout_in_seconds": "infinity"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else None if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else None if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else None if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else None if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/inline-path-params/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/inline-path-params/.fern/metadata.json
@@ -7,8 +7,7 @@
     "recursion_limit": 1234
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/inline_request_params/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/inline_request_params/.fern/metadata.json
@@ -6,8 +6,7 @@
     "inline_request_params": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/output-directory-project-root/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/.fern/metadata.json
@@ -6,8 +6,7 @@
     "output_directory": "project-root"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/.fern/metadata.json
@@ -7,8 +7,7 @@
     "package_name": "sub.dir"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/client.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/client.py
@@ -63,7 +63,7 @@ class SeedExhaustive:
     )
     """
     def __init__(self, *, base_url: str, token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None, headers: typing.Optional[typing.Dict[str, str]] = None, timeout: typing.Optional[float] = None, max_retries: typing.Optional[int] = None, stream_reconnection_enabled: typing.Optional[bool] = None, max_stream_reconnection_attempts: typing.Optional[int] = None, follow_redirects: typing.Optional[bool] = True, httpx_client: typing.Optional[httpx.Client] = None, logging: typing.Optional[typing.Union[LogConfig, Logger]] = None):
-        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(base_url=base_url, token=token, headers=headers, httpx_client=httpx_client if httpx_client is not None else httpx.Client(timeout=_defaulted_timeout, follow_redirects=follow_redirects) if follow_redirects is not None else httpx.Client(timeout=_defaulted_timeout)
         , timeout=_defaulted_timeout, max_retries=_defaulted_max_retries, stream_reconnection_enabled=stream_reconnection_enabled, max_stream_reconnection_attempts=max_stream_reconnection_attempts, logging=logging)
@@ -170,7 +170,7 @@ class AsyncSeedExhaustive:
     )
     """
     def __init__(self, *, base_url: str, token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None, headers: typing.Optional[typing.Dict[str, str]] = None, async_token: typing.Optional[typing.Callable[[], typing.Awaitable[str]]] = None, timeout: typing.Optional[float] = None, max_retries: typing.Optional[int] = None, stream_reconnection_enabled: typing.Optional[bool] = None, max_stream_reconnection_attempts: typing.Optional[int] = None, follow_redirects: typing.Optional[bool] = True, httpx_client: typing.Optional[httpx.AsyncClient] = None, logging: typing.Optional[typing.Union[LogConfig, Logger]] = None):
-        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(base_url=base_url, token=token, headers=headers, async_token=async_token, httpx_client=httpx_client if httpx_client is not None else _make_default_async_client(timeout=_defaulted_timeout, follow_redirects=follow_redirects)
         , timeout=_defaulted_timeout, max_retries=_defaulted_max_retries, stream_reconnection_enabled=stream_reconnection_enabled, max_stream_reconnection_attempts=max_stream_reconnection_attempts, logging=logging)

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_client.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/.fern/metadata.json
@@ -7,8 +7,7 @@
     "package_path": "my_org/my_sdk"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/client.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/client.py
@@ -63,7 +63,7 @@ class SeedExhaustive:
     )
     """
     def __init__(self, *, base_url: str, token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None, headers: typing.Optional[typing.Dict[str, str]] = None, timeout: typing.Optional[float] = None, max_retries: typing.Optional[int] = None, stream_reconnection_enabled: typing.Optional[bool] = None, max_stream_reconnection_attempts: typing.Optional[int] = None, follow_redirects: typing.Optional[bool] = True, httpx_client: typing.Optional[httpx.Client] = None, logging: typing.Optional[typing.Union[LogConfig, Logger]] = None):
-        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(base_url=base_url, token=token, headers=headers, httpx_client=httpx_client if httpx_client is not None else httpx.Client(timeout=_defaulted_timeout, follow_redirects=follow_redirects) if follow_redirects is not None else httpx.Client(timeout=_defaulted_timeout)
         , timeout=_defaulted_timeout, max_retries=_defaulted_max_retries, stream_reconnection_enabled=stream_reconnection_enabled, max_stream_reconnection_attempts=max_stream_reconnection_attempts, logging=logging)
@@ -170,7 +170,7 @@ class AsyncSeedExhaustive:
     )
     """
     def __init__(self, *, base_url: str, token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None, headers: typing.Optional[typing.Dict[str, str]] = None, async_token: typing.Optional[typing.Callable[[], typing.Awaitable[str]]] = None, timeout: typing.Optional[float] = None, max_retries: typing.Optional[int] = None, stream_reconnection_enabled: typing.Optional[bool] = None, max_stream_reconnection_attempts: typing.Optional[int] = None, follow_redirects: typing.Optional[bool] = True, httpx_client: typing.Optional[httpx.AsyncClient] = None, logging: typing.Optional[typing.Union[LogConfig, Logger]] = None):
-        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(base_url=base_url, token=token, headers=headers, async_token=async_token, httpx_client=httpx_client if httpx_client is not None else _make_default_async_client(timeout=_defaulted_timeout, follow_redirects=follow_redirects)
         , timeout=_defaulted_timeout, max_retries=_defaulted_max_retries, stream_reconnection_enabled=stream_reconnection_enabled, max_stream_reconnection_attempts=max_stream_reconnection_attempts, logging=logging)

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_client.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/output-directory-source-root/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/.fern/metadata.json
@@ -6,8 +6,7 @@
     "output_directory": "source-root"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/client.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/client.py
@@ -63,7 +63,7 @@ class SeedExhaustive:
     )
     """
     def __init__(self, *, base_url: str, token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None, headers: typing.Optional[typing.Dict[str, str]] = None, timeout: typing.Optional[float] = None, max_retries: typing.Optional[int] = None, stream_reconnection_enabled: typing.Optional[bool] = None, max_stream_reconnection_attempts: typing.Optional[int] = None, follow_redirects: typing.Optional[bool] = True, httpx_client: typing.Optional[httpx.Client] = None, logging: typing.Optional[typing.Union[LogConfig, Logger]] = None):
-        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(base_url=base_url, token=token, headers=headers, httpx_client=httpx_client if httpx_client is not None else httpx.Client(timeout=_defaulted_timeout, follow_redirects=follow_redirects) if follow_redirects is not None else httpx.Client(timeout=_defaulted_timeout)
         , timeout=_defaulted_timeout, max_retries=_defaulted_max_retries, stream_reconnection_enabled=stream_reconnection_enabled, max_stream_reconnection_attempts=max_stream_reconnection_attempts, logging=logging)
@@ -170,7 +170,7 @@ class AsyncSeedExhaustive:
     )
     """
     def __init__(self, *, base_url: str, token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None, headers: typing.Optional[typing.Dict[str, str]] = None, async_token: typing.Optional[typing.Callable[[], typing.Awaitable[str]]] = None, timeout: typing.Optional[float] = None, max_retries: typing.Optional[int] = None, stream_reconnection_enabled: typing.Optional[bool] = None, max_stream_reconnection_attempts: typing.Optional[int] = None, follow_redirects: typing.Optional[bool] = True, httpx_client: typing.Optional[httpx.AsyncClient] = None, logging: typing.Optional[typing.Union[LogConfig, Logger]] = None):
-        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(base_url=base_url, token=token, headers=headers, async_token=async_token, httpx_client=httpx_client if httpx_client is not None else _make_default_async_client(timeout=_defaulted_timeout, follow_redirects=follow_redirects)
         , timeout=_defaulted_timeout, max_retries=_defaulted_max_retries, stream_reconnection_enabled=stream_reconnection_enabled, max_stream_reconnection_attempts=max_stream_reconnection_attempts, logging=logging)

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/package-path/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/package-path/.fern/metadata.json
@@ -6,8 +6,7 @@
     "package_path": "matryoshka/doll/structure"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pydantic-v1/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v1/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/pyproject_extras/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pyproject_extras/.fern/metadata.json
@@ -15,8 +15,7 @@
     "pyproject_toml": "[tool.covcheck.group.unit.coverage]\nbranch = 26.0\nline = 62.0\n\n[tool.covcheck.group.service.coverage]\nbranch = 30.0\nline = 67.0\n"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/union-utils/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/union-utils/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedExhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncSeedExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/client.py
@@ -74,9 +74,7 @@ class Exhaustive:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -220,9 +218,7 @@ class AsyncExhaustive:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/extends/.fern/metadata.json
+++ b/seed/python-sdk/extends/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/extends/src/seed/client.py
+++ b/seed/python-sdk/extends/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedExtends:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -209,9 +207,7 @@ class AsyncSeedExtends:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/extends/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/extra-properties/.fern/metadata.json
+++ b/seed/python-sdk/extra-properties/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/extra-properties/src/seed/client.py
+++ b/seed/python-sdk/extra-properties/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedExtraProperties:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedExtraProperties:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/extra-properties/src/seed/core/http_client.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/file-download/default-chunk-size/.fern/metadata.json
+++ b/seed/python-sdk/file-download/default-chunk-size/.fern/metadata.json
@@ -7,8 +7,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedFileDownload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedFileDownload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/file-download/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/file-download/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedFileDownload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedFileDownload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/python-sdk/file-upload-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/file-upload-openapi/src/seed/client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/.fern/metadata.json
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/.fern/metadata.json
@@ -6,8 +6,7 @@
     "exclude_types_from_init_exports": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedFileUpload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedFileUpload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/file-upload/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/file-upload/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedFileUpload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedFileUpload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/file-upload/use_typeddict_requests/.fern/metadata.json
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/.fern/metadata.json
@@ -7,8 +7,7 @@
     "use_typeddict_requests_for_file_upload": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedFileUpload:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedFileUpload:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/folders/.fern/metadata.json
+++ b/seed/python-sdk/folders/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/folders/src/seed/client.py
+++ b/seed/python-sdk/folders/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -216,9 +214,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/folders/src/seed/core/http_client.py
+++ b/seed/python-sdk/folders/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/python-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/client.py
@@ -72,9 +72,7 @@ class SeedHeaderTokenEnvironmentVariable:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if header_token_auth is None:
             raise ApiError(
@@ -182,9 +180,7 @@ class AsyncSeedHeaderTokenEnvironmentVariable:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if header_token_auth is None:
             raise ApiError(

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/header-auth/.fern/metadata.json
+++ b/seed/python-sdk/header-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/header-auth/src/seed/client.py
+++ b/seed/python-sdk/header-auth/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedHeaderToken:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -176,9 +174,7 @@ class AsyncSeedHeaderToken:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/header-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/http-head/.fern/metadata.json
+++ b/seed/python-sdk/http-head/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/http-head/src/seed/client.py
+++ b/seed/python-sdk/http-head/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedHttpHead:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedHttpHead:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/http-head/src/seed/core/http_client.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/python-sdk/idempotency-headers/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/idempotency-headers/src/seed/client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedIdempotencyHeaders:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedIdempotencyHeaders:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/imdb/.fern/metadata.json
+++ b/seed/python-sdk/imdb/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/imdb/src/seed/client.py
+++ b/seed/python-sdk/imdb/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/imdb/src/seed/core/http_client.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/python-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/client.py
@@ -90,9 +90,7 @@ class SeedInferredAuthExplicit:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = InferredAuthTokenProvider(
             x_api_key=x_api_key,
@@ -259,9 +257,7 @@ class AsyncSeedInferredAuthExplicit:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = AsyncInferredAuthTokenProvider(
             x_api_key=x_api_key,

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/client.py
@@ -76,9 +76,7 @@ class SeedInferredAuthImplicitApiKey:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = InferredAuthTokenProvider(
             api_key=api_key,
@@ -228,9 +226,7 @@ class AsyncSeedInferredAuthImplicitApiKey:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = AsyncInferredAuthTokenProvider(
             api_key=api_key,

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/client.py
@@ -90,9 +90,7 @@ class SeedInferredAuthImplicitNoExpiry:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = InferredAuthTokenProvider(
             x_api_key=x_api_key,
@@ -259,9 +257,7 @@ class AsyncSeedInferredAuthImplicitNoExpiry:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = AsyncInferredAuthTokenProvider(
             x_api_key=x_api_key,

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/python-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/client.py
@@ -85,9 +85,7 @@ class SeedInferredAuthImplicit:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = InferredAuthTokenProvider(
             client_id=client_id,
@@ -248,9 +246,7 @@ class AsyncSeedInferredAuthImplicit:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = AsyncInferredAuthTokenProvider(
             client_id=client_id,

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/python-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/client.py
@@ -90,9 +90,7 @@ class SeedInferredAuthImplicit:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = InferredAuthTokenProvider(
             x_api_key=x_api_key,
@@ -259,9 +257,7 @@ class AsyncSeedInferredAuthImplicit:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = AsyncInferredAuthTokenProvider(
             x_api_key=x_api_key,

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/inline-enum-type-name-override/.fern/metadata.json
+++ b/seed/python-sdk/inline-enum-type-name-override/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/client.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_client.py
+++ b/seed/python-sdk/inline-enum-type-name-override/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/license/.fern/metadata.json
+++ b/seed/python-sdk/license/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/license/src/seed/client.py
+++ b/seed/python-sdk/license/src/seed/client.py
@@ -64,9 +64,7 @@ class SeedLicense:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -192,9 +190,7 @@ class AsyncSeedLicense:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/license/src/seed/core/http_client.py
+++ b/seed/python-sdk/license/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/literal-user-agent/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/client.py
@@ -66,9 +66,7 @@ class SeedLiteralUserAgent:
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
         user_agent: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -197,9 +195,7 @@ class AsyncSeedLiteralUserAgent:
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
         user_agent: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/literal/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/literal/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/literal/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/client.py
@@ -75,9 +75,7 @@ class SeedLiteral:
         version: typing.Optional[str] = None,
         audit_logging: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -219,9 +217,7 @@ class AsyncSeedLiteral:
         version: typing.Optional[str] = None,
         audit_logging: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/literal/use_typeddict_requests/.fern/metadata.json
+++ b/seed/python-sdk/literal/use_typeddict_requests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_typeddict_requests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/client.py
@@ -75,9 +75,7 @@ class SeedLiteral:
         version: typing.Optional[str] = None,
         audit_logging: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -219,9 +217,7 @@ class AsyncSeedLiteral:
         version: typing.Optional[str] = None,
         audit_logging: typing.Optional[str] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/literals-unions/.fern/metadata.json
+++ b/seed/python-sdk/literals-unions/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/literals-unions/src/seed/client.py
+++ b/seed/python-sdk/literals-unions/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedLiteralsUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedLiteralsUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/literals-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/mixed-case/.fern/metadata.json
+++ b/seed/python-sdk/mixed-case/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/mixed-case/src/seed/client.py
+++ b/seed/python-sdk/mixed-case/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedMixedCase:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedMixedCase:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/mixed-case/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/.fern/metadata.json
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/.fern/metadata.json
@@ -7,8 +7,7 @@
     "use_typeddict_requests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedMixedFileDirectory:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedMixedFileDirectory:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedMixedFileDirectory:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedMixedFileDirectory:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/multi-content-type-examples/.fern/metadata.json
+++ b/seed/python-sdk/multi-content-type-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/multi-content-type-examples/src/seed/client.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/multi-content-type-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-content-type-examples/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/python-sdk/multi-line-docs/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/multi-line-docs/src/seed/client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedMultiLineDocs:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedMultiLineDocs:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/python-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/client.py
@@ -73,9 +73,7 @@ class SeedMultiUrlEnvironmentNoDefault:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             environment=environment,
@@ -193,9 +191,7 @@ class AsyncSeedMultiUrlEnvironmentNoDefault:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             environment=environment,

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/python-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/client.py
@@ -78,9 +78,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             environment=environment,
@@ -211,9 +209,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             environment=environment,

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/python-sdk/multi-url-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/multi-url-environment/src/seed/client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/client.py
@@ -77,9 +77,7 @@ class SeedMultiUrlEnvironment:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             environment=environment,
@@ -201,9 +199,7 @@ class AsyncSeedMultiUrlEnvironment:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             environment=environment,

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/python-sdk/multiple-request-bodies/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/multiple-request-bodies/src/seed/client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/client.py
@@ -81,9 +81,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -264,9 +262,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/no-content-response/.fern/metadata.json
+++ b/seed/python-sdk/no-content-response/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/no-content-response/src/seed/client.py
+++ b/seed/python-sdk/no-content-response/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/no-content-response/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/no-environment/.fern/metadata.json
+++ b/seed/python-sdk/no-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/no-environment/src/seed/client.py
+++ b/seed/python-sdk/no-environment/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedNoEnvironment:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedNoEnvironment:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/no-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/no-retries/.fern/metadata.json
+++ b/seed/python-sdk/no-retries/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/no-retries/src/seed/client.py
+++ b/seed/python-sdk/no-retries/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedNoRetries:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedNoRetries:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/no-retries/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/null-type/.fern/metadata.json
+++ b/seed/python-sdk/null-type/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/null-type/src/seed/client.py
+++ b/seed/python-sdk/null-type/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/null-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/python-sdk/nullable-allof-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/nullable-allof-extends/src/seed/client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/client.py
@@ -77,9 +77,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -250,9 +248,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/python-sdk/nullable-optional/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/nullable-optional/src/seed/client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedNullableOptional:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedNullableOptional:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/python-sdk/nullable-request-body/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/nullable-request-body/src/seed/client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/nullable/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/nullable/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedNullable:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedNullable:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/nullable/use-typeddict-requests/.fern/metadata.json
+++ b/seed/python-sdk/nullable/use-typeddict-requests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_typeddict_requests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedNullable:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedNullable:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/client.py
@@ -139,9 +139,7 @@ class SeedOauthClientCredentials:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -381,9 +379,7 @@ class AsyncSeedOauthClientCredentials:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/client.py
@@ -133,9 +133,7 @@ class SeedOauthClientCredentialsDefault:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -363,9 +361,7 @@ class AsyncSeedOauthClientCredentialsDefault:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/client.py
@@ -134,9 +134,7 @@ class SeedOauthClientCredentialsEnvironmentVariables:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -364,9 +362,7 @@ class AsyncSeedOauthClientCredentialsEnvironmentVariables:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/client.py
@@ -132,9 +132,7 @@ class SeedOauthClientCredentialsMandatoryAuth:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -353,9 +351,7 @@ class AsyncSeedOauthClientCredentialsMandatoryAuth:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/client.py
@@ -133,9 +133,7 @@ class SeedOauthClientCredentials:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -363,9 +361,7 @@ class AsyncSeedOauthClientCredentials:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/client.py
@@ -131,9 +131,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -343,9 +341,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/client.py
@@ -131,9 +131,7 @@ class SeedOauthClientCredentialsReference:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -343,9 +341,7 @@ class AsyncSeedOauthClientCredentialsReference:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/client.py
@@ -138,9 +138,7 @@ class SeedOauthClientCredentialsWithVariables:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -384,9 +382,7 @@ class AsyncSeedOauthClientCredentialsWithVariables:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/python-sdk/oauth-client-credentials/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/oauth-client-credentials/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/client.py
@@ -133,9 +133,7 @@ class SeedOauthClientCredentials:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
@@ -363,9 +361,7 @@ class AsyncSeedOauthClientCredentials:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/object/.fern/metadata.json
+++ b/seed/python-sdk/object/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/object/src/seed/client.py
+++ b/seed/python-sdk/object/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedObject:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedObject:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/object/src/seed/core/http_client.py
+++ b/seed/python-sdk/object/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/python-sdk/objects-with-imports/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/objects-with-imports/src/seed/client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedObjectsWithImports:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedObjectsWithImports:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/openapi-request-body-ref/.fern/metadata.json
+++ b/seed/python-sdk/openapi-request-body-ref/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/client.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -189,9 +187,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_client.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/openapi-subtitle/.fern/metadata.json
+++ b/seed/python-sdk/openapi-subtitle/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/openapi-subtitle/src/seed/client.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/client.py
@@ -65,9 +65,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -226,9 +224,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/openapi-subtitle/src/seed/core/http_client.py
+++ b/seed/python-sdk/openapi-subtitle/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/optional/.fern/metadata.json
+++ b/seed/python-sdk/optional/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/optional/src/seed/client.py
+++ b/seed/python-sdk/optional/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedObjectsWithImports:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedObjectsWithImports:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/optional/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/package-yml/.fern/metadata.json
+++ b/seed/python-sdk/package-yml/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/package-yml/src/seed/client.py
+++ b/seed/python-sdk/package-yml/src/seed/client.py
@@ -74,9 +74,7 @@ class SeedPackageYml:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -223,9 +221,7 @@ class AsyncSeedPackageYml:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/package-yml/src/seed/core/http_client.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/python-sdk/pagination-custom/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/pagination-custom/src/seed/client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedPagination:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedPagination:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/python-sdk/pagination-uri-path/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/pagination-uri-path/src/seed/client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedPaginationUriPath:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -180,9 +178,7 @@ class AsyncSeedPaginationUriPath:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/client.py
@@ -72,9 +72,7 @@ class SeedPagination:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -200,9 +198,7 @@ class AsyncSeedPagination:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/.fern/metadata.json
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/client.py
@@ -72,9 +72,7 @@ class SeedPagination:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -200,9 +198,7 @@ class AsyncSeedPagination:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/pagination/page-index-semantics/.fern/metadata.json
+++ b/seed/python-sdk/pagination/page-index-semantics/.fern/metadata.json
@@ -6,8 +6,7 @@
     "offsetSemantics": "page-index"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/client.py
@@ -72,9 +72,7 @@ class SeedPagination:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -200,9 +198,7 @@ class AsyncSeedPagination:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/path-parameters/.fern/metadata.json
+++ b/seed/python-sdk/path-parameters/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/path-parameters/src/seed/client.py
+++ b/seed/python-sdk/path-parameters/src/seed/client.py
@@ -71,9 +71,7 @@ class SeedPathParameters:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -186,9 +184,7 @@ class AsyncSeedPathParameters:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/path-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/plain-text/.fern/metadata.json
+++ b/seed/python-sdk/plain-text/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/plain-text/src/seed/client.py
+++ b/seed/python-sdk/plain-text/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedPlainText:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedPlainText:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/plain-text/src/seed/core/http_client.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/property-access/.fern/metadata.json
+++ b/seed/python-sdk/property-access/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/property-access/src/seed/client.py
+++ b/seed/python-sdk/property-access/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedPropertyAccess:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -230,9 +228,7 @@ class AsyncSeedPropertyAccess:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/property-access/src/seed/core/http_client.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/public-object/.fern/metadata.json
+++ b/seed/python-sdk/public-object/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/public-object/src/seed/client.py
+++ b/seed/python-sdk/public-object/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedPublicObject:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedPublicObject:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/public-object/src/seed/core/http_client.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-backslash-escape/.fern/metadata.json
+++ b/seed/python-sdk/python-backslash-escape/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-backslash-escape/src/seed/client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedPythonBackslashEscape:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedPythonBackslashEscape:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/.fern/metadata.json
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/.fern/metadata.json
@@ -9,8 +9,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedPythonPositionalSingleProperty:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -224,9 +222,7 @@ class AsyncSeedPythonPositionalSingleProperty:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/.fern/metadata.json
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedPythonPositionalSingleProperty:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -224,9 +222,7 @@ class AsyncSeedPythonPositionalSingleProperty:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-reserved-keyword-subpackages/.fern/metadata.json
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/.fern/metadata.json
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -236,9 +234,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/python-sdk/query-param-name-conflict/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/query-param-name-conflict/src/seed/client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -237,9 +235,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -330,9 +328,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -330,9 +328,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/query-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/query-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedQueryParameters:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedQueryParameters:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/request-parameters/.fern/metadata.json
+++ b/seed/python-sdk/request-parameters/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/request-parameters/src/seed/client.py
+++ b/seed/python-sdk/request-parameters/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedRequestParameters:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedRequestParameters:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/request-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/required-nullable/.fern/metadata.json
+++ b/seed/python-sdk/required-nullable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/required-nullable/src/seed/client.py
+++ b/seed/python-sdk/required-nullable/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -285,9 +283,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/required-nullable/src/seed/core/http_client.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/python-sdk/reserved-keywords/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/reserved-keywords/src/seed/client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedNurseryApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedNurseryApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/response-property/.fern/metadata.json
+++ b/seed/python-sdk/response-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/response-property/src/seed/client.py
+++ b/seed/python-sdk/response-property/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedResponseProperty:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedResponseProperty:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/python-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -295,9 +293,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/python-sdk/server-sent-event-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/server-sent-event-examples/src/seed/client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedServerSentEvents:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedServerSentEvents:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/.fern/metadata.json
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/client.py
@@ -79,9 +79,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -832,9 +830,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/python-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/client.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedServerSentEventsResumable:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedServerSentEventsResumable:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/server-sent-events/with-wire-tests/.fern/metadata.json
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable_wire_tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedServerSentEvents:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedServerSentEvents:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/server-url-templating/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/server-url-templating/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/client.py
@@ -82,9 +82,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if region is not None or server_url_environment is not None:
             _region = region if region is not None else "us-east-1"
@@ -291,9 +289,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if region is not None or server_url_environment is not None:
             _region = region if region is not None else "us-east-1"

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/simple-api/.fern/metadata.json
+++ b/seed/python-sdk/simple-api/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/simple-api/src/seed/client.py
+++ b/seed/python-sdk/simple-api/src/seed/client.py
@@ -76,9 +76,7 @@ class SeedSimpleApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -191,9 +189,7 @@ class AsyncSeedSimpleApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/simple-api/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/.fern/metadata.json
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/client.py
@@ -65,9 +65,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -197,9 +195,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/python-sdk/single-url-environment-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/single-url-environment-default/src/seed/client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/client.py
@@ -80,9 +80,7 @@ class SeedSingleUrlEnvironmentDefault:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -199,9 +197,7 @@ class AsyncSeedSingleUrlEnvironmentDefault:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/python-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/client.py
@@ -76,9 +76,7 @@ class SeedSingleUrlEnvironmentNoDefault:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -191,9 +189,7 @@ class AsyncSeedSingleUrlEnvironmentNoDefault:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/python-sdk/streaming-parameter/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/streaming-parameter/src/seed/client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedStreaming:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedStreaming:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedStreaming:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedStreaming:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/streaming/skip-pydantic-validation/.fern/metadata.json
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedStreaming:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedStreaming:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/trace/.fern/metadata.json
+++ b/seed/python-sdk/trace/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/trace/src/seed/client.py
+++ b/seed/python-sdk/trace/src/seed/client.py
@@ -90,9 +90,7 @@ class SeedTrace:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),
@@ -276,9 +274,7 @@ class AsyncSeedTrace:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=_get_base_url(base_url=base_url, environment=environment),

--- a/seed/python-sdk/trace/src/seed/core/http_client.py
+++ b/seed/python-sdk/trace/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedUndiscriminatedUnionWithResponseProperty:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -219,9 +217,7 @@ class AsyncSeedUndiscriminatedUnionWithResponseProperty:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/undiscriminated-unions/.fern/metadata.json
+++ b/seed/python-sdk/undiscriminated-unions/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/undiscriminated-unions/src/seed/client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedUndiscriminatedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedUndiscriminatedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/python-sdk/union-query-parameters/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/union-query-parameters/src/seed/client.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedUnionQueryParameters:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedUnionQueryParameters:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/union-query-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/python-sdk/unions-with-local-date/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions-with-local-date/src/seed/client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -189,9 +187,7 @@ class AsyncSeedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unions/flatten-union-request-bodies/.fern/metadata.json
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/.fern/metadata.json
@@ -6,8 +6,7 @@
     "flatten_union_request_bodies": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/client.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/unions/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/.fern/metadata.json
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/.fern/metadata.json
@@ -10,8 +10,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unions/union-naming-v1/.fern/metadata.json
+++ b/seed/python-sdk/unions/union-naming-v1/.fern/metadata.json
@@ -9,8 +9,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unions/union-utils/.fern/metadata.json
+++ b/seed/python-sdk/unions/union-utils/.fern/metadata.json
@@ -9,8 +9,7 @@
     "use_inheritance_for_extended_models": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unions/union-utils/src/seed/client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedUnions:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -179,9 +177,7 @@ class AsyncSeedUnions:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/unknown/.fern/metadata.json
+++ b/seed/python-sdk/unknown/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/unknown/src/seed/client.py
+++ b/seed/python-sdk/unknown/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedUnknownAsAny:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedUnknownAsAny:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/unknown/src/seed/core/http_client.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/python-sdk/url-form-encoded/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/url-form-encoded/src/seed/client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -246,9 +244,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/validation/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/validation/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/validation/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedValidation:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -255,9 +253,7 @@ class AsyncSeedValidation:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/validation/with-defaults-parameters/.fern/metadata.json
+++ b/seed/python-sdk/validation/with-defaults-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_request_defaults": "parameters"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedValidation:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -260,9 +258,7 @@ class AsyncSeedValidation:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/validation/with-defaults/.fern/metadata.json
+++ b/seed/python-sdk/validation/with-defaults/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use_request_defaults": "all"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/validation/with-defaults/src/seed/client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedValidation:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -260,9 +258,7 @@ class AsyncSeedValidation:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/variables/.fern/metadata.json
+++ b/seed/python-sdk/variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/variables/src/seed/client.py
+++ b/seed/python-sdk/variables/src/seed/client.py
@@ -70,9 +70,7 @@ class SeedVariables:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -176,9 +174,7 @@ class AsyncSeedVariables:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/variables/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/version-no-default/.fern/metadata.json
+++ b/seed/python-sdk/version-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/version-no-default/src/seed/client.py
+++ b/seed/python-sdk/version-no-default/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedVersion:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedVersion:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/version-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/version/.fern/metadata.json
+++ b/seed/python-sdk/version/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/version/src/seed/client.py
+++ b/seed/python-sdk/version/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedVersion:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedVersion:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/version/src/seed/core/http_client.py
+++ b/seed/python-sdk/version/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/python-sdk/webhook-audience/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/webhook-audience/src/seed/client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/webhooks/.fern/metadata.json
+++ b/seed/python-sdk/webhooks/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/webhooks/src/seed/client.py
+++ b/seed/python-sdk/webhooks/src/seed/client.py
@@ -62,9 +62,7 @@ class SeedWebhooks:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -155,9 +153,7 @@ class AsyncSeedWebhooks:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/webhooks/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/python-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedWebsocketBearerAuth:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if api_key is None:
             raise ApiError(body="The client must be instantiated be either passing in api_key or setting SEED_API_KEY")
@@ -170,9 +168,7 @@ class AsyncSeedWebsocketBearerAuth:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         if api_key is None:
             raise ApiError(body="The client must be instantiated be either passing in api_key or setting SEED_API_KEY")

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/python-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/client.py
@@ -87,9 +87,7 @@ class SeedWebsocketAuth:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = InferredAuthTokenProvider(
             x_api_key=x_api_key,
@@ -229,9 +227,7 @@ class AsyncSeedWebsocketAuth:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         inferred_auth_token_provider = AsyncInferredAuthTokenProvider(
             x_api_key=x_api_key,

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/python-sdk/websocket-multi-url/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/websocket-multi-url/src/seed/client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/client.py
@@ -71,9 +71,7 @@ class SeedWebsocketMultiUrl:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             environment=environment,
@@ -177,9 +175,7 @@ class AsyncSeedWebsocketMultiUrl:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             environment=environment,

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/websocket/websocket-base/.fern/metadata.json
+++ b/seed/python-sdk/websocket/websocket-base/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/websocket/websocket-base/src/seed/client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/client.py
@@ -67,9 +67,7 @@ class SeedWebsocket:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -169,9 +167,7 @@ class AsyncSeedWebsocket:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/.fern/metadata.json
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedWebsocket:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -189,9 +187,7 @@ class AsyncSeedWebsocket:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/.fern/metadata.json
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/.fern/metadata.json
@@ -6,8 +6,7 @@
     "should_generate_websocket_clients": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/client.py
@@ -69,9 +69,7 @@ class SeedWebsocket:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -189,9 +187,7 @@ class AsyncSeedWebsocket:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))

--- a/seed/python-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/python-sdk/x-fern-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-python-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/x-fern-default/src/seed/client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/client.py
@@ -68,9 +68,7 @@ class SeedApi:
         httpx_client: typing.Optional[httpx.Client] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
@@ -214,9 +212,7 @@ class AsyncSeedApi:
         httpx_client: typing.Optional[httpx.AsyncClient] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        _defaulted_timeout = (
-            timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read
-        )
+        _defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
         _defaulted_max_retries = max_retries if max_retries is not None else 2
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
@@ -312,11 +312,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
@@ -472,11 +473,12 @@ class HttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.Iterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -601,11 +603,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> httpx.Response:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))
@@ -764,11 +767,12 @@ class AsyncHttpClient:
         force_multipart: typing.Optional[bool] = None,
     ) -> typing.AsyncIterator[httpx.Response]:
         base_url = self.get_base_url(base_url)
-        timeout = (
+        _timeout = (
             request_options.get("timeout_in_seconds")
             if request_options is not None and request_options.get("timeout_in_seconds") is not None
             else self.base_timeout()
         )
+        timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
 
         request_files: typing.Optional[RequestFiles] = (
             convert_file_dict_to_httpx_tuples(remove_omit_from_dict(remove_none_from_dict(files), omit))


### PR DESCRIPTION
## Description
Closes https://github.com/fern-api/fern/issues/5321

When a custom `httpx.Client` (or `httpx.AsyncClient`) is passed to the generated Python SDK client, the timeout configured on that httpx client was being ignored. The SDK extracted only the `.read` component of the timeout and passed it explicitly to every request, overriding the user's full timeout configuration (including separate connect/read/write/pool timeouts).

## Changes Made

**`generators/python/core_utilities/shared/http_client.py`** — the runtime HTTP client used by all generated Python SDKs:
```python
# Before: timeout could be None, which httpx interprets as "no timeout"
timeout = ... else self.base_timeout()

# After: None → httpx.USE_CLIENT_DEFAULT, telling httpx to use its own config
_timeout = ... else self.base_timeout()
timeout = _timeout if _timeout is not None else httpx.USE_CLIENT_DEFAULT
```
Applied in all 4 call sites: `HttpClient.request()`, `HttpClient.stream()`, `AsyncHttpClient.request()`, `AsyncHttpClient.stream()`.

**`generators/python/src/.../root_client_generator.py`** — the code that generates `client.py`:
```python
# Before: extracted httpx_client.timeout.read (lossy — drops connect/write/pool)
_defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else httpx_client.timeout.read

# After: stores None, signaling "defer to client defaults"
_defaulted_timeout = timeout if timeout is not None else 60 if httpx_client is None else None
```

**Behavior summary:**
| Scenario | Before | After |
|----------|--------|-------|
| No custom httpx_client | ✅ Uses configured default (60s) | ✅ Same |
| Custom httpx_client, no explicit timeout | ❌ Extracts `.read` only, loses connect/write/pool | ✅ Defers to httpx client's full Timeout config |
| Custom httpx_client + explicit timeout param | ✅ Uses provided timeout | ✅ Same |
| Per-request `timeout_in_seconds` in request_options | ✅ Overrides | ✅ Same |

## Testing
- [x] All 194 Python SDK seed tests pass
- [x] All 52 `test_http_client.py` unit tests pass
- [x] Pre-commit hooks (ruff, formatting) pass

Link to Devin session: https://app.devin.ai/sessions/30f8aeb6bbd14e8b8ae8b2a722756bd4
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->