### PR TITLE
fix(ci): add OIDC permissions to ir-release workflow

### DIFF
--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - "packages/ir-sdk/fern/apis/ir-types-latest/VERSION"
 
+permissions: # Required for OIDC
+  id-token: write
+  contents: read
+
 env:
   DO_NOT_TRACK: "1"
 


### PR DESCRIPTION
## Description

The `ir-release.yml` workflow's `dynamic-ir` job has been failing since ~run #78 because it lacks the `permissions: id-token: write` required for OIDC-based npm publishing. This is why `@fern-api/dynamic-ir-sdk` hasn't been published past 67.2.0 despite the IR being at 67.9.0.

Every other publish workflow in the repo (e.g. `publish-generator-csharp-sdk.yml`, `publish-generator-ts-sdk.yml`) has this permission block, but `ir-release.yml` was missing it.

## Changes Made

- Added `permissions: id-token: write` and `contents: read` at the workflow level in `ir-release.yml`, matching the pattern used by all other publish workflows

## Testing

- Verified all other `publish-generator-*.yml` workflows use the same `permissions` block with `# Required for OIDC` comment
- This is a CI-only change; correctness will be validated by re-running the workflow after merge

Link to Devin session: https://app.devin.ai/sessions/d14ad8da74e2419895c72616f19bd174
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->