### PR TITLE
fix(java): improve deserialization error handling and add RFC 2822 date support

### DIFF
--- a/generators/java/generator-utils/src/main/resources/DateTimeDeserializer.java
+++ b/generators/java/generator-utils/src/main/resources/DateTimeDeserializer.java
@@ -14,7 +14,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -44,9 +45,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
                         value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/generators/java/generator-utils/src/main/resources/PathPage.java
+++ b/generators/java/generator-utils/src/main/resources/PathPage.java
@@ -1,3 +1,4 @@
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -115,6 +116,8 @@ public final class PathPage {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new __API_EXCEPTION__(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new __BASE_EXCEPTION__("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new __BASE_EXCEPTION__("Network error executing HTTP request", e);
         }

--- a/generators/java/generator-utils/src/main/resources/UriPage.java
+++ b/generators/java/generator-utils/src/main/resources/UriPage.java
@@ -1,3 +1,4 @@
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -114,6 +115,8 @@ public final class UriPage {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new __API_EXCEPTION__(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new __BASE_EXCEPTION__("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new __BASE_EXCEPTION__("Network error executing HTTP request", e);
         }

--- a/generators/java/sdk/changes/unreleased/fix-deserialization-error-handling.yml
+++ b/generators/java/sdk/changes/unreleased/fix-deserialization-error-handling.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Fix misleading "Network error" message when deserialization fails. JSON deserialization
+    errors (e.g. unsupported date formats) are now reported as "Failed to deserialize response"
+    instead of being incorrectly wrapped as network errors.
+  type: fix
+- summary: |
+    Add RFC 1123 (RFC 2822) date format support to DateTimeDeserializer. Dates like
+    "Thu, 07 May 2026 14:23:38 +0000" are now parsed correctly.
+  type: fix

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AsyncHttpResponseParserGenerator.java
@@ -1,5 +1,6 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.ir.model.commons.ErrorId;
 import com.fern.ir.model.http.HttpEndpoint;
 import com.fern.java.client.ClientGeneratorContext;
@@ -216,6 +217,13 @@ public final class AsyncHttpResponseParserGenerator extends AbstractHttpResponse
         httpResponseBuilder.indent();
         onResponseWriter.accept(httpResponseBuilder);
         httpResponseBuilder
+                .beginControlFlow("catch ($T e)", JsonProcessingException.class)
+                .addStatement(
+                        "$L.completeExceptionally(new $T($S + e.getMessage(), e))",
+                        FUTURE,
+                        baseErrorClassName,
+                        "Failed to deserialize response: ")
+                .endControlFlow()
                 .beginControlFlow("catch ($T e)", IOException.class)
                 .addStatement(
                         "$L.completeExceptionally(new $T($S, e))",

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
@@ -274,9 +274,7 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
         httpResponseBuilder
                 .beginControlFlow("catch ($T e)", JsonProcessingException.class)
                 .addStatement(
-                        "throw new $T($S + e.getMessage(), e)",
-                        baseErrorClassName,
-                        "Failed to deserialize response: ")
+                        "throw new $T($S + e.getMessage(), e)", baseErrorClassName, "Failed to deserialize response: ")
                 .endControlFlow()
                 .beginControlFlow("catch ($T e)", IOException.class)
                 .addStatement("throw new $T($S, e)", baseErrorClassName, "Network error executing HTTP request")

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SyncHttpResponseParserGenerator.java
@@ -1,5 +1,6 @@
 package com.fern.java.client.generators.endpoint;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.ir.model.commons.ErrorId;
 import com.fern.ir.model.http.HttpEndpoint;
 import com.fern.java.client.ClientGeneratorContext;
@@ -271,6 +272,12 @@ public final class SyncHttpResponseParserGenerator extends AbstractHttpResponseP
     @Override
     public void addGenericFailureCodeBlock(CodeBlock.Builder httpResponseBuilder) {
         httpResponseBuilder
+                .beginControlFlow("catch ($T e)", JsonProcessingException.class)
+                .addStatement(
+                        "throw new $T($S + e.getMessage(), e)",
+                        baseErrorClassName,
+                        "Failed to deserialize response: ")
+                .endControlFlow()
                 .beginControlFlow("catch ($T e)", IOException.class)
                 .addStatement("throw new $T($S, e)", baseErrorClassName, "Network error executing HTTP request")
                 .endControlFlow()

--- a/seed/java-sdk/exhaustive/custom-client-class-name/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/.fern/metadata.json
@@ -7,8 +7,7 @@
     "client-class-name": "Best"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -171,6 +174,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -243,6 +249,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -316,6 +325,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -389,6 +401,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -463,6 +478,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -536,6 +554,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -621,6 +642,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -516,6 +530,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -97,6 +97,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -178,6 +181,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -79,6 +79,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -152,6 +155,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -224,6 +230,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -305,6 +314,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -366,6 +378,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -185,6 +188,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -257,6 +263,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -341,6 +350,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -415,6 +427,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -488,6 +503,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -560,6 +578,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -633,6 +654,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -706,6 +730,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -789,6 +816,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -874,6 +904,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -957,6 +990,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -102,6 +102,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -160,6 +162,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -217,6 +221,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -287,6 +293,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -347,6 +355,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -406,6 +416,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -464,6 +476,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -523,6 +537,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -582,6 +598,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -650,6 +668,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -721,6 +741,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -790,6 +812,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -115,6 +116,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -104,6 +104,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -173,6 +176,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -239,6 +245,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -306,6 +315,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -374,6 +386,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -442,6 +457,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -519,6 +537,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -596,6 +617,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -667,6 +691,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -782,6 +809,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -879,6 +909,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -948,6 +981,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -1027,6 +1063,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -150,6 +152,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -203,6 +207,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -257,6 +263,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -312,6 +320,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -367,6 +377,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -430,6 +442,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -494,6 +508,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -551,6 +567,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -651,6 +669,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -733,6 +753,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -788,6 +810,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -852,6 +876,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -160,6 +163,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -229,6 +235,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -299,6 +308,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -369,6 +381,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -440,6 +455,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -509,6 +527,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -578,6 +599,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -648,6 +672,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -79,6 +80,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -138,6 +142,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -199,6 +206,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -260,6 +270,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -211,6 +214,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -102,6 +102,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -185,6 +187,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -105,6 +105,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }
@@ -140,6 +144,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new BestApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new BestException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new BestException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.BestApiException;
 import com.seed.exhaustive.core.BestException;
 import com.seed.exhaustive.core.BestHttpResponse;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new BestApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new BestException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new BestException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/custom-dependency/.fern/metadata.json
@@ -9,8 +9,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -175,6 +178,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -243,6 +249,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -311,6 +320,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -381,6 +393,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -451,6 +466,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -529,6 +547,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -608,6 +629,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -680,6 +704,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -797,6 +824,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -895,6 +925,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -965,6 +998,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1045,6 +1081,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -151,6 +153,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -204,6 +208,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -258,6 +264,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -313,6 +321,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -368,6 +378,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -432,6 +444,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -496,6 +510,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -553,6 +569,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -653,6 +671,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -736,6 +756,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -791,6 +813,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -855,6 +879,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/custom-error-names/.fern/metadata.json
@@ -8,8 +8,7 @@
     "base-exception-class-name": "CustomException"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -172,6 +175,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -244,6 +250,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -317,6 +326,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -390,6 +402,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -465,6 +480,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -538,6 +556,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -624,6 +645,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -179,6 +182,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -153,6 +156,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -225,6 +231,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -306,6 +315,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -367,6 +379,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -185,6 +188,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -257,6 +263,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -342,6 +351,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -417,6 +429,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -491,6 +506,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -563,6 +581,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -638,6 +659,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -711,6 +735,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -794,6 +821,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -881,6 +911,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -964,6 +997,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -174,6 +177,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -241,6 +247,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -308,6 +317,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -377,6 +389,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -446,6 +461,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -523,6 +541,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -601,6 +622,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -672,6 +696,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -788,6 +815,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -885,6 +915,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -954,6 +987,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -1033,6 +1069,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -151,6 +153,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -204,6 +208,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -258,6 +264,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -313,6 +321,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -368,6 +378,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -432,6 +444,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -496,6 +510,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -553,6 +569,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -653,6 +671,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -736,6 +756,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -791,6 +813,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -855,6 +879,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -161,6 +164,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -231,6 +237,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -301,6 +310,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -371,6 +383,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -442,6 +457,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -512,6 +530,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -582,6 +603,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -652,6 +676,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -80,6 +81,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -138,6 +142,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -199,6 +206,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -260,6 +270,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -211,6 +214,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }
@@ -140,6 +144,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new CustomApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new CustomException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(new CustomException("Network error executing HTTP request", e));
                 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.CustomApiException;
 import com.seed.exhaustive.core.CustomException;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new CustomApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new CustomException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new CustomException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/custom-interceptors/.fern/metadata.json
@@ -6,8 +6,7 @@
     "custom-interceptors": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -191,6 +194,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -327,6 +336,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -397,6 +409,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -467,6 +482,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -545,6 +563,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -624,6 +645,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -696,6 +720,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -813,6 +840,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -911,6 +941,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -981,6 +1014,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1061,6 +1097,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -165,6 +167,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -218,6 +222,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -272,6 +278,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -327,6 +335,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -382,6 +392,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -446,6 +458,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -510,6 +524,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -567,6 +583,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -667,6 +685,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -750,6 +770,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -805,6 +827,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -869,6 +893,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -88,6 +89,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -78,6 +79,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/custom-license/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-java-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -191,6 +194,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -327,6 +336,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -397,6 +409,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -467,6 +482,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -545,6 +563,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -624,6 +645,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -696,6 +720,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -813,6 +840,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -911,6 +941,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -981,6 +1014,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1061,6 +1097,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -165,6 +167,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -218,6 +222,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -272,6 +278,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -327,6 +335,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -382,6 +392,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -446,6 +458,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -510,6 +524,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -567,6 +583,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -667,6 +685,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -750,6 +770,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -805,6 +827,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -869,6 +893,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -88,6 +89,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -78,6 +79,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/custom-plugins/.fern/metadata.json
@@ -10,8 +10,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -175,6 +178,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -243,6 +249,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -311,6 +320,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -381,6 +393,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -451,6 +466,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -529,6 +547,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -608,6 +629,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -680,6 +704,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -797,6 +824,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -895,6 +925,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -965,6 +998,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1045,6 +1081,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -151,6 +153,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -204,6 +208,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -258,6 +264,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -313,6 +321,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -368,6 +378,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -432,6 +444,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -496,6 +510,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -553,6 +569,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -653,6 +671,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -736,6 +756,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -791,6 +813,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -855,6 +879,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/.fern/metadata.json
@@ -7,8 +7,7 @@
     "enable-public-constructors": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -175,6 +178,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -243,6 +249,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -311,6 +320,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -381,6 +393,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -451,6 +466,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -529,6 +547,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -608,6 +629,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -680,6 +704,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -797,6 +824,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -895,6 +925,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -965,6 +998,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1045,6 +1081,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -151,6 +153,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -204,6 +208,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -258,6 +264,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -313,6 +321,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -368,6 +378,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -432,6 +444,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -496,6 +510,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -553,6 +569,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -653,6 +671,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -736,6 +756,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -791,6 +813,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -855,6 +879,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/flat-package-layout/.fern/metadata.json
@@ -7,8 +7,7 @@
     "use-default-request-parameter-values": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -191,6 +194,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -327,6 +336,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -397,6 +409,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -467,6 +482,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -545,6 +563,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -624,6 +645,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -696,6 +720,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -813,6 +840,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -911,6 +941,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -981,6 +1014,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1061,6 +1097,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -88,6 +89,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -165,6 +167,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -218,6 +222,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -272,6 +278,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -327,6 +335,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -382,6 +392,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -446,6 +458,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -510,6 +524,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -567,6 +583,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -667,6 +685,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -750,6 +770,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -805,6 +827,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -869,6 +893,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -78,6 +79,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/.fern/metadata.json
@@ -7,8 +7,7 @@
     "enable-forward-compatible-enums": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -175,6 +178,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -243,6 +249,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -311,6 +320,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -381,6 +393,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -451,6 +466,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -529,6 +547,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -608,6 +629,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -680,6 +704,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -797,6 +824,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -895,6 +925,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -965,6 +998,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1045,6 +1081,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -151,6 +153,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -204,6 +208,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -258,6 +264,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -313,6 +321,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -368,6 +378,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -432,6 +444,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -496,6 +510,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -553,6 +569,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -653,6 +671,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -736,6 +756,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -791,6 +813,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -855,6 +879,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/.fern/metadata.json
@@ -7,8 +7,7 @@
     "json-include": "non-empty"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -175,6 +178,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -243,6 +249,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -311,6 +320,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -381,6 +393,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -451,6 +466,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -529,6 +547,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -608,6 +629,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -680,6 +704,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -797,6 +824,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -895,6 +925,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -965,6 +998,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1045,6 +1081,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -151,6 +153,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -204,6 +208,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -258,6 +264,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -313,6 +321,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -368,6 +378,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -432,6 +444,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -496,6 +510,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -553,6 +569,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -653,6 +671,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -736,6 +756,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -791,6 +813,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -855,6 +879,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/local-files/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/local-files/.fern/metadata.json
@@ -7,7 +7,6 @@
     "package-prefix": "com.fern.sdk"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
-  "requestedVersion": "0.0.1",
-  "ciProvider": "github"
+  "invokedBy": "manual",
+  "requestedVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/core/DateTimeDeserializer.java
@@ -20,7 +20,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -50,9 +51,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
                         value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/container/AsyncRawContainerClient.java
@@ -92,6 +92,9 @@ public class AsyncRawContainerClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -153,6 +156,9 @@ public class AsyncRawContainerClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
+            }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
             }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -216,6 +222,9 @@ public class AsyncRawContainerClient {
                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                 return;
               }
+              catch (JsonProcessingException e) {
+                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+              }
               catch (IOException e) {
                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
               }
@@ -277,6 +286,9 @@ public class AsyncRawContainerClient {
                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                   return;
+                }
+                catch (JsonProcessingException e) {
+                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 }
                 catch (IOException e) {
                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -340,6 +352,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
                   }
+                  catch (JsonProcessingException e) {
+                    future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                  }
                   catch (IOException e) {
                     future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                   }
@@ -402,6 +417,9 @@ public class AsyncRawContainerClient {
                       future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                       return;
                     }
+                    catch (JsonProcessingException e) {
+                      future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                    }
                     catch (IOException e) {
                       future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                     }
@@ -463,6 +481,9 @@ public class AsyncRawContainerClient {
                         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                         future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                         return;
+                      }
+                      catch (JsonProcessingException e) {
+                        future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                       }
                       catch (IOException e) {
                         future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -538,6 +559,9 @@ public class AsyncRawContainerClient {
                           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                           future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                           return;
+                        }
+                        catch (JsonProcessingException e) {
+                          future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                         }
                         catch (IOException e) {
                           future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/container/RawContainerClient.java
@@ -82,6 +82,9 @@ public class RawContainerClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -130,6 +133,9 @@ public class RawContainerClient {
           }
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -180,6 +186,9 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
           }
+          catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+          }
           catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
           }
@@ -228,6 +237,9 @@ public class RawContainerClient {
               }
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+            }
+            catch (JsonProcessingException e) {
+              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
             }
             catch (IOException e) {
               throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -278,6 +290,9 @@ public class RawContainerClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
               }
+              catch (JsonProcessingException e) {
+                throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+              }
               catch (IOException e) {
                 throw new SeedExhaustiveException("Network error executing HTTP request", e);
               }
@@ -327,6 +342,9 @@ public class RawContainerClient {
                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                   throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                 }
+                catch (JsonProcessingException e) {
+                  throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                }
                 catch (IOException e) {
                   throw new SeedExhaustiveException("Network error executing HTTP request", e);
                 }
@@ -375,6 +393,9 @@ public class RawContainerClient {
                     }
                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                     throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                  }
+                  catch (JsonProcessingException e) {
+                    throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                   }
                   catch (IOException e) {
                     throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -437,6 +458,9 @@ public class RawContainerClient {
                       }
                       Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                       throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                    }
+                    catch (JsonProcessingException e) {
+                      throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                     }
                     catch (IOException e) {
                       throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -95,6 +95,9 @@ public class AsyncRawContentTypeClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -165,6 +168,9 @@ public class AsyncRawContentTypeClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
+            }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
             }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -84,6 +84,9 @@ public class RawContentTypeClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -140,6 +143,9 @@ public class RawContentTypeClient {
           String responseBodyString = responseBody != null ? responseBody.string() : "{}";
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -86,6 +86,9 @@ public class AsyncRawEnumClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/enum_/RawEnumClient.java
@@ -75,6 +75,9 @@ public class RawEnumClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -80,6 +80,9 @@ public class AsyncRawHttpMethodsClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -141,6 +144,9 @@ public class AsyncRawHttpMethodsClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
+            }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
             }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -204,6 +210,9 @@ public class AsyncRawHttpMethodsClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                 return;
+              }
+              catch (JsonProcessingException e) {
+                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
               }
               catch (IOException e) {
                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -278,6 +287,9 @@ public class AsyncRawHttpMethodsClient {
                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                   return;
                 }
+                catch (JsonProcessingException e) {
+                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                }
                 catch (IOException e) {
                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                 }
@@ -331,6 +343,9 @@ public class AsyncRawHttpMethodsClient {
                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                     future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                  }
+                  catch (JsonProcessingException e) {
+                    future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                   }
                   catch (IOException e) {
                     future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -69,6 +69,9 @@ public class RawHttpMethodsClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -117,6 +120,9 @@ public class RawHttpMethodsClient {
           }
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -167,6 +173,9 @@ public class RawHttpMethodsClient {
             }
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+          }
+          catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
           }
           catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -227,6 +236,9 @@ public class RawHttpMethodsClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
             }
+            catch (JsonProcessingException e) {
+              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+            }
             catch (IOException e) {
               throw new SeedExhaustiveException("Network error executing HTTP request", e);
             }
@@ -267,6 +279,9 @@ public class RawHttpMethodsClient {
                 }
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+              }
+              catch (JsonProcessingException e) {
+                throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
               }
               catch (IOException e) {
                 throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/object/AsyncRawObjectClient.java
@@ -108,6 +108,9 @@ public class AsyncRawObjectClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -170,6 +173,9 @@ public class AsyncRawObjectClient {
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
             }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+            }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
             }
@@ -231,6 +237,9 @@ public class AsyncRawObjectClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                 return;
+              }
+              catch (JsonProcessingException e) {
+                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
               }
               catch (IOException e) {
                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawObjectClient {
                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                   return;
                 }
+                catch (JsonProcessingException e) {
+                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                }
                 catch (IOException e) {
                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                 }
@@ -367,6 +379,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
                   }
+                  catch (JsonProcessingException e) {
+                    future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                  }
                   catch (IOException e) {
                     future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                   }
@@ -428,6 +443,9 @@ public class AsyncRawObjectClient {
                       Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                       future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                       return;
+                    }
+                    catch (JsonProcessingException e) {
+                      future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                     }
                     catch (IOException e) {
                       future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -491,6 +509,9 @@ public class AsyncRawObjectClient {
                         future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                         return;
                       }
+                      catch (JsonProcessingException e) {
+                        future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                      }
                       catch (IOException e) {
                         future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                       }
@@ -553,6 +574,9 @@ public class AsyncRawObjectClient {
                           future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                           return;
                         }
+                        catch (JsonProcessingException e) {
+                          future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                        }
                         catch (IOException e) {
                           future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                         }
@@ -614,6 +638,9 @@ public class AsyncRawObjectClient {
                             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                             return;
+                          }
+                          catch (JsonProcessingException e) {
+                            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                           }
                           catch (IOException e) {
                             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -685,6 +712,9 @@ public class AsyncRawObjectClient {
                               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                               return;
+                            }
+                            catch (JsonProcessingException e) {
+                              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                             }
                             catch (IOException e) {
                               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -760,6 +790,9 @@ public class AsyncRawObjectClient {
                                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                                 return;
                               }
+                              catch (JsonProcessingException e) {
+                                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                              }
                               catch (IOException e) {
                                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                               }
@@ -831,6 +864,9 @@ public class AsyncRawObjectClient {
                                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                                   return;
+                                }
+                                catch (JsonProcessingException e) {
+                                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                                 }
                                 catch (IOException e) {
                                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/object/RawObjectClient.java
@@ -97,6 +97,9 @@ public class RawObjectClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -146,6 +149,9 @@ public class RawObjectClient {
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
         }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+        }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -194,6 +200,9 @@ public class RawObjectClient {
             }
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+          }
+          catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
           }
           catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -254,6 +263,9 @@ public class RawObjectClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
             }
+            catch (JsonProcessingException e) {
+              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+            }
             catch (IOException e) {
               throw new SeedExhaustiveException("Network error executing HTTP request", e);
             }
@@ -304,6 +316,9 @@ public class RawObjectClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
               }
+              catch (JsonProcessingException e) {
+                throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+              }
               catch (IOException e) {
                 throw new SeedExhaustiveException("Network error executing HTTP request", e);
               }
@@ -352,6 +367,9 @@ public class RawObjectClient {
                   }
                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                   throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                }
+                catch (JsonProcessingException e) {
+                  throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                 }
                 catch (IOException e) {
                   throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -402,6 +420,9 @@ public class RawObjectClient {
                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                     throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                   }
+                  catch (JsonProcessingException e) {
+                    throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                  }
                   catch (IOException e) {
                     throw new SeedExhaustiveException("Network error executing HTTP request", e);
                   }
@@ -451,6 +472,9 @@ public class RawObjectClient {
                       Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                       throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                     }
+                    catch (JsonProcessingException e) {
+                      throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                    }
                     catch (IOException e) {
                       throw new SeedExhaustiveException("Network error executing HTTP request", e);
                     }
@@ -499,6 +523,9 @@ public class RawObjectClient {
                         }
                         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                      }
+                      catch (JsonProcessingException e) {
+                        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                       }
                       catch (IOException e) {
                         throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -557,6 +584,9 @@ public class RawObjectClient {
                           }
                           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                        }
+                        catch (JsonProcessingException e) {
+                          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                         }
                         catch (IOException e) {
                           throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -619,6 +649,9 @@ public class RawObjectClient {
                             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                           }
+                          catch (JsonProcessingException e) {
+                            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                          }
                           catch (IOException e) {
                             throw new SeedExhaustiveException("Network error executing HTTP request", e);
                           }
@@ -677,6 +710,9 @@ public class RawObjectClient {
                               }
                               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                            }
+                            catch (JsonProcessingException e) {
+                              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                             }
                             catch (IOException e) {
                               throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.QueryStringMapper;
@@ -123,6 +124,9 @@ public class AsyncRawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
+          }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
           }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/RawPaginationClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.QueryStringMapper;
@@ -101,6 +102,9 @@ public class RawPaginationClient {
         }
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+      }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
       }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/AsyncRawParamsClient.java
@@ -104,6 +104,9 @@ public class AsyncRawParamsClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -180,6 +183,9 @@ public class AsyncRawParamsClient {
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
             }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+            }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
             }
@@ -240,6 +246,9 @@ public class AsyncRawParamsClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                 return;
+              }
+              catch (JsonProcessingException e) {
+                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
               }
               catch (IOException e) {
                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -302,6 +311,9 @@ public class AsyncRawParamsClient {
                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                   return;
                 }
+                catch (JsonProcessingException e) {
+                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                }
                 catch (IOException e) {
                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                 }
@@ -363,6 +375,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
                   }
+                  catch (JsonProcessingException e) {
+                    future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                  }
                   catch (IOException e) {
                     future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                   }
@@ -423,6 +438,9 @@ public class AsyncRawParamsClient {
                       Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                       future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                       return;
+                    }
+                    catch (JsonProcessingException e) {
+                      future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                     }
                     catch (IOException e) {
                       future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -492,6 +510,9 @@ public class AsyncRawParamsClient {
                         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                         future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                         return;
+                      }
+                      catch (JsonProcessingException e) {
+                        future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                       }
                       catch (IOException e) {
                         future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -563,6 +584,9 @@ public class AsyncRawParamsClient {
                           future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                           return;
                         }
+                        catch (JsonProcessingException e) {
+                          future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                        }
                         catch (IOException e) {
                           future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                         }
@@ -623,6 +647,9 @@ public class AsyncRawParamsClient {
                             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                             return;
+                          }
+                          catch (JsonProcessingException e) {
+                            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                           }
                           catch (IOException e) {
                             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -727,6 +754,9 @@ public class AsyncRawParamsClient {
                               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                               return;
                             }
+                            catch (JsonProcessingException e) {
+                              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                            }
                             catch (IOException e) {
                               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                             }
@@ -814,6 +844,9 @@ public class AsyncRawParamsClient {
                                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                                 return;
                               }
+                              catch (JsonProcessingException e) {
+                                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                              }
                               catch (IOException e) {
                                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                               }
@@ -874,6 +907,9 @@ public class AsyncRawParamsClient {
                                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                                   return;
+                                }
+                                catch (JsonProcessingException e) {
+                                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                                 }
                                 catch (IOException e) {
                                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -944,6 +980,9 @@ public class AsyncRawParamsClient {
                                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                                     future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                                     return;
+                                  }
+                                  catch (JsonProcessingException e) {
+                                    future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                                   }
                                   catch (IOException e) {
                                     future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/RawParamsClient.java
@@ -94,6 +94,9 @@ public class RawParamsClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -157,6 +160,9 @@ public class RawParamsClient {
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
         }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+        }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -203,6 +209,9 @@ public class RawParamsClient {
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+          }
+          catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
           }
           catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -252,6 +261,9 @@ public class RawParamsClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
             }
+            catch (JsonProcessingException e) {
+              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+            }
             catch (IOException e) {
               throw new SeedExhaustiveException("Network error executing HTTP request", e);
             }
@@ -300,6 +312,9 @@ public class RawParamsClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
               }
+              catch (JsonProcessingException e) {
+                throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+              }
               catch (IOException e) {
                 throw new SeedExhaustiveException("Network error executing HTTP request", e);
               }
@@ -347,6 +362,9 @@ public class RawParamsClient {
                   String responseBodyString = responseBody != null ? responseBody.string() : "{}";
                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                   throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                }
+                catch (JsonProcessingException e) {
+                  throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                 }
                 catch (IOException e) {
                   throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -404,6 +422,9 @@ public class RawParamsClient {
                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                     throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                   }
+                  catch (JsonProcessingException e) {
+                    throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                  }
                   catch (IOException e) {
                     throw new SeedExhaustiveException("Network error executing HTTP request", e);
                   }
@@ -460,6 +481,9 @@ public class RawParamsClient {
                       Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                       throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                     }
+                    catch (JsonProcessingException e) {
+                      throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                    }
                     catch (IOException e) {
                       throw new SeedExhaustiveException("Network error executing HTTP request", e);
                     }
@@ -507,6 +531,9 @@ public class RawParamsClient {
                         }
                         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                      }
+                      catch (JsonProcessingException e) {
+                        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                       }
                       catch (IOException e) {
                         throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -598,6 +625,9 @@ public class RawParamsClient {
                           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                         }
+                        catch (JsonProcessingException e) {
+                          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                        }
                         catch (IOException e) {
                           throw new SeedExhaustiveException("Network error executing HTTP request", e);
                         }
@@ -672,6 +702,9 @@ public class RawParamsClient {
                             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                           }
+                          catch (JsonProcessingException e) {
+                            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                          }
                           catch (IOException e) {
                             throw new SeedExhaustiveException("Network error executing HTTP request", e);
                           }
@@ -719,6 +752,9 @@ public class RawParamsClient {
                               }
                               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                            }
+                            catch (JsonProcessingException e) {
+                              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                             }
                             catch (IOException e) {
                               throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -775,6 +811,9 @@ public class RawParamsClient {
                                 }
                                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                                 throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                              }
+                              catch (JsonProcessingException e) {
+                                throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                               }
                               catch (IOException e) {
                                 throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -90,6 +90,9 @@ public class AsyncRawPrimitiveClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -151,6 +154,9 @@ public class AsyncRawPrimitiveClient {
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
             }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+            }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
             }
@@ -211,6 +217,9 @@ public class AsyncRawPrimitiveClient {
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                 return;
+              }
+              catch (JsonProcessingException e) {
+                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
               }
               catch (IOException e) {
                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -274,6 +283,9 @@ public class AsyncRawPrimitiveClient {
                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                   return;
                 }
+                catch (JsonProcessingException e) {
+                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                }
                 catch (IOException e) {
                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                 }
@@ -335,6 +347,9 @@ public class AsyncRawPrimitiveClient {
                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                     future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                  }
+                  catch (JsonProcessingException e) {
+                    future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                   }
                   catch (IOException e) {
                     future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -398,6 +413,9 @@ public class AsyncRawPrimitiveClient {
                       future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                       return;
                     }
+                    catch (JsonProcessingException e) {
+                      future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                    }
                     catch (IOException e) {
                       future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                     }
@@ -459,6 +477,9 @@ public class AsyncRawPrimitiveClient {
                         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                         future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                         return;
+                      }
+                      catch (JsonProcessingException e) {
+                        future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                       }
                       catch (IOException e) {
                         future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -522,6 +543,9 @@ public class AsyncRawPrimitiveClient {
                           future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                           return;
                         }
+                        catch (JsonProcessingException e) {
+                          future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+                        }
                         catch (IOException e) {
                           future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
                         }
@@ -583,6 +607,9 @@ public class AsyncRawPrimitiveClient {
                             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                             return;
+                          }
+                          catch (JsonProcessingException e) {
+                            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                           }
                           catch (IOException e) {
                             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -80,6 +80,9 @@ public class RawPrimitiveClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -127,6 +130,9 @@ public class RawPrimitiveClient {
           }
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -176,6 +182,9 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
           }
+          catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+          }
           catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
           }
@@ -224,6 +233,9 @@ public class RawPrimitiveClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
             }
+            catch (JsonProcessingException e) {
+              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+            }
             catch (IOException e) {
               throw new SeedExhaustiveException("Network error executing HTTP request", e);
             }
@@ -271,6 +283,9 @@ public class RawPrimitiveClient {
                 }
                 Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                 throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+              }
+              catch (JsonProcessingException e) {
+                throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
               }
               catch (IOException e) {
                 throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -321,6 +336,9 @@ public class RawPrimitiveClient {
                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                   throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                 }
+                catch (JsonProcessingException e) {
+                  throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                }
                 catch (IOException e) {
                   throw new SeedExhaustiveException("Network error executing HTTP request", e);
                 }
@@ -368,6 +386,9 @@ public class RawPrimitiveClient {
                     }
                     Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                     throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                  }
+                  catch (JsonProcessingException e) {
+                    throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                   }
                   catch (IOException e) {
                     throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -417,6 +438,9 @@ public class RawPrimitiveClient {
                       Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                       throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
                     }
+                    catch (JsonProcessingException e) {
+                      throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+                    }
                     catch (IOException e) {
                       throw new SeedExhaustiveException("Network error executing HTTP request", e);
                     }
@@ -464,6 +488,9 @@ public class RawPrimitiveClient {
                         }
                         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+                      }
+                      catch (JsonProcessingException e) {
+                        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
                       }
                       catch (IOException e) {
                         throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/AsyncRawPutClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.RequestOptions;
@@ -86,6 +87,9 @@ public class AsyncRawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
+          }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
           }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/RawPutClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.RequestOptions;
@@ -74,6 +75,9 @@ public class RawPutClient {
         }
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+      }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
       }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/union/AsyncRawUnionClient.java
@@ -85,6 +85,9 @@ public class AsyncRawUnionClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/union/RawUnionClient.java
@@ -75,6 +75,9 @@ public class RawUnionClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.RequestOptions;
@@ -73,6 +74,9 @@ public class AsyncRawUrlsClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -125,6 +129,9 @@ public class AsyncRawUrlsClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
+            }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
             }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -179,6 +186,9 @@ public class AsyncRawUrlsClient {
                 future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                 return;
               }
+              catch (JsonProcessingException e) {
+                future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+              }
               catch (IOException e) {
                 future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
               }
@@ -231,6 +241,9 @@ public class AsyncRawUrlsClient {
                   Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
                   future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
                   return;
+                }
+                catch (JsonProcessingException e) {
+                  future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 }
                 catch (IOException e) {
                   future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/urls/RawUrlsClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.RequestOptions;
@@ -62,6 +63,9 @@ public class RawUrlsClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -100,6 +104,9 @@ public class RawUrlsClient {
           }
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);
@@ -140,6 +147,9 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
           }
+          catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+          }
           catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
           }
@@ -178,6 +188,9 @@ public class RawUrlsClient {
               }
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+            }
+            catch (JsonProcessingException e) {
+              throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
             }
             catch (IOException e) {
               throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -108,6 +108,9 @@ public class AsyncRawInlinedRequestsClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -194,6 +197,9 @@ public class AsyncRawInlinedRequestsClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
+            }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
             }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -97,6 +97,9 @@ public class RawInlinedRequestsClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -169,6 +172,9 @@ public class RawInlinedRequestsClient {
           }
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noauth/AsyncRawNoAuthClient.java
@@ -102,6 +102,9 @@ public class AsyncRawNoAuthClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noauth/RawNoAuthClient.java
@@ -91,6 +91,9 @@ public class RawNoAuthClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.RequestOptions;
@@ -76,6 +77,9 @@ public class AsyncRawNoReqBodyClient {
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
           }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
+          }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));
           }
@@ -128,6 +132,9 @@ public class AsyncRawNoReqBodyClient {
               Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
               future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
               return;
+            }
+            catch (JsonProcessingException e) {
+              future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
             }
             catch (IOException e) {
               future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/noreqbody/RawNoReqBodyClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.ObjectMappers;
 import com.fern.sdk.core.RequestOptions;
@@ -65,6 +66,9 @@ public class RawNoReqBodyClient {
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
       }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
+      }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);
       }
@@ -103,6 +107,9 @@ public class RawNoReqBodyClient {
           }
           Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
           throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+        }
+        catch (JsonProcessingException e) {
+          throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         }
         catch (IOException e) {
           throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.MediaTypes;
 import com.fern.sdk.core.ObjectMappers;
@@ -88,6 +89,9 @@ public class AsyncRawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             future.completeExceptionally(new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response));
             return;
+          }
+          catch (JsonProcessingException e) {
+            future.completeExceptionally(new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
           }
           catch (IOException e) {
             future.completeExceptionally(new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -4,6 +4,7 @@
 
 package com.fern.sdk.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fern.sdk.core.ClientOptions;
 import com.fern.sdk.core.MediaTypes;
 import com.fern.sdk.core.ObjectMappers;
@@ -77,6 +78,9 @@ public class RawReqWithHeadersClient {
         String responseBodyString = responseBody != null ? responseBody.string() : "{}";
         Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
         throw new SeedExhaustiveApiException("Error with status code " + response.code(), response.code(), errorBody, response);
+      }
+      catch (JsonProcessingException e) {
+        throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
       }
       catch (IOException e) {
         throw new SeedExhaustiveException("Network error executing HTTP request", e);

--- a/seed/java-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -191,6 +194,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -327,6 +336,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -397,6 +409,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -467,6 +482,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -545,6 +563,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -624,6 +645,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -696,6 +720,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -813,6 +840,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -911,6 +941,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -981,6 +1014,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1061,6 +1097,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -165,6 +167,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -218,6 +222,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -272,6 +278,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -327,6 +335,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -382,6 +392,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -446,6 +458,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -510,6 +524,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -567,6 +583,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -667,6 +685,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -750,6 +770,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -805,6 +827,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -869,6 +893,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -88,6 +89,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -78,6 +79,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/publish-to/.fern/metadata.json
@@ -6,8 +6,7 @@
     "publish-to": "central"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -191,6 +194,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -327,6 +336,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -397,6 +409,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -467,6 +482,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -545,6 +563,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -624,6 +645,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -696,6 +720,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -813,6 +840,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -911,6 +941,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -981,6 +1014,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1061,6 +1097,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -165,6 +167,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -218,6 +222,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -272,6 +278,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -327,6 +335,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -382,6 +392,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -446,6 +458,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -510,6 +524,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -567,6 +583,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -667,6 +685,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -750,6 +770,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -805,6 +827,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -869,6 +893,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -88,6 +89,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -78,6 +79,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/.fern/metadata.json
+++ b/seed/java-sdk/exhaustive/signed_publish/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-java-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/container/AsyncRawContainerClient.java
@@ -99,6 +99,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -173,6 +176,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -246,6 +252,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -320,6 +329,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -394,6 +406,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -470,6 +485,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -544,6 +562,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -631,6 +652,9 @@ public class AsyncRawContainerClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/container/RawContainerClient.java
@@ -88,6 +88,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -148,6 +150,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -206,6 +210,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -266,6 +272,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -325,6 +333,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -385,6 +395,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -445,6 +457,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -517,6 +531,8 @@ public class RawContainerClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/AsyncRawContentTypeClient.java
@@ -98,6 +98,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -180,6 +183,9 @@ public class AsyncRawContentTypeClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/contenttype/RawContentTypeClient.java
@@ -88,6 +88,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -154,6 +156,8 @@ public class RawContentTypeClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/AsyncRawEnumClient.java
@@ -90,6 +90,9 @@ public class AsyncRawEnumClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/enum_/RawEnumClient.java
@@ -80,6 +80,8 @@ public class RawEnumClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/AsyncRawHttpMethodsClient.java
@@ -82,6 +82,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -154,6 +157,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -227,6 +233,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -309,6 +318,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -371,6 +383,9 @@ public class AsyncRawHttpMethodsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/httpmethods/RawHttpMethodsClient.java
@@ -73,6 +73,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -130,6 +132,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -188,6 +192,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -254,6 +260,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -302,6 +310,8 @@ public class RawHttpMethodsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/object/AsyncRawObjectClient.java
@@ -113,6 +113,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -186,6 +189,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -345,6 +354,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -421,6 +433,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -496,6 +511,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -569,6 +587,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -645,6 +666,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -719,6 +743,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -803,6 +830,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -891,6 +921,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -975,6 +1008,9 @@ public class AsyncRawObjectClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/object/RawObjectClient.java
@@ -104,6 +104,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -163,6 +165,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -220,6 +224,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -290,6 +296,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -350,6 +358,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -409,6 +419,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -468,6 +480,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -527,6 +541,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -587,6 +603,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -656,6 +674,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -727,6 +747,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -796,6 +818,8 @@ public class RawObjectClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/AsyncRawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -134,6 +135,9 @@ public class AsyncRawPaginationClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/RawPaginationClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.pagination;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.QueryStringMapper;
@@ -116,6 +117,8 @@ public class RawPaginationClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/AsyncRawParamsClient.java
@@ -105,6 +105,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -191,6 +194,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -259,6 +265,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -327,6 +336,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -397,6 +409,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -467,6 +482,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -545,6 +563,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -624,6 +645,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -696,6 +720,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -813,6 +840,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -911,6 +941,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -981,6 +1014,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -1061,6 +1097,9 @@ public class AsyncRawParamsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/RawParamsClient.java
@@ -95,6 +95,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -165,6 +167,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -218,6 +222,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -272,6 +278,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -327,6 +335,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -382,6 +392,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -446,6 +458,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -510,6 +524,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -567,6 +583,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -667,6 +685,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -750,6 +770,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -805,6 +827,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -869,6 +893,8 @@ public class RawParamsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/AsyncRawPrimitiveClient.java
@@ -91,6 +91,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -162,6 +165,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -233,6 +239,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -304,6 +313,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -375,6 +387,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -447,6 +462,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -518,6 +536,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -589,6 +610,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -660,6 +684,9 @@ public class AsyncRawPrimitiveClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/primitive/RawPrimitiveClient.java
@@ -81,6 +81,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -137,6 +139,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -193,6 +197,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -249,6 +255,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -305,6 +313,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -362,6 +372,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -418,6 +430,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -474,6 +488,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -530,6 +546,8 @@ public class RawPrimitiveClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/AsyncRawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -88,6 +89,9 @@ public class AsyncRawPutClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/RawPutClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.put;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -78,6 +79,8 @@ public class RawPutClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/union/AsyncRawUnionClient.java
@@ -89,6 +89,9 @@ public class AsyncRawUnionClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/union/RawUnionClient.java
@@ -79,6 +79,8 @@ public class RawUnionClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/urls/AsyncRawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -77,6 +78,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -139,6 +143,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -201,6 +208,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -263,6 +273,9 @@ public class AsyncRawUrlsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/urls/RawUrlsClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.endpoints.urls;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -68,6 +69,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -116,6 +119,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -164,6 +169,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -212,6 +219,8 @@ public class RawUrlsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/inlinedrequests/AsyncRawInlinedRequestsClient.java
@@ -113,6 +113,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -212,6 +215,9 @@ public class AsyncRawInlinedRequestsClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/inlinedrequests/RawInlinedRequestsClient.java
@@ -103,6 +103,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -187,6 +189,8 @@ public class RawInlinedRequestsClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noauth/AsyncRawNoAuthClient.java
@@ -106,6 +106,9 @@ public class AsyncRawNoAuthClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noauth/RawNoAuthClient.java
@@ -95,6 +95,8 @@ public class RawNoAuthClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noreqbody/AsyncRawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -80,6 +81,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));
@@ -141,6 +145,9 @@ public class AsyncRawNoReqBodyClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/noreqbody/RawNoReqBodyClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.noreqbody;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.core.RequestOptions;
@@ -70,6 +71,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }
@@ -117,6 +120,8 @@ public class RawNoReqBodyClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/AsyncRawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -89,6 +90,9 @@ public class AsyncRawReqWithHeadersClient {
                     future.completeExceptionally(new SeedExhaustiveApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedExhaustiveException("Network error executing HTTP request", e));

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/RawReqWithHeadersClient.java
@@ -3,6 +3,7 @@
  */
 package com.seed.exhaustive.resources.reqwithheaders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seed.exhaustive.core.ClientOptions;
 import com.seed.exhaustive.core.MediaTypes;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -79,6 +80,8 @@ public class RawReqWithHeadersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedExhaustiveApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedExhaustiveException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedExhaustiveException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/pagination/default/.fern/metadata.json
+++ b/seed/java-sdk/pagination/default/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/AsyncRawComplexClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/AsyncRawComplexClient.java
@@ -127,6 +127,9 @@ public class AsyncRawComplexClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
@@ -109,6 +109,8 @@ public class RawComplexClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
@@ -156,6 +156,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -252,6 +255,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -358,6 +364,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -467,6 +476,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -577,6 +589,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -685,6 +700,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -791,6 +809,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -898,6 +919,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -991,6 +1015,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1089,6 +1116,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1184,6 +1214,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1279,6 +1312,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
@@ -141,6 +141,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -220,6 +222,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -306,6 +310,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -394,6 +400,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -482,6 +490,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -568,6 +578,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -652,6 +664,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -738,6 +752,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -811,6 +827,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -889,6 +907,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -961,6 +981,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1034,6 +1056,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
@@ -165,6 +165,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -261,6 +264,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -367,6 +373,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -489,6 +498,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -598,6 +610,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -708,6 +723,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -816,6 +834,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -922,6 +943,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1029,6 +1053,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1122,6 +1149,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1220,6 +1250,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1315,6 +1348,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1417,6 +1453,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1512,6 +1551,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1608,6 +1650,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1711,6 +1756,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
@@ -150,6 +150,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -229,6 +231,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -315,6 +319,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -419,6 +425,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -507,6 +515,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -595,6 +605,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -681,6 +693,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -765,6 +779,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -851,6 +867,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -924,6 +942,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1002,6 +1022,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1074,6 +1096,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1157,6 +1181,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1230,6 +1256,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1304,6 +1332,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1387,6 +1417,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/pagination/item-index-semantics/.fern/metadata.json
+++ b/seed/java-sdk/pagination/item-index-semantics/.fern/metadata.json
@@ -7,8 +7,7 @@
     "offset-semantics": "item-index"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/DateTimeDeserializer.java
@@ -19,7 +19,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 
 /**
- * Custom deserializer that handles converting ISO8601 dates into {@link OffsetDateTime} objects.
+ * Custom deserializer that handles converting date-time strings into {@link OffsetDateTime} objects.
+ * Supports ISO 8601 format, space-separated variants, and RFC 1123 (RFC 2822) format.
  */
 class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
     private static final SimpleModule MODULE;
@@ -48,9 +49,15 @@ class DateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
             try {
                 temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(value, OffsetDateTime::from, LocalDateTime::from);
             } catch (DateTimeParseException e) {
-                // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
-                temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
-                        value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                try {
+                    // Fall back to space-separated format (e.g. "2025-02-15 10:30:00+00:00").
+                    temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                            value.replace(' ', 'T'), OffsetDateTime::from, LocalDateTime::from);
+                } catch (DateTimeParseException e2) {
+                    // Fall back to RFC 1123 format (e.g. "Thu, 07 May 2026 14:23:38 +0000").
+                    temporal = DateTimeFormatter.RFC_1123_DATE_TIME.parseBest(
+                            value, OffsetDateTime::from, LocalDateTime::from);
+                }
             }
 
             if (temporal.query(TemporalQueries.offset()) == null) {

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/complex/AsyncRawComplexClient.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/complex/AsyncRawComplexClient.java
@@ -127,6 +127,9 @@ public class AsyncRawComplexClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/complex/RawComplexClient.java
@@ -109,6 +109,8 @@ public class RawComplexClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/AsyncRawInlineUsersClient.java
@@ -156,6 +156,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -252,6 +255,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -358,6 +364,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -467,6 +476,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -577,6 +589,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -685,6 +700,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -791,6 +809,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -898,6 +919,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -991,6 +1015,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1089,6 +1116,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1184,6 +1214,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1279,6 +1312,9 @@ public class AsyncRawInlineUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/RawInlineUsersClient.java
@@ -141,6 +141,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -220,6 +222,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -306,6 +310,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -394,6 +400,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -482,6 +490,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -568,6 +578,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -653,6 +665,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -740,6 +754,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -813,6 +829,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -891,6 +909,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -963,6 +983,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1036,6 +1058,8 @@ public class RawInlineUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/AsyncRawUsersClient.java
@@ -165,6 +165,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -261,6 +264,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -367,6 +373,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -489,6 +498,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -598,6 +610,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -708,6 +723,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -816,6 +834,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -922,6 +943,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1029,6 +1053,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1122,6 +1149,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1220,6 +1250,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1315,6 +1348,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1417,6 +1453,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1512,6 +1551,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1608,6 +1650,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));
@@ -1711,6 +1756,9 @@ public class AsyncRawUsersClient {
                     future.completeExceptionally(new SeedPaginationApiException(
                             "Error with status code " + response.code(), response.code(), errorBody, response));
                     return;
+                } catch (JsonProcessingException e) {
+                    future.completeExceptionally(
+                            new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e));
                 } catch (IOException e) {
                     future.completeExceptionally(
                             new SeedPaginationException("Network error executing HTTP request", e));

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/RawUsersClient.java
@@ -150,6 +150,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -229,6 +231,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -315,6 +319,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -419,6 +425,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -507,6 +515,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -595,6 +605,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -681,6 +693,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -766,6 +780,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -853,6 +869,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -926,6 +944,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1004,6 +1024,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1076,6 +1098,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1159,6 +1183,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1232,6 +1258,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1306,6 +1334,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }
@@ -1389,6 +1419,8 @@ public class RawUsersClient {
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
             throw new SeedPaginationApiException(
                     "Error with status code " + response.code(), response.code(), errorBody, response);
+        } catch (JsonProcessingException e) {
+            throw new SeedPaginationException("Failed to deserialize response: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new SeedPaginationException("Network error executing HTTP request", e);
         }


### PR DESCRIPTION
## Description

Fixes two related issues in the generated Java SDK:

1. **Misleading error message**: `JsonProcessingException` (a subclass of `IOException`) was being caught by the generic `catch (IOException e)` block and reported as "Network error executing HTTP request" — even though the actual issue was a deserialization failure. This made debugging extremely confusing.

2. **Missing RFC 2822 date support**: `DateTimeDeserializer` only supported ISO 8601 and space-separated ISO variants. APIs like Twilio return dates in RFC 2822 format (`Thu, 07 May 2026 14:23:38 +0000`) which caused parse failures that surfaced as the misleading network error above.

## Changes Made

- **`DateTimeDeserializer.java`** (resource template): Added a third fallback using `DateTimeFormatter.RFC_1123_DATE_TIME` to handle RFC 2822 dates like `Thu, 07 May 2026 14:23:38 +0000`
- **`SyncHttpResponseParserGenerator.java`**: Added `catch (JsonProcessingException e)` before `catch (IOException e)` with message `"Failed to deserialize response: " + e.getMessage()`
- **`AsyncHttpResponseParserGenerator.java`**: Same treatment in the `onResponse` callback's catch block
- **`PathPage.java` / `UriPage.java`**: Same `JsonProcessingException` → `IOException` ordering in pagination templates

Before this fix, a Twilio message fetch would throw:
```
TwilioApiException: Network error executing HTTP request
Caused by: JsonMappingException: Text 'Thu, 07 May 2026 14:23:38 +0000' could not be parsed
```

After this fix:
- The date parses successfully (RFC 2822 support)
- If another deserialization error occurs, it correctly reports: `"Failed to deserialize response: <details>"`

## Testing

- [x] `seed test --generator java-sdk --fixture exhaustive --skip-scripts` — 14/14 passed
- [x] `seed test --generator java-sdk --fixture pagination --skip-scripts` — 2/2 passed
- [x] Java generator Gradle compilation passes
- [x] Generated output verified: `JsonProcessingException` catch appears before `IOException` in all client methods

Link to Devin session: https://app.devin.ai/sessions/e58130b66f1a47109153c04d0971fcc5
Requested by: @iamnamananand996