### PR TITLE
fix(typescript): emit unquoted object keys for valid identifiers in dynamic snippets

### DIFF
--- a/generators/typescript-v2/ast/src/ast/TypeLiteral.ts
+++ b/generators/typescript-v2/ast/src/ast/TypeLiteral.ts
@@ -264,13 +264,25 @@ export class TypeLiteral extends AstNode {
         writer.writeLine("{");
         writer.indent();
         for (const entry of entries) {
-            entry.key.write(writer);
+            this.writeObjectKey({ writer, key: entry.key });
             writer.write(": ");
             entry.value.write(writer);
             writer.writeLine(",");
         }
         writer.dedent();
         writer.write("}");
+    }
+
+    private writeObjectKey({ writer, key }: { writer: Writer; key: TypeLiteral }): void {
+        const internal = key.internalType;
+        // Emit valid identifier string keys bare (e.g. `foo: `) to match typed
+        // object properties; anything else (non-identifier strings, numbers)
+        // falls back to the literal's own rendering (e.g. a quoted string).
+        if (internal.type === "string" && isValidIdentifier(internal.value)) {
+            writer.write(internal.value);
+            return;
+        }
+        key.write(writer);
     }
 
     private writeObject({ writer, object }: { writer: Writer; object: Object_ }): void {
@@ -435,13 +447,22 @@ export class TypeLiteral extends AstNode {
         writer.writeLine("{");
         writer.indent();
         for (const [key, val] of entries) {
-            writer.write(`${key}: `);
+            if (isValidIdentifier(key)) {
+                writer.write(`${key}: `);
+            } else {
+                writer.writeNode(TypeLiteral.string(key));
+                writer.write(": ");
+            }
             writer.writeNode(TypeLiteral.unknown(val));
             writer.writeLine(",");
         }
         writer.dedent();
         writer.write("}");
     }
+}
+
+function isValidIdentifier(value: string): boolean {
+    return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(value);
 }
 
 function filterNopObjectFields({ fields }: { fields: ObjectField[] }): ObjectField[] {

--- a/generators/typescript-v2/ast/src/ast/__test__/TypeLiteral.test.ts
+++ b/generators/typescript-v2/ast/src/ast/__test__/TypeLiteral.test.ts
@@ -111,4 +111,42 @@ World!\``);
             expect(await actual.toStringAsync({ customConfig: {} })).toMatchSnapshot();
         });
     });
+
+    describe("recordWithIdentifierKeysToString", () => {
+        it("Should emit valid identifier keys without quotes and quote the rest", async () => {
+            const actual = ts.codeblock((writer) => {
+                writer.write("let myRecord = ");
+                writer.writeNode(
+                    ts.TypeLiteral.record({
+                        entries: [
+                            {
+                                key: ts.TypeLiteral.string("validKey"),
+                                value: ts.TypeLiteral.number(1)
+                            },
+                            {
+                                key: ts.TypeLiteral.string("needs-quotes"),
+                                value: ts.TypeLiteral.number(2)
+                            }
+                        ]
+                    })
+                );
+            });
+            expect(await actual.toStringAsync({ customConfig: {} })).toMatchSnapshot();
+        });
+    });
+
+    describe("unknownObjectToString", () => {
+        it("Should emit valid identifier keys without quotes and quote the rest", async () => {
+            const actual = ts.codeblock((writer) => {
+                writer.write("let myUnknown = ");
+                writer.writeNode(
+                    ts.TypeLiteral.unknown({
+                        validKey: "a",
+                        "needs quotes": "b"
+                    })
+                );
+            });
+            expect(await actual.toStringAsync({ customConfig: {} })).toMatchSnapshot();
+        });
+    });
 });

--- a/generators/typescript-v2/ast/src/ast/__test__/__snapshots__/TypeLiteral.test.ts.snap
+++ b/generators/typescript-v2/ast/src/ast/__test__/__snapshots__/TypeLiteral.test.ts.snap
@@ -36,6 +36,13 @@ World!\\\`\`"
 
 exports[`TypeLiteral > numberToString > Should generate a simple number 1`] = `"7"`;
 
+exports[`TypeLiteral > recordWithIdentifierKeysToString > Should emit valid identifier keys without quotes and quote the rest 1`] = `
+"let myRecord = {
+    validKey: 1,
+    "needs-quotes": 2,
+}"
+`;
+
 exports[`TypeLiteral > simpleObjectToString > Should generate a simple object 1`] = `
 "let myObj = {
     name: "John Smith",
@@ -48,3 +55,10 @@ exports[`TypeLiteral > stringToString > Should generate a simple string literal 
 exports[`TypeLiteral > stringWithDoubleQuotesToString > Should generate a simple string literal with escaped double quotes 1`] = `""\\"Hello, World!\\"""`;
 
 exports[`TypeLiteral > trueBooleanToString > Should generate a true boolean 1`] = `"true"`;
+
+exports[`TypeLiteral > unknownObjectToString > Should emit valid identifier keys without quotes and quote the rest 1`] = `
+"let myUnknown = {
+    validKey: "a",
+    "needs quotes": "b",
+}"
+`;

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -59,9 +59,9 @@ async function main() {
             type: "movie",
             tag: "tag-12efs9dv",
             metadata: {
-                "academyAward": true,
-                "releaseDate": "2023-12-08",
-                "ratings": {
+                academyAward: true,
+                releaseDate: "2023-12-08",
+                ratings: {
                     rottenTomatoes: 97,
                     imdb: 7.6,
                 },
@@ -78,8 +78,8 @@ async function main() {
             type: "metadata",
             id: "event-12345",
             data: {
-                "key1": "val1",
-                "key2": "val2",
+                key1: "val1",
+                key2: "val2",
             },
             jsonString: "abc",
         },
@@ -122,13 +122,13 @@ async function main() {
         type: "movie",
         tag: "development",
         metadata: {
-            "actors": [
+            actors: [
                 "Christian Bale",
                 "Florence Pugh",
                 "Willem Dafoe",
             ],
-            "releaseDate": "2023-12-08",
-            "ratings": {
+            releaseDate: "2023-12-08",
+            ratings: {
                 rottenTomatoes: 97,
                 imdb: 7.6,
             },
@@ -251,10 +251,10 @@ async function main() {
         token: "<YOUR_API_KEY>",
     });
     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
-        "test": 0,
-        "test2": true,
-        "test3": "Test",
-        "test4": [
+        test: 0,
+        test2: true,
+        test3: "Test",
+        test4: [
             "1",
             "1",
             "1",

--- a/generators/typescript/sdk/changes/unreleased/fix-unquote-map-keys.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-unquote-map-keys.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Emit object keys without quotes in generated dynamic snippets when the key is
+    a valid JavaScript identifier. Previously, keys of maps and free-form objects
+    (e.g. `map<string, unknown>` values) were always quoted, producing inconsistent
+    output where `metadata: { "releaseDate": ... }` sat next to unquoted typed
+    properties. Keys that are not valid identifiers remain quoted.
+  type: fix


### PR DESCRIPTION
## Description

Follow-up to the Ruby unknown-type fix (#16733). In generated TypeScript dynamic snippets, keys of maps (`map<string, X>`) and free-form/unknown objects were always emitted as quoted strings, while typed object properties were emitted bare. This produced inconsistent output such as:

```ts
outputSchema: {
  "type": "object",          // map<string, unknown> key -> quoted
  properties: {
    score: { type: "integer" },   // nested unknown object key -> already bare
  },
  "required": ["score"],
  "additionalProperties": false,
},
parameters: {
  "scale": { type: "STRING" },     // map key -> quoted
},
```

Ruby/PHP already emit bare keys; Go (`map[string]any{"k": ...}`), C# (`["k"] = ...`), and Python (dict keys) require quotes and are unchanged.

## Changes Made

- `typescript-v2/ast` `TypeLiteral`: added a shared `isValidIdentifier` check.
  - `writeRecord` now emits string keys bare when they are valid JS identifiers (`/^[a-zA-Z_$][a-zA-Z0-9_$]*$/`), otherwise falls back to the quoted string literal.
  - `writeUnknownObject` now quotes keys that are **not** valid identifiers (previously it emitted every key bare, which could produce invalid TS for keys with spaces/dashes).
- Result: `{ "type": "object" }` → `{ type: "object" }`; keys like `"needs-quotes"` stay quoted.
- Added `TypeLiteral` unit tests covering both bare-identifier and quoted-non-identifier cases (record + unknown object).
- Regenerated affected dynamic-snippets test snapshots.
- Added a changelog entry under `generators/typescript/sdk/changes/unreleased/` (the published `fern-typescript-sdk` generator consumes `typescript-v2/dynamic-snippets`).

No `seed/ts-sdk` fixture output changed — regenerating all ts-sdk fixtures locally produced no snippet diffs (existing fixtures don't exercise a map with identifier keys), so CI seed tests are unaffected.

## Testing
- [x] Unit tests added/updated (`TypeLiteral.test.ts`, plus updated `DynamicSnippetsGenerator` snapshots) — TS v2 `ast` (32) and `dynamic-snippets` (33) suites pass
- [x] Regenerated all `ts-sdk` seed fixtures locally to confirm no unintended output changes
- [x] `biome check` clean on changed files


Link to Devin session: https://app.devin.ai/sessions/63d9a6a7c2c24ef8bed536b7579ae352
Requested by: @iamnamananand996