### PR TITLE
feat(cli): support custom URL slug per locale in docs.yml translations

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -4635,6 +4635,17 @@
             }
           ],
           "description": "Whether this language is the default. At most one entry should be marked as default."
+        },
+        "slug": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Custom URL slug to serve this locale under, instead of the locale code\n(e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...`). Must be a\nURL-safe segment and cannot be a recognized locale code."
         }
       },
       "required": [

--- a/fern-yml.schema.json
+++ b/fern-yml.schema.json
@@ -1794,6 +1794,10 @@
                   },
                   "default": {
                     "type": "boolean"
+                  },
+                  "slug": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
                   }
                 },
                 "required": [

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -38,6 +38,12 @@ types:
       default:
         type: optional<boolean>
         docs: Whether this language is the default. At most one entry should be marked as default.
+      slug:
+        type: optional<string>
+        docs: |
+          Custom URL slug to serve this locale under, instead of the locale code
+          (e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...`). Must be a
+          URL-safe segment and cannot be a recognized locale code.
 
   TranslationConfig:
     discriminated: false

--- a/packages/cli/cli/changes/unreleased/translations-slug-override.yml
+++ b/packages/cli/cli/changes/unreleased/translations-slug-override.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add an optional `slug` field to `translations` entries in `docs.yml`, letting a
+    localized site serve a locale under a custom URL segment (e.g. `lang: ja` with
+    `slug: jp` serves Japanese at `/jp/...`) while the locale still drives the
+    language identity (hreflang, `<html lang>`, switcher label, translated content
+    directory). Locales without a `slug` continue to use their own code as the URL
+    prefix, so existing sites are unaffected.
+
+    `fern check` now rejects a `slug` that would silently mis-route: a recognized
+    locale code (e.g. `ja`), another configured locale's code, or a slug already
+    used by another locale.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/translations-slug-override.yml
+++ b/packages/cli/cli/changes/unreleased/translations-slug-override.yml
@@ -8,7 +8,8 @@
     directory). Locales without a `slug` continue to use their own code as the URL
     prefix, so existing sites are unaffected.
 
-    `fern check` now rejects a `slug` that would silently mis-route: a recognized
-    locale code (e.g. `ja`), another configured locale's code, or a slug already
-    used by another locale.
+    `fern check` now rejects a `slug` that would silently mis-route: one that is
+    not a URL-safe segment (letters, digits, single hyphens), a recognized locale
+    code (e.g. `ja`), another configured locale's code, or a slug already used by
+    another locale.
   type: feat

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -47,6 +47,22 @@ export const Language = z
         "Language must be a valid BCP 47 language tag (e.g. 'en', 'ja', 'ja-JP', 'pt-BR', 'zh-Hans-CN')"
     );
 
+/**
+ * A single URL path segment used as a locale's public URL prefix.
+ *
+ * Unlike {@link Language}, this is intentionally NOT constrained to the BCP 47
+ * grammar — the whole point of a slug override is to let a site pick an
+ * arbitrary public URL for a locale (e.g. `jp`, `japan`, `v2`). It is only
+ * constrained to what makes a safe, unambiguous single path segment: URL-safe
+ * characters and no slashes, spaces, or empty values.
+ */
+export const LocaleUrlSlug = z
+    .string()
+    .regex(
+        /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/,
+        "slug must be a URL-safe path segment (letters, numbers, and single hyphens), e.g. 'jp'"
+    );
+
 export const PageActionOption = z.enum([
     "copy-page",
     "view-as-markdown",
@@ -956,7 +972,19 @@ export const ProductFileConfig = z.object({
 
 export const TranslationConfigObject = z.object({
     lang: Language,
-    default: z.boolean().optional()
+    default: z.boolean().optional(),
+    /**
+     * Overrides the URL path segment used for this locale. By default the
+     * locale (`lang`) doubles as its own URL prefix (e.g. `ja` → `/ja/...`).
+     * Set `slug` when a site wants a different public URL — e.g. a marketing
+     * team already publishes Japanese under `/jp` — without changing the
+     * locale's language identity (`lang` still drives hreflang, `<html lang>`,
+     * the language-switcher label, translated content directory, etc.).
+     *
+     * Any URL-safe single path segment (see {@link LocaleUrlSlug}) — it is not
+     * restricted to the BCP 47 language grammar.
+     */
+    slug: LocaleUrlSlug.optional()
 });
 
 export const TranslationConfig = z.union([Language, TranslationConfigObject]);
@@ -964,6 +992,7 @@ export const TranslationConfig = z.union([Language, TranslationConfigObject]);
 export function normalizeTranslationConfig(config: z.infer<typeof TranslationConfig>): {
     lang: string;
     default?: boolean;
+    slug?: string;
 } {
     if (typeof config === "string") {
         return { lang: config };

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -48,13 +48,9 @@ export const Language = z
     );
 
 /**
- * A single URL path segment used as a locale's public URL prefix.
- *
- * Unlike {@link Language}, this is intentionally NOT constrained to the BCP 47
- * grammar — the whole point of a slug override is to let a site pick an
- * arbitrary public URL for a locale (e.g. `jp`, `japan`, `v2`). It is only
- * constrained to what makes a safe, unambiguous single path segment: URL-safe
- * characters and no slashes, spaces, or empty values.
+ * A locale's public URL prefix. Unlike {@link Language} it is not BCP 47 — the
+ * point is an arbitrary public URL (e.g. `jp`, `japan`) — only a safe single
+ * path segment (URL-safe chars, no slashes/spaces/empties).
  */
 export const LocaleUrlSlug = z
     .string()
@@ -974,15 +970,10 @@ export const TranslationConfigObject = z.object({
     lang: Language,
     default: z.boolean().optional(),
     /**
-     * Overrides the URL path segment used for this locale. By default the
-     * locale (`lang`) doubles as its own URL prefix (e.g. `ja` → `/ja/...`).
-     * Set `slug` when a site wants a different public URL — e.g. a marketing
-     * team already publishes Japanese under `/jp` — without changing the
-     * locale's language identity (`lang` still drives hreflang, `<html lang>`,
-     * the language-switcher label, translated content directory, etc.).
-     *
-     * Any URL-safe single path segment (see {@link LocaleUrlSlug}) — it is not
-     * restricted to the BCP 47 language grammar.
+     * Overrides this locale's URL prefix (default: `lang` itself, e.g. `ja` →
+     * `/ja/...`). Set it for a different public URL (e.g. Japanese under `/jp`)
+     * without changing the language identity `lang` drives. Any URL-safe segment
+     * (see {@link LocaleUrlSlug}), not restricted to BCP 47.
      */
     slug: LocaleUrlSlug.optional()
 });

--- a/packages/cli/configuration/src/docs-yml/__test__/translations.test.ts
+++ b/packages/cli/configuration/src/docs-yml/__test__/translations.test.ts
@@ -46,6 +46,21 @@ describe("TranslationConfig schema", () => {
             expect(() => TranslationConfig.parse({ lang: "en", default: "yes" })).toThrow();
         });
 
+        it("should parse a translation entry with a slug override", () => {
+            const result = TranslationConfig.parse({ lang: "ja", slug: "jp" });
+            expect(typeof result === "string" ? undefined : result.lang).toBe("ja");
+            expect(typeof result === "string" ? undefined : result.slug).toBe("jp");
+        });
+
+        it("should leave slug undefined when not provided", () => {
+            const result = TranslationConfig.parse({ lang: "ja" });
+            expect(typeof result === "string" ? undefined : result.slug).toBeUndefined();
+        });
+
+        it("should reject an invalid slug", () => {
+            expect(() => TranslationConfig.parse({ lang: "ja", slug: "not a slug" })).toThrow();
+        });
+
         it("should accept all common language codes", () => {
             const langs = ["en", "es", "fr", "de", "it", "pt", "ja", "zh", "ko", "el", "no", "pl", "ru", "sv", "tr"];
             for (const lang of langs) {

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/TranslationConfigObject.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/TranslationConfigObject.ts
@@ -6,10 +6,4 @@ export interface TranslationConfigObject {
     lang: FernDocsConfig.Language;
     /** Whether this language is the default. At most one entry should be marked as default. */
     default?: boolean;
-    /**
-     * Overrides the URL path segment this locale is served under (e.g. `lang: ja`
-     * with `slug: jp` serves Japanese at `/jp/...`). Any URL-safe single segment;
-     * the locale keeps its language identity everywhere else. Defaults to `lang`.
-     */
-    slug?: string;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/TranslationConfigObject.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/TranslationConfigObject.ts
@@ -6,4 +6,10 @@ export interface TranslationConfigObject {
     lang: FernDocsConfig.Language;
     /** Whether this language is the default. At most one entry should be marked as default. */
     default?: boolean;
+    /**
+     * Overrides the URL path segment this locale is served under (e.g. `lang: ja`
+     * with `slug: jp` serves Japanese at `/jp/...`). Any URL-safe single segment;
+     * the locale keeps its language identity everywhere else. Defaults to `lang`.
+     */
+    slug?: string;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/TranslationConfigObject.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/TranslationConfigObject.ts
@@ -6,4 +6,10 @@ export interface TranslationConfigObject {
     lang: FernDocsConfig.Language;
     /** Whether this language is the default. At most one entry should be marked as default. */
     default?: boolean;
+    /**
+     * Custom URL slug to serve this locale under, instead of the locale code
+     * (e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...`). Must be a
+     * URL-safe segment and cannot be a recognized locale code.
+     */
+    slug?: string;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/TranslationConfigObject.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/TranslationConfigObject.ts
@@ -11,11 +11,13 @@ export const TranslationConfigObject: core.serialization.ObjectSchema<
 > = core.serialization.object({
     lang: Language,
     default: core.serialization.boolean().optional(),
+    slug: core.serialization.string().optional(),
 });
 
 export declare namespace TranslationConfigObject {
     export interface Raw {
         lang: Language.Raw;
         default?: boolean | null;
+        slug?: string | null;
     }
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/TranslationConfigObject.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/TranslationConfigObject.ts
@@ -11,13 +11,11 @@ export const TranslationConfigObject: core.serialization.ObjectSchema<
 > = core.serialization.object({
     lang: Language,
     default: core.serialization.boolean().optional(),
-    slug: core.serialization.string().optional(),
 });
 
 export declare namespace TranslationConfigObject {
     export interface Raw {
         lang: Language.Raw;
         default?: boolean | null;
-        slug?: string | null;
     }
 }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -57,6 +57,15 @@ interface LibraryNavNode {
 interface DocsTranslationsConfig {
     defaultLocale: string;
     translations: string[] | undefined;
+    /**
+     * Maps a locale to the URL path segment it should be served under, for
+     * locales that set a `slug` override in `docs.yml` (e.g. `{ ja: "jp" }` so
+     * Japanese is served at `/jp/...`). Absent/empty when every locale uses its
+     * own code as its URL prefix. Locales not present here fall back to using
+     * their own code as the prefix. The default locale is served unprefixed, so
+     * it never appears here.
+     */
+    localeSlugs: Record<string, string> | undefined;
 }
 
 // TODO: Remove this shim once the published @fern-api/fdr-sdk type for
@@ -355,9 +364,23 @@ export class DocsDefinitionResolver {
             return undefined;
         }
 
+        // Collect locale → URL-slug overrides. The default locale is served
+        // unprefixed so any slug on it is meaningless and skipped; a slug equal
+        // to the locale is the implicit default and adds nothing.
+        const localeSlugs: Record<string, string> = {};
+        for (const translation of normalizedTranslations) {
+            if (translation === defaultTranslation) {
+                continue;
+            }
+            if (translation.slug != null && translation.slug !== translation.lang) {
+                localeSlugs[translation.lang] = translation.slug;
+            }
+        }
+
         return {
             defaultLocale: defaultTranslation.lang,
-            translations: normalizedTranslations.map((translation) => translation.lang)
+            translations: normalizedTranslations.map((translation) => translation.lang),
+            localeSlugs: Object.keys(localeSlugs).length > 0 ? localeSlugs : undefined
         };
     }
     private collectedFileIds = new Map<AbsoluteFilePath, string>();

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -58,12 +58,9 @@ interface DocsTranslationsConfig {
     defaultLocale: string;
     translations: string[] | undefined;
     /**
-     * Maps a locale to the URL path segment it should be served under, for
-     * locales that set a `slug` override in `docs.yml` (e.g. `{ ja: "jp" }` so
-     * Japanese is served at `/jp/...`). Absent/empty when every locale uses its
-     * own code as its URL prefix. Locales not present here fall back to using
-     * their own code as the prefix. The default locale is served unprefixed, so
-     * it never appears here.
+     * Maps a locale to its custom URL segment from a `docs.yml` `slug` override
+     * (e.g. `{ ja: "jp" }`). Absent when every locale uses its own code; the
+     * default locale is served unprefixed and never appears here.
      */
     localeSlugs: Record<string, string> | undefined;
 }
@@ -364,9 +361,8 @@ export class DocsDefinitionResolver {
             return undefined;
         }
 
-        // Collect locale → URL-slug overrides. The default locale is served
-        // unprefixed so any slug on it is meaningless and skipped; a slug equal
-        // to the locale is the implicit default and adds nothing.
+        // Collect locale → URL-slug overrides, skipping the (unprefixed) default
+        // locale and any slug that just equals its own locale.
         const localeSlugs: Record<string, string> = {};
         for (const translation of normalizedTranslations) {
             if (translation === defaultTranslation) {

--- a/packages/cli/docs-resolver/src/__test__/translations-config.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/translations-config.test.ts
@@ -5,6 +5,7 @@ import { DocsDefinitionResolver } from "../DocsDefinitionResolver.js";
 interface DocsTranslationsConfig {
     defaultLocale: string;
     translations: string[] | undefined;
+    localeSlugs?: Record<string, string> | undefined;
 }
 
 interface DocsConfigWithTranslations {
@@ -15,6 +16,7 @@ function createResolverWithTranslations(
     translations: Array<{
         lang: string;
         default?: boolean;
+        slug?: string;
     }>
 ): DocsDefinitionResolver {
     const resolver = Object.create(DocsDefinitionResolver.prototype) as DocsDefinitionResolver;
@@ -56,9 +58,10 @@ function createResolverWithTranslations(
         title: undefined,
         translationPages: undefined,
         translations: translations.map((translation) => ({
-            // The resolver only reads `lang` and `default`.
+            // The resolver only reads `lang`, `default`, and `slug`.
             lang: translation.lang,
-            default: translation.default
+            default: translation.default,
+            slug: translation.slug
         })),
         typography: undefined
     });
@@ -104,5 +107,41 @@ describe("DocsDefinitionResolver translations config", () => {
             defaultLocale: "fr",
             translations: ["fr", "de"]
         });
+    });
+
+    it("emits locale → URL-slug overrides when a translation sets a slug", async () => {
+        const resolver = createResolverWithTranslations([
+            { lang: "en", default: true },
+            { lang: "ja", slug: "jp" }
+        ]);
+
+        const convertDocsConfiguration = Reflect.get(resolver, "convertDocsConfiguration") as (
+            root: object
+        ) => Promise<object>;
+
+        const config = await convertDocsConfiguration.call(resolver, { type: "root" });
+
+        expect(getTranslationsConfig(config)).toEqual({
+            defaultLocale: "en",
+            translations: ["en", "ja"],
+            localeSlugs: { ja: "jp" }
+        });
+    });
+
+    it("ignores a slug on the default locale and a slug equal to the locale", async () => {
+        const resolver = createResolverWithTranslations([
+            { lang: "en", default: true, slug: "us" },
+            { lang: "fr", slug: "fr" }
+        ]);
+
+        const convertDocsConfiguration = Reflect.get(resolver, "convertDocsConfiguration") as (
+            root: object
+        ) => Promise<object>;
+
+        const config = await convertDocsConfiguration.call(resolver, { type: "root" });
+
+        // Default-locale slug is meaningless (served unprefixed) and slug===lang
+        // adds nothing, so no localeSlugs map is emitted.
+        expect(getTranslationsConfig(config)?.localeSlugs).toBeUndefined();
     });
 });

--- a/packages/cli/workspace/loader/src/__test__/validateTranslationSlugs.test.ts
+++ b/packages/cli/workspace/loader/src/__test__/validateTranslationSlugs.test.ts
@@ -1,0 +1,124 @@
+import { type RawTranslationEntry, validateTranslationSlugs } from "../validateTranslationSlugs.js";
+
+describe("validateTranslationSlugs", () => {
+    describe("valid configurations", () => {
+        it("accepts a market-code slug that is not a locale (jp for ja)", () => {
+            expect(
+                validateTranslationSlugs([{ lang: "en", default: true }, { lang: "fr" }, { lang: "ja", slug: "jp" }])
+            ).toEqual([]);
+        });
+
+        it("accepts translations with no slugs", () => {
+            expect(validateTranslationSlugs([{ lang: "en", default: true }, { lang: "ja" }, { lang: "fr" }])).toEqual(
+                []
+            );
+        });
+
+        it("accepts the string (shorthand) syntax", () => {
+            expect(validateTranslationSlugs(["en", "ja", "fr"])).toEqual([]);
+        });
+
+        it("accepts undefined / empty translations", () => {
+            expect(validateTranslationSlugs(undefined)).toEqual([]);
+            expect(validateTranslationSlugs([])).toEqual([]);
+        });
+
+        it("ignores a slug that equals its own locale (case-insensitively)", () => {
+            expect(validateTranslationSlugs([{ lang: "ja", slug: "ja" }])).toEqual([]);
+            expect(validateTranslationSlugs([{ lang: "ja", slug: "JA" }])).toEqual([]);
+        });
+
+        it("accepts multiple distinct market-code slugs", () => {
+            expect(
+                validateTranslationSlugs([
+                    { lang: "en", default: true },
+                    { lang: "ja", slug: "jp" },
+                    { lang: "ko", slug: "kr" }
+                ])
+            ).toEqual([]);
+        });
+    });
+
+    describe("reserved locale code slugs are rejected", () => {
+        it("rejects a slug equal to a recognized locale code (ja)", () => {
+            const errors = validateTranslationSlugs([
+                { lang: "en", default: true },
+                { lang: "de", slug: "ja" }
+            ]);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain('slug "ja"');
+            expect(errors[0]).toContain("reserved locale code");
+        });
+
+        it("rejects reserved slugs case-insensitively (JA, EN, Fr)", () => {
+            expect(validateTranslationSlugs([{ lang: "de", slug: "JA" }])).toHaveLength(1);
+            expect(validateTranslationSlugs([{ lang: "de", slug: "EN" }])).toHaveLength(1);
+            expect(validateTranslationSlugs([{ lang: "de", slug: "Fr" }])).toHaveLength(1);
+        });
+
+        it("rejects regional and script locale codes as slugs (pt-BR, zh-Hans)", () => {
+            expect(validateTranslationSlugs([{ lang: "de", slug: "pt-BR" }])).toHaveLength(1);
+            expect(validateTranslationSlugs([{ lang: "de", slug: "zh-Hans" }])).toHaveLength(1);
+        });
+
+        // The two edge cases the customer asked about.
+        it("Scenario A: another locale borrowing `ja` while `ja` uses `jp`", () => {
+            const errors = validateTranslationSlugs([
+                { lang: "en", default: true },
+                { lang: "ja", slug: "jp" },
+                { lang: "ko", slug: "ja" }
+            ]);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain('slug "ja"');
+        });
+
+        it("Scenario B: an unrelated locale borrowing `ja` with no Japanese configured", () => {
+            const errors = validateTranslationSlugs([
+                { lang: "en", default: true },
+                { lang: "ko", slug: "ja" }
+            ]);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain('slug "ja"');
+        });
+    });
+
+    describe("collisions with configured locales are rejected", () => {
+        it("rejects a slug equal to another configured (non-reserved) locale", () => {
+            // `xh` (Xhosa) is a valid tag but not in the recognized set, so this
+            // exercises the "collides with another configured locale" branch
+            // rather than the reserved-code branch.
+            const errors = validateTranslationSlugs([{ lang: "xh" }, { lang: "en", default: true, slug: "xh" }]);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain("conflicts with another locale");
+        });
+    });
+
+    describe("duplicate slugs are rejected", () => {
+        it("rejects two locales sharing the same slug", () => {
+            const errors = validateTranslationSlugs([
+                { lang: "ja", slug: "jp" },
+                { lang: "ko", slug: "jp" }
+            ]);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain("used by more than one locale");
+        });
+
+        it("treats duplicate slugs case-insensitively", () => {
+            const errors = validateTranslationSlugs([
+                { lang: "ja", slug: "jp" },
+                { lang: "ko", slug: "JP" }
+            ]);
+            expect(errors).toHaveLength(1);
+        });
+    });
+
+    it("reports every offending slug independently", () => {
+        const errors = validateTranslationSlugs([
+            { lang: "en", default: true },
+            { lang: "de", slug: "ja" }, // reserved
+            { lang: "ko", slug: "kr" }, // valid
+            { lang: "it", slug: "kr" } // duplicate of ko's slug
+        ] as RawTranslationEntry[]);
+        expect(errors).toHaveLength(2);
+    });
+});

--- a/packages/cli/workspace/loader/src/__test__/validateTranslationSlugs.test.ts
+++ b/packages/cli/workspace/loader/src/__test__/validateTranslationSlugs.test.ts
@@ -39,6 +39,36 @@ describe("validateTranslationSlugs", () => {
         });
     });
 
+    describe("malformed slugs are rejected", () => {
+        it.each([
+            "my docs",
+            "en/us",
+            "jp.",
+            "jp!",
+            "-jp",
+            "jp-",
+            "jp--kr",
+            "",
+            "café"
+        ])("rejects slug %j as not URL-safe", (slug) => {
+            const errors = validateTranslationSlugs([
+                { lang: "en", default: true },
+                { lang: "ja", slug }
+            ]);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toContain("is not a valid URL slug");
+        });
+
+        it("accepts hyphenated non-locale market slugs (latam-1, apac-2)", () => {
+            expect(
+                validateTranslationSlugs([
+                    { lang: "de", slug: "latam-1" },
+                    { lang: "ja", slug: "apac-2" }
+                ])
+            ).toEqual([]);
+        });
+    });
+
     describe("reserved locale code slugs are rejected", () => {
         it("rejects a slug equal to a recognized locale code (ja)", () => {
             const errors = validateTranslationSlugs([

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4635,17 +4635,6 @@
             }
           ],
           "description": "Whether this language is the default. At most one entry should be marked as default."
-        },
-        "slug": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Overrides the URL path segment this locale is served under. By default the locale (`lang`) is its own URL prefix (e.g. `ja` → `/ja/...`). Set `slug` to serve it under a different public URL — e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...` — without changing the locale's language identity."
         }
       },
       "required": [

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4635,6 +4635,17 @@
             }
           ],
           "description": "Whether this language is the default. At most one entry should be marked as default."
+        },
+        "slug": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Custom URL slug to serve this locale under, instead of the locale code\n(e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...`). Must be a\nURL-safe segment and cannot be a recognized locale code."
         }
       },
       "required": [

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4635,6 +4635,17 @@
             }
           ],
           "description": "Whether this language is the default. At most one entry should be marked as default."
+        },
+        "slug": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Overrides the URL path segment this locale is served under. By default the locale (`lang`) is its own URL prefix (e.g. `ja` → `/ja/...`). Set `slug` to serve it under a different public URL — e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...` — without changing the locale's language identity."
         }
       },
       "required": [

--- a/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
@@ -8,6 +8,7 @@ import yaml from "js-yaml";
 
 import * as DocsYmlJsonSchema from "./docs-yml.schema.json";
 import { DocsWorkspace } from "./types/Workspace.js";
+import { type RawTranslationEntry, validateTranslationSlugs } from "./validateTranslationSlugs.js";
 
 export async function loadDocsWorkspace({
     fernDirectory,
@@ -95,9 +96,10 @@ export async function loadRawDocsConfiguration({
             context.logger.debug(`No null/undefined values found during sanitization`);
         }
 
+        let parsed: docsYml.RawSchemas.DocsConfiguration;
         try {
             context.logger.debug(`Attempting to parse sanitized docs configuration`);
-            return docsYml.RawSchemas.Serializer.DocsConfiguration.parseOrThrow(sanitizedJson);
+            parsed = docsYml.RawSchemas.Serializer.DocsConfiguration.parseOrThrow(sanitizedJson);
         } catch (err) {
             context.logger.error(`Parsing failed even after sanitization: ${extractErrorMessage(err)}`);
             // Log the JSON structure to debug
@@ -107,6 +109,21 @@ export async function loadRawDocsConfiguration({
                 code: CliError.Code.ParseError
             });
         }
+
+        // Semantic validation the JSON schema can't express: a translation `slug`
+        // must not collide with a recognized locale code, another configured
+        // locale, or another slug — otherwise it silently mis-routes at the edge.
+        // Fail `fern check` / generation with a clear message instead. (Kept
+        // outside the try above so this message isn't re-wrapped as a parse error.)
+        const slugErrors = validateTranslationSlugs(parsed.translations as RawTranslationEntry[] | undefined);
+        if (slugErrors.length > 0) {
+            throw new CliError({
+                message: `Invalid docs.yml:\n${slugErrors.join("\n")}`,
+                code: CliError.Code.ParseError
+            });
+        }
+
+        return parsed;
     } else {
         throw new CliError({
             message: `Failed to parse docs.yml:\n${result.error?.message ?? "Unknown error"}`,

--- a/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
@@ -110,11 +110,8 @@ export async function loadRawDocsConfiguration({
             });
         }
 
-        // Semantic validation the JSON schema can't express: a translation `slug`
-        // must not collide with a recognized locale code, another configured
-        // locale, or another slug — otherwise it silently mis-routes at the edge.
-        // Fail `fern check` / generation with a clear message instead. (Kept
-        // outside the try above so this message isn't re-wrapped as a parse error.)
+        // Semantic slug validation the JSON schema can't express. Kept outside the
+        // try above so the message isn't re-wrapped as a parse error.
         const slugErrors = validateTranslationSlugs(parsed.translations as RawTranslationEntry[] | undefined);
         if (slugErrors.length > 0) {
             throw new CliError({

--- a/packages/cli/workspace/loader/src/validateTranslationSlugs.ts
+++ b/packages/cli/workspace/loader/src/validateTranslationSlugs.ts
@@ -1,0 +1,196 @@
+/**
+ * Locale codes the docs platform recognizes as routable URL prefixes.
+ *
+ * This list MUST stay in sync, one-to-one, with `LOCALE_LABELS` in fern-platform
+ * (`packages/fern-docs/components/src/header/language-dropdown-utils.ts`) — that
+ * is the exact set the docs middleware matches URL path prefixes against
+ * (`KNOWN_LOCALES = Object.keys(LOCALE_LABELS)`).
+ *
+ * A translation `slug` override may NOT be one of these codes: the docs
+ * middleware resolves a recognized locale code to its locale at the edge, before
+ * any slug logic runs (it can't read the site config there). So a slug that
+ * collides with a locale code could never take effect and would silently
+ * mis-route. We reject such slugs at `fern check` / generation time instead.
+ */
+const RECOGNIZED_LOCALE_CODES: readonly string[] = [
+    "en",
+    "en-US",
+    "en-GB",
+    "en-AU",
+    "en-CA",
+    "en-IE",
+    "en-IN",
+    "en-NZ",
+    "fr",
+    "fr-FR",
+    "fr-CA",
+    "fr-BE",
+    "fr-CH",
+    "de",
+    "de-DE",
+    "de-AT",
+    "de-CH",
+    "it",
+    "it-IT",
+    "it-CH",
+    "ja",
+    "ja-JP",
+    "es",
+    "es-ES",
+    "es-MX",
+    "es-AR",
+    "es-CL",
+    "es-CO",
+    "es-419",
+    "ko",
+    "ko-KR",
+    "zh",
+    "zh-CN",
+    "zh-TW",
+    "zh-HK",
+    "zh-SG",
+    "zh-Hans",
+    "zh-Hant",
+    "ru",
+    "ru-RU",
+    "pt",
+    "pt-PT",
+    "pt-BR",
+    "nl",
+    "nl-NL",
+    "nl-BE",
+    "el",
+    "el-GR",
+    "no",
+    "nb",
+    "nn",
+    "nb-NO",
+    "nn-NO",
+    "pl",
+    "pl-PL",
+    "sv",
+    "sv-SE",
+    "tr",
+    "tr-TR",
+    "id",
+    "id-ID",
+    "da",
+    "da-DK",
+    "fi",
+    "fi-FI",
+    "cs",
+    "cs-CZ",
+    "sk",
+    "sk-SK",
+    "hu",
+    "hu-HU",
+    "ro",
+    "ro-RO",
+    "bg",
+    "bg-BG",
+    "hr",
+    "hr-HR",
+    "sr",
+    "sr-RS",
+    "sl",
+    "sl-SI",
+    "uk",
+    "uk-UA",
+    "ca",
+    "ca-ES",
+    "he",
+    "he-IL",
+    "ar",
+    "ar-SA",
+    "ar-EG",
+    "ar-AE",
+    "ar-MA",
+    "fa",
+    "fa-IR",
+    "ur",
+    "ur-PK",
+    "hi",
+    "hi-IN",
+    "bn",
+    "bn-BD",
+    "bn-IN",
+    "th",
+    "th-TH",
+    "vi",
+    "vi-VN",
+    "ms",
+    "ms-MY"
+];
+
+/**
+ * Locale prefix matching in the docs middleware is case-insensitive, so the
+ * reserved set is compared case-insensitively too.
+ */
+const RECOGNIZED_LOCALE_CODES_LOWER: ReadonlySet<string> = new Set(RECOGNIZED_LOCALE_CODES.map((c) => c.toLowerCase()));
+
+/** A `translations` entry as it appears in the raw docs.yml (string or object). */
+export type RawTranslationEntry = string | { lang: string; slug?: string | null; default?: boolean | null };
+
+function normalizeEntry(entry: RawTranslationEntry): { lang: string; slug: string | undefined } {
+    if (typeof entry === "string") {
+        return { lang: entry, slug: undefined };
+    }
+    return { lang: entry.lang, slug: entry.slug ?? undefined };
+}
+
+/**
+ * Validates the `slug` overrides on `translations`. Returns a list of
+ * human-readable error messages (empty when valid).
+ *
+ * A slug is rejected when it:
+ *  1. is a recognized locale code (would be intercepted by middleware as that
+ *     locale before the slug can take effect),
+ *  2. equals another translation's locale (`lang`) configured on the same site,
+ *  3. duplicates another translation's slug.
+ *
+ * A slug equal to its own locale (case-insensitively) is a harmless no-op and is
+ * ignored.
+ */
+export function validateTranslationSlugs(translations: readonly RawTranslationEntry[] | undefined): string[] {
+    if (translations == null || translations.length === 0) {
+        return [];
+    }
+
+    const normalized = translations.map(normalizeEntry);
+    const configuredLangs = new Set(normalized.map((t) => t.lang.toLowerCase()));
+    const slugOwnerByLower = new Map<string, string>();
+    const errors: string[] = [];
+
+    for (const { lang, slug } of normalized) {
+        if (slug == null || slug.toLowerCase() === lang.toLowerCase()) {
+            continue;
+        }
+        const slugLower = slug.toLowerCase();
+
+        if (RECOGNIZED_LOCALE_CODES_LOWER.has(slugLower)) {
+            errors.push(
+                `translations: slug "${slug}" (for locale "${lang}") is a reserved locale code and cannot be used as a URL slug. ` +
+                    `Choose a non-locale slug, e.g. a market/region code like "jp".`
+            );
+            continue;
+        }
+        if (configuredLangs.has(slugLower)) {
+            errors.push(
+                `translations: slug "${slug}" (for locale "${lang}") conflicts with another locale ("${slug}") configured on this site. ` +
+                    `A slug cannot equal another locale's code.`
+            );
+            continue;
+        }
+        const existingOwner = slugOwnerByLower.get(slugLower);
+        if (existingOwner != null) {
+            errors.push(
+                `translations: slug "${slug}" is used by more than one locale ("${existingOwner}" and "${lang}"). ` +
+                    `Each slug must be unique.`
+            );
+            continue;
+        }
+        slugOwnerByLower.set(slugLower, lang);
+    }
+
+    return errors;
+}

--- a/packages/cli/workspace/loader/src/validateTranslationSlugs.ts
+++ b/packages/cli/workspace/loader/src/validateTranslationSlugs.ts
@@ -1,16 +1,11 @@
 /**
- * Locale codes the docs platform recognizes as routable URL prefixes.
+ * Locale codes the docs platform recognizes as routable URL prefixes. A `slug`
+ * override may not be one of these: the edge middleware resolves them to a locale
+ * before any slug logic runs, so such a slug would silently mis-route.
  *
- * This list MUST stay in sync, one-to-one, with `LOCALE_LABELS` in fern-platform
- * (`packages/fern-docs/components/src/header/language-dropdown-utils.ts`) — that
- * is the exact set the docs middleware matches URL path prefixes against
- * (`KNOWN_LOCALES = Object.keys(LOCALE_LABELS)`).
- *
- * A translation `slug` override may NOT be one of these codes: the docs
- * middleware resolves a recognized locale code to its locale at the edge, before
- * any slug logic runs (it can't read the site config there). So a slug that
- * collides with a locale code could never take effect and would silently
- * mis-route. We reject such slugs at `fern check` / generation time instead.
+ * MUST stay in sync one-to-one with `LOCALE_LABELS` in fern-platform
+ * (`packages/fern-docs/components/src/header/language-dropdown-utils.ts`), the
+ * exact set middleware matches against.
  */
 const RECOGNIZED_LOCALE_CODES: readonly string[] = [
     "en",
@@ -129,11 +124,9 @@ const RECOGNIZED_LOCALE_CODES: readonly string[] = [
 const RECOGNIZED_LOCALE_CODES_LOWER: ReadonlySet<string> = new Set(RECOGNIZED_LOCALE_CODES.map((c) => c.toLowerCase()));
 
 /**
- * A slug becomes a single URL path segment, so it must be URL-safe: letters and
- * digits, joined by single hyphens (no spaces, slashes, dots, or other
- * punctuation). This mirrors `LocaleUrlSlug` in `DocsYmlSchemas.ts`, but that
- * zod schema is not on the production parse path (the SDK serializer accepts any
- * string), so the constraint is actually enforced here.
+ * A slug must be a URL-safe path segment: letters/digits joined by single
+ * hyphens. Mirrors `LocaleUrlSlug` in `DocsYmlSchemas.ts`, but that zod schema
+ * isn't on the production parse path, so the constraint is enforced here.
  */
 const URL_SLUG_PATTERN = /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/;
 

--- a/packages/cli/workspace/loader/src/validateTranslationSlugs.ts
+++ b/packages/cli/workspace/loader/src/validateTranslationSlugs.ts
@@ -128,6 +128,15 @@ const RECOGNIZED_LOCALE_CODES: readonly string[] = [
  */
 const RECOGNIZED_LOCALE_CODES_LOWER: ReadonlySet<string> = new Set(RECOGNIZED_LOCALE_CODES.map((c) => c.toLowerCase()));
 
+/**
+ * A slug becomes a single URL path segment, so it must be URL-safe: letters and
+ * digits, joined by single hyphens (no spaces, slashes, dots, or other
+ * punctuation). This mirrors `LocaleUrlSlug` in `DocsYmlSchemas.ts`, but that
+ * zod schema is not on the production parse path (the SDK serializer accepts any
+ * string), so the constraint is actually enforced here.
+ */
+const URL_SLUG_PATTERN = /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/;
+
 /** A `translations` entry as it appears in the raw docs.yml (string or object). */
 export type RawTranslationEntry = string | { lang: string; slug?: string | null; default?: boolean | null };
 
@@ -143,10 +152,11 @@ function normalizeEntry(entry: RawTranslationEntry): { lang: string; slug: strin
  * human-readable error messages (empty when valid).
  *
  * A slug is rejected when it:
- *  1. is a recognized locale code (would be intercepted by middleware as that
+ *  1. is not a URL-safe path segment (letters, digits, single hyphens),
+ *  2. is a recognized locale code (would be intercepted by middleware as that
  *     locale before the slug can take effect),
- *  2. equals another translation's locale (`lang`) configured on the same site,
- *  3. duplicates another translation's slug.
+ *  3. equals another translation's locale (`lang`) configured on the same site,
+ *  4. duplicates another translation's slug.
  *
  * A slug equal to its own locale (case-insensitively) is a harmless no-op and is
  * ignored.
@@ -163,6 +173,14 @@ export function validateTranslationSlugs(translations: readonly RawTranslationEn
 
     for (const { lang, slug } of normalized) {
         if (slug == null || slug.toLowerCase() === lang.toLowerCase()) {
+            continue;
+        }
+
+        if (!URL_SLUG_PATTERN.test(slug)) {
+            errors.push(
+                `translations: slug "${slug}" (for locale "${lang}") is not a valid URL slug. ` +
+                    `Use only letters, digits, and single hyphens (e.g. "jp" or "latam").`
+            );
             continue;
         }
         const slugLower = slug.toLowerCase();


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11520

Adds an optional `slug` to `translations` entries in `docs.yml`, letting a localized docs site serve a locale under a custom URL segment — e.g. `lang: ja` with `slug: jp` serves Japanese at `/jp/...` — while the locale keeps its language identity everywhere else (hreflang, `<html lang>`, the language-switcher label, the translated content directory).

This is the **CLI half**. The slug rides the existing publish pipeline: the resolver emits a `localeSlugs` map into the docs config, which is forwarded into the ledger config/manifest, and the docs frontend resolves it at render time (separate fern-platform PR: <link>). No Edge Config or dashboard step.

Locales without a `slug` are completely unaffected — they continue to use their own code as the URL prefix.

## Changes Made
- `docs.yml` schema: add optional `slug` (a URL-safe segment, not the BCP-47 grammar) to translation entries — updated the JSON schema (the validator), the generated serialization + API types, and the zod schema.
- Resolver: emit a `localeSlugs` (locale → slug) map into the docs config so it flows through the ledger publish pipeline into the manifest.
- `fern check` / generation validation: reject a `slug` that would silently mis-route — a recognized locale code (e.g. `ja`), another configured locale's code, or a slug already used by another locale. The reserved-locale set is copied one-to-one from fern-platform's `LOCALE_LABELS`.
- Changelog entry (`feat`).

## Testing
- [x] Unit tests added/updated — `validateTranslationSlugs` (15 cases incl. both conflict edge cases, regional/script codes, case-insensitivity, duplicates), plus translation schema + resolver `localeSlugs` tests.
- [x] Manual testing completed — built the prod CLI and ran `fern check` on a real docs project: `slug: jp` passes; `slug: en` fails with a clear reserved-locale error. Published to a dev FDR and confirmed `/jp/...` serves Japanese end-to-end via the fern-platform PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->