### PR TITLE
fix(ci): use FERN_NPM_TOKEN for dynamic-ir npm publish

### DIFF
--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Release SDKs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
         run: |
           cd packages/ir-sdk
           version=$(cat fern/apis/ir-types-latest/VERSION)

--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -24,7 +24,7 @@ groups:
         output:
           location: npm
           package-name: "@fern-api/dynamic-ir-sdk"
-          token: OIDC
+          token: ${NPM_TOKEN}
         config:
           noOptionalProperties: false
         smart-casing: false


### PR DESCRIPTION
## Description

The `dynamic-ir` job in `ir-release.yml` has been failing because it used `token: OIDC` for npm publishing, which doesn't work with remote generation (`fern generate` without `--local`). This switches to using the org-level `FERN_NPM_TOKEN` secret instead.

This is why `@fern-api/dynamic-ir-sdk` hasn't been published past 67.2.0 despite the IR being at 67.9.0.

## Changes Made

- `generators.yml`: Changed `token: OIDC` → `token: ${NPM_TOKEN}` for the `dynamic-ir` group
- `ir-release.yml`: Added `NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}` env var to the `dynamic-ir` job's Release SDKs step

## Testing

- CI-only change; correctness validated by re-running the workflow after merge via `workflow_dispatch`

Link to Devin session: https://app.devin.ai/sessions/d14ad8da74e2419895c72616f19bd174
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->