### PR TITLE
fix(cli-generator): tolerate array-wrapped schema objects in OpenAPI parser

### DIFF
--- a/generators/cli/changes/unreleased/fix-schema-property-array-tolerance.yml
+++ b/generators/cli/changes/unreleased/fix-schema-property-array-tolerance.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Fix OpenAPI parser crash when a schema property value is an array instead
+    of an object. Some Fern-processed specs (e.g. ElevenLabs) emit a
+    single-element array wrapping the real schema object. The parser now
+    unwraps single-element arrays and falls back to a default schema for
+    other non-object values, instead of aborting with "invalid type: sequence,
+    expected struct OpenApiSchemaObject".
+  type: fix

--- a/generators/cli/sdk/src/openapi/parser.rs
+++ b/generators/cli/sdk/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,136 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn property_value_single_element_array_unwrapped() {
+        // Some Fern-processed specs emit a property value as a
+        // single-element array wrapping the real schema object.
+        // The parser should unwrap it transparently.
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn property_value_multi_element_array_defaults() {
+        // Multi-element arrays at property positions fall back to an
+        // empty (default) schema instead of aborting the entire parse.
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /things:
+    get:
+      operationId: getThings
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: things
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok_field:
+                    type: string
+                  odd_field:
+                    - type: string
+                    - type: integer
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with multi-element array property should parse");
+        let things = doc.resources.get("things").expect("things resource");
+        assert!(
+            things.methods.values().any(|m| m.id.as_deref() == Some("getThings")),
+            "getThings method should exist",
+        );
+    }
+
+    #[test]
+    fn component_schema_as_array_tolerated() {
+        // A component schema whose value is a single-element array
+        // should be unwrapped, not crash the parser.
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/allof-inline/src/openapi/parser.rs
+++ b/seed/cli/allof-inline/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/allof/src/openapi/parser.rs
+++ b/seed/cli/allof/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/api-wide-base-path-with-default/src/openapi/parser.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/parser.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/cli-multi-spec/no-custom-config/src/openapi/parser.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/file-upload-openapi/src/openapi/parser.rs
+++ b/seed/cli/file-upload-openapi/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/imdb/src/openapi/parser.rs
+++ b/seed/cli/imdb/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/inline-enum-type-name-override/src/openapi/parser.rs
+++ b/seed/cli/inline-enum-type-name-override/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/multi-content-type-examples/src/openapi/parser.rs
+++ b/seed/cli/multi-content-type-examples/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/multi-url-environment-reference/src/openapi/parser.rs
+++ b/seed/cli/multi-url-environment-reference/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/no-content-response/src/openapi/parser.rs
+++ b/seed/cli/no-content-response/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/null-type/src/openapi/parser.rs
+++ b/seed/cli/null-type/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/nullable-allof-extends/src/openapi/parser.rs
+++ b/seed/cli/nullable-allof-extends/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/nullable-request-body/src/openapi/parser.rs
+++ b/seed/cli/nullable-request-body/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/oauth-client-credentials-openapi/src/openapi/parser.rs
+++ b/seed/cli/oauth-client-credentials-openapi/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/openapi-request-body-ref/src/openapi/parser.rs
+++ b/seed/cli/openapi-request-body-ref/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/openapi-subtitle/src/openapi/parser.rs
+++ b/seed/cli/openapi-subtitle/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/query-param-name-conflict/src/openapi/parser.rs
+++ b/seed/cli/query-param-name-conflict/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi-as-objects/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi/github-npm/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/schemaless-request-body-examples/src/openapi/parser.rs
+++ b/seed/cli/schemaless-request-body-examples/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/server-sent-events-openapi/src/openapi/parser.rs
+++ b/seed/cli/server-sent-events-openapi/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/server-url-templating/src/openapi/parser.rs
+++ b/seed/cli/server-url-templating/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/url-form-encoded/src/openapi/parser.rs
+++ b/seed/cli/url-form-encoded/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/webhook-audience/src/openapi/parser.rs
+++ b/seed/cli/webhook-audience/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }

--- a/seed/cli/x-fern-default/src/openapi/parser.rs
+++ b/seed/cli/x-fern-default/src/openapi/parser.rs
@@ -752,7 +752,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -964,6 +964,31 @@ where
     deserializer.deserialize_any(TypeVisitor)
 }
 
+/// Deserialize `properties` tolerantly: each value is normally a schema object,
+/// but some Fern-processed specs emit a single-element array wrapping the
+/// schema (e.g. `[{"x-fern-type-name": "Foo"}]`). Single-element arrays
+/// are unwrapped; other non-object values are replaced with an empty schema
+/// so parsing continues instead of aborting.
+fn deserialize_schema_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_yaml::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::with_capacity(raw.len());
+    for (key, value) in raw {
+        let schema_value = match &value {
+            serde_yaml::Value::Sequence(seq) if seq.len() == 1 => seq[0].clone(),
+            _ => value,
+        };
+        let schema = serde_yaml::from_value::<OpenApiSchemaObject>(schema_value)
+            .unwrap_or_default();
+        result.insert(key, schema);
+    }
+    Ok(result)
+}
+
 /// Deserialize `additionalProperties` which can be a boolean or a schema object.
 /// When it's `false`, we treat it as None. When `true`, we treat it as an empty schema.
 fn deserialize_additional_properties<'de, D>(
@@ -1011,7 +1036,7 @@ where
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_schema_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -10972,6 +10997,269 @@ components:
         assert!(
             schemas.contains_key("inline_op_response"),
             "inline schema must be stored in schemas map",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-value-as-array tolerance (ElevenLabs / Fern-processed specs)
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // deserialize_schema_properties: unit tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: deserialize a raw YAML mapping through `deserialize_schema_properties`
+    /// so we can test the deserializer in isolation without going through
+    /// the full spec parser.
+    fn deser_properties(yaml: &str) -> HashMap<String, OpenApiSchemaObject> {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_schema_properties")]
+            properties: HashMap<String, OpenApiSchemaObject>,
+        }
+        let w: Wrapper = serde_yaml::from_str(yaml).expect("YAML should parse");
+        w.properties
+    }
+
+    #[test]
+    fn schema_properties_normal_objects_pass_through() {
+        let props = deser_properties(
+            r#"
+properties:
+  name:
+    type: string
+    description: "a name"
+  count:
+    type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["name"].schema_type(), Some("string"));
+        assert_eq!(props["name"].description.as_deref(), Some("a name"));
+        assert_eq!(props["count"].schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_unwrapped() {
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - type: string
+      description: "unwrapped from array"
+"#,
+        );
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["state"].schema_type(), Some("string"));
+        assert_eq!(
+            props["state"].description.as_deref(),
+            Some("unwrapped from array"),
+        );
+    }
+
+    #[test]
+    fn schema_properties_single_element_array_with_fern_extension() {
+        // Exact pattern from ElevenLabs Fern-processed spec:
+        // property value is `[{"x-fern-type-name": "SpeechHistoryState"}]`
+        let props = deser_properties(
+            r#"
+properties:
+  state:
+    - x-fern-type-name: SpeechHistoryState
+"#,
+        );
+        assert_eq!(props.len(), 1, "state property should be present");
+        // The schema won't have a type but should exist as a valid schema object.
+        assert!(props.contains_key("state"));
+    }
+
+    #[test]
+    fn schema_properties_multi_element_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  good:
+    type: string
+  ambiguous:
+    - type: string
+    - type: integer
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["good"].schema_type(), Some("string"));
+        // Multi-element array can't be unambiguously unwrapped, so falls back
+        // to default (no type).
+        assert_eq!(props["ambiguous"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_empty_array_falls_back_to_default() {
+        let props = deser_properties(
+            r#"
+properties:
+  normal:
+    type: boolean
+  empty_arr: []
+"#,
+        );
+        assert_eq!(props.len(), 2);
+        assert_eq!(props["normal"].schema_type(), Some("boolean"));
+        assert_eq!(props["empty_arr"].schema_type(), None);
+    }
+
+    #[test]
+    fn schema_properties_mixed_normal_and_array_values() {
+        let props = deser_properties(
+            r#"
+properties:
+  id:
+    type: integer
+  tags:
+    type: array
+    items:
+      type: string
+  wrapped_status:
+    - type: string
+      description: "status field"
+  multi_wrap:
+    - type: string
+    - type: number
+"#,
+        );
+        assert_eq!(props.len(), 4);
+        assert_eq!(props["id"].schema_type(), Some("integer"));
+        assert_eq!(props["tags"].schema_type(), Some("array"));
+        assert_eq!(props["wrapped_status"].schema_type(), Some("string"));
+        assert_eq!(
+            props["wrapped_status"].description.as_deref(),
+            Some("status field"),
+        );
+        // multi-element array → default
+        assert_eq!(props["multi_wrap"].schema_type(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: full spec parsing with array-wrapped properties
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_spec_array_property_in_response_schema() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      x-fern-sdk-method-name: list
+      x-fern-sdk-group-name: items
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  normal_prop:
+                    type: string
+                  wrapped_prop:
+                    - type: integer
+                      description: "wrapped in array"
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("listItems")),
+            "listItems method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_array_property_in_request_body() {
+        let yaml = r#"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      x-fern-sdk-method-name: create
+      x-fern-sdk-group-name: items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                state:
+                  - type: string
+                    description: "array-wrapped in request body"
+      responses:
+        "201":
+          description: created
+"#;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued request body property should parse");
+        let items = doc.resources.get("items").expect("items resource");
+        assert!(
+            items.methods.values().any(|m| m.id.as_deref() == Some("createItem")),
+            "createItem method should exist",
+        );
+    }
+
+    #[test]
+    fn full_spec_component_schema_as_array_tolerated() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      x-fern-sdk-method-name: get
+      x-fern-sdk-group-name: foo
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Normal"
+components:
+  schemas:
+    Normal:
+      type: object
+      properties:
+        name:
+          type: string
+    Wrapped:
+      - type: object
+        properties:
+          state:
+            type: string
+"##;
+        let doc = load_openapi_spec(yaml, "t")
+            .expect("spec with array-valued component schema should parse");
+        assert!(
+            doc.schemas.contains_key("Normal"),
+            "Normal schema should be present",
         );
     }
 }


### PR DESCRIPTION
## Description

Fixes ElevenLabs CLI `--help` returning a 500 error: `"Failed to parse OpenAPI spec: invalid type: sequence, expected struct OpenApiSchemaObject"`.

Some Fern-processed OpenAPI specs emit property values as single-element arrays wrapping the real schema object (e.g. `[{"x-fern-type-name": "SpeechHistoryState"}]`) instead of the schema object directly. The serde `HashMap<String, OpenApiSchemaObject>` deserializer rejects these arrays.

## Changes Made

- Added `deserialize_schema_properties` custom deserializer in `generators/cli/sdk/src/openapi/parser.rs`:
  - Unwraps single-element arrays → contained schema object  
  - Falls back to `OpenApiSchemaObject::default()` for other non-object values (empty arrays, multi-element arrays)
- Applied to `OpenApiSchemaObject.properties` and `OpenApiComponents.schemas` fields
- Pattern follows existing `deserialize_additional_properties` approach

```rust
// Before: crashes on array values
#[serde(default)]
properties: HashMap<String, OpenApiSchemaObject>,

// After: tolerates array-wrapped values
#[serde(default, deserialize_with = "deserialize_schema_properties")]
properties: HashMap<String, OpenApiSchemaObject>,
```

- Regenerated all 28 CLI seed fixtures with updated parser.rs

## Testing

- [x] Unit tests added (9 new tests):
  - `schema_properties_normal_objects_pass_through` — regression: normal properties still work
  - `schema_properties_single_element_array_unwrapped` — verifies schema type + description survive unwrapping
  - `schema_properties_single_element_array_with_fern_extension` — exact ElevenLabs pattern with `x-fern-type-name`
  - `schema_properties_multi_element_array_falls_back_to_default` — graceful fallback
  - `schema_properties_empty_array_falls_back_to_default` — edge case
  - `schema_properties_mixed_normal_and_array_values` — mixed properties in one schema
  - `full_spec_array_property_in_response_schema` — end-to-end response parsing
  - `full_spec_array_property_in_request_body` — end-to-end request body parsing
  - `full_spec_component_schema_as_array_tolerated` — component-level schema tolerance
- [x] Full test suite passes (1718 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` passes clean

Link to Devin session: https://app.devin.ai/sessions/2aad7a08033b475faa8b20710a2f8647
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->