### PR TITLE
feat(typescript): implement SSE stream auto-reconnection for resumable endpoints

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/feat-sse-stream-reconnection.yml
+++ b/generators/typescript/sdk/changes/unreleased/feat-sse-stream-reconnection.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Implement SSE stream auto-reconnection for resumable endpoints. When an SSE
+    stream drops mid-connection and the endpoint is marked `resumable: true`, the
+    SDK now automatically reconnects using the Last-Event-ID header, honoring
+    server-sent retry directives clamped to 30 seconds. Reconnection respects
+    `reconnectionEnabled` and `maxReconnectionAttempts` options.
+  type: feat

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedStreamingEndpointImplementation.test.ts
@@ -440,6 +440,52 @@ describe("GeneratedStreamingEndpointImplementation", () => {
             const output = serializeStatements(stmts);
             expect(output).toMatchSnapshot();
         });
+
+        it("generates reconnect function for resumable SSE streaming endpoints", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.response = {
+                body: FernIr.HttpResponseBody.streaming(
+                    FernIr.StreamingResponse.sse({
+                        payload: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        terminator: "[[DONE]]",
+                        resumable: true,
+                        docs: undefined,
+                        v2Examples: undefined
+                    })
+                ),
+                statusCode: undefined,
+                isWildcardStatusCode: undefined,
+                docs: undefined
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockFileContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
+
+        it("does not generate reconnect function for non-resumable SSE endpoints", () => {
+            const endpoint = createHttpEndpoint();
+            endpoint.response = {
+                body: FernIr.HttpResponseBody.streaming(
+                    FernIr.StreamingResponse.sse({
+                        payload: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                        terminator: "[[DONE]]",
+                        resumable: false,
+                        docs: undefined,
+                        v2Examples: undefined
+                    })
+                ),
+                statusCode: undefined,
+                isWildcardStatusCode: undefined,
+                docs: undefined
+            };
+            const impl = createImpl({ endpoint });
+            const context = createMockFileContext();
+            const stmts = impl.invokeFetcher(context);
+            const output = serializeStatements(stmts);
+            expect(output).toMatchSnapshot();
+        });
     });
 
     describe("endpoint and response properties", () => {

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
@@ -9,6 +9,9 @@ const _reconnect = async (lastEventId: string) => {
     if (!_reconnectResponse.ok) {
         throw new Error("SSE stream reconnection failed");
     }
+    if (_reconnectResponse.body == null) {
+        throw new Error("SSE stream reconnection failed: empty response body");
+    }
     return _reconnectResponse.body;
 };"
 `;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedStreamingEndpointImplementation.test.ts.snap
@@ -1,5 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GeneratedStreamingEndpointImplementation > SSE response type > does not generate reconnect function for non-resumable SSE endpoints 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
+
+exports[`GeneratedStreamingEndpointImplementation > SSE response type > generates reconnect function for resumable SSE streaming endpoints 1`] = `
+"const _response = await this._options.fetcher.fetch({});
+const _reconnect = async (lastEventId: string) => {
+    const _reconnectResponse = await this._options.fetcher.fetch({});
+    if (!_reconnectResponse.ok) {
+        throw new Error("SSE stream reconnection failed");
+    }
+    return _reconnectResponse.body;
+};"
+`;
+
 exports[`GeneratedStreamingEndpointImplementation > SSE response type > uses sse response type for SSE streaming endpoints 1`] = `"const _response = await this._options.fetcher.fetch({});"`;
 
 exports[`GeneratedStreamingEndpointImplementation > SSE response type > uses sse response type for streamParameter SSE endpoints 1`] = `"const _response = await this._options.fetcher.fetch({});"`;

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
@@ -409,6 +409,28 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
                         true
                     )
                 ),
+                ts.factory.createIfStatement(
+                    ts.factory.createBinaryExpression(
+                        ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier(reconnectResponseVar),
+                            ts.factory.createIdentifier("body")
+                        ),
+                        ts.factory.createToken(ts.SyntaxKind.EqualsEqualsToken),
+                        ts.factory.createNull()
+                    ),
+                    ts.factory.createBlock(
+                        [
+                            ts.factory.createThrowStatement(
+                                ts.factory.createNewExpression(ts.factory.createIdentifier("Error"), undefined, [
+                                    ts.factory.createStringLiteral(
+                                        "SSE stream reconnection failed: empty response body"
+                                    )
+                                ])
+                            )
+                        ],
+                        true
+                    )
+                ),
                 ts.factory.createReturnStatement(
                     ts.factory.createPropertyAccessExpression(
                         ts.factory.createIdentifier(reconnectResponseVar),

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
@@ -265,6 +265,19 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
         return "streaming";
     }
 
+    /**
+     * Checks whether the endpoint is a resumable SSE stream.
+     *
+     * This reads the raw IR endpoint response body, which may be either
+     * `streaming` or `streamParameter`. Both cases are handled here because
+     * `invokeFetcher` uses this to decide whether to emit `const _reconnect`.
+     *
+     * In `GeneratedThrowingEndpointResponse`, the `streamParameter` variant
+     * is normalized to `HttpResponseBody.streaming(streamResponse)` before
+     * construction (see GeneratedSdkClientClassImpl.ts), so the reconnect
+     * options are wired through the `this.response?.type === "streaming"`
+     * branch for both cases.
+     */
     private isResumableSse(): boolean {
         const responseBody = this.endpoint.response?.body;
         if (responseBody?.type === "streaming" && responseBody.value.type === "sse") {
@@ -339,6 +352,17 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
         return statements;
     }
 
+    /**
+     * Generates the `_reconnect` arrow function that re-issues the original
+     * request with a `Last-Event-ID` header.
+     *
+     * TODO: Headers are resolved once at the original call site and reused
+     * verbatim on reconnect. For auth suppliers that return refreshing tokens,
+     * a long-lived stream that drops after the token expires will reconnect
+     * with a stale credential (resulting in a 401 treated as a failed reconnect
+     * attempt). A future enhancement should re-resolve headers on each
+     * reconnection to support token refresh.
+     */
     private generateReconnectFunction(context: FileContext, originalFetcherArgs: Fetcher.Args): ts.Statement {
         const lastEventIdParam = ts.factory.createParameterDeclaration(
             undefined,

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
@@ -17,6 +17,8 @@ import {
     getTimeoutExpression
 } from "./utils/requestOptionsParameter.js";
 
+export const RECONNECT_FUNCTION_VARIABLE_NAME = "_reconnect";
+
 export declare namespace GeneratedStreamingEndpointImplementation {
     export interface Init {
         packageId: PackageId;
@@ -263,6 +265,17 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
         return "streaming";
     }
 
+    private isResumableSse(): boolean {
+        const responseBody = this.endpoint.response?.body;
+        if (responseBody?.type === "streaming" && responseBody.value.type === "sse") {
+            return responseBody.value.resumable === true;
+        }
+        if (responseBody?.type === "streamParameter" && responseBody.streamResponse.type === "sse") {
+            return responseBody.streamResponse.resumable === true;
+        }
+        return false;
+    }
+
     public invokeFetcher(context: FileContext): ts.Statement[] {
         const fetcherArgs: Fetcher.Args = {
             ...this.request.getFetcherRequestArgs(context),
@@ -295,7 +308,7 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
                 : undefined
         };
 
-        return [
+        const statements: ts.Statement[] = [
             ts.factory.createVariableStatement(
                 undefined,
                 ts.factory.createVariableDeclarationList(
@@ -318,6 +331,119 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
                 )
             )
         ];
+
+        if (this.isResumableSse()) {
+            statements.push(this.generateReconnectFunction(context, fetcherArgs));
+        }
+
+        return statements;
+    }
+
+    private generateReconnectFunction(context: FileContext, originalFetcherArgs: Fetcher.Args): ts.Statement {
+        const lastEventIdParam = ts.factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            "lastEventId",
+            undefined,
+            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+        );
+
+        const headerElements: ts.ObjectLiteralElementLike[] = [];
+        if (originalFetcherArgs.headers != null) {
+            headerElements.push(ts.factory.createSpreadAssignment(originalFetcherArgs.headers));
+        }
+        headerElements.push(
+            ts.factory.createPropertyAssignment(
+                ts.factory.createStringLiteral("Last-Event-ID"),
+                ts.factory.createIdentifier("lastEventId")
+            )
+        );
+
+        const reconnectFetcherArgs: Fetcher.Args = {
+            ...originalFetcherArgs,
+            headers: ts.factory.createObjectLiteralExpression(headerElements, false)
+        };
+
+        const reconnectResponseVar = "_reconnectResponse";
+        const fetcherInvocation = context.coreUtilities.fetcher.fetcher._invoke(reconnectFetcherArgs, {
+            referenceToFetcher: this.generatedSdkClientClass.getReferenceToFetcher(context),
+            cast: getReadableTypeNode({
+                typeArgument: undefined,
+                context,
+                streamType: this.streamType
+            })
+        });
+
+        const body = ts.factory.createBlock(
+            [
+                ts.factory.createVariableStatement(
+                    undefined,
+                    ts.factory.createVariableDeclarationList(
+                        [
+                            ts.factory.createVariableDeclaration(
+                                reconnectResponseVar,
+                                undefined,
+                                undefined,
+                                fetcherInvocation
+                            )
+                        ],
+                        ts.NodeFlags.Const
+                    )
+                ),
+                ts.factory.createIfStatement(
+                    ts.factory.createPrefixUnaryExpression(
+                        ts.SyntaxKind.ExclamationToken,
+                        ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier(reconnectResponseVar),
+                            ts.factory.createIdentifier("ok")
+                        )
+                    ),
+                    ts.factory.createBlock(
+                        [
+                            ts.factory.createThrowStatement(
+                                ts.factory.createNewExpression(
+                                    ts.factory.createIdentifier("Error"),
+                                    undefined,
+                                    [ts.factory.createStringLiteral("SSE stream reconnection failed")]
+                                )
+                            )
+                        ],
+                        true
+                    )
+                ),
+                ts.factory.createReturnStatement(
+                    ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier(reconnectResponseVar),
+                        ts.factory.createIdentifier("body")
+                    )
+                )
+            ],
+            true
+        );
+
+        const reconnectArrowFn = ts.factory.createArrowFunction(
+            [ts.factory.createToken(ts.SyntaxKind.AsyncKeyword)],
+            undefined,
+            [lastEventIdParam],
+            undefined,
+            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            body
+        );
+
+        return ts.factory.createVariableStatement(
+            undefined,
+            ts.factory.createVariableDeclarationList(
+                [
+                    ts.factory.createVariableDeclaration(
+                        RECONNECT_FUNCTION_VARIABLE_NAME,
+                        undefined,
+                        undefined,
+                        reconnectArrowFn
+                    )
+                ],
+                ts.NodeFlags.Const
+            )
+        );
     }
 
     public getReferenceToRequestBody(context: FileContext): ts.Expression | undefined {

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/GeneratedStreamingEndpointImplementation.ts
@@ -401,11 +401,9 @@ export class GeneratedStreamingEndpointImplementation implements GeneratedEndpoi
                     ts.factory.createBlock(
                         [
                             ts.factory.createThrowStatement(
-                                ts.factory.createNewExpression(
-                                    ts.factory.createIdentifier("Error"),
-                                    undefined,
-                                    [ts.factory.createStringLiteral("SSE stream reconnection failed")]
-                                )
+                                ts.factory.createNewExpression(ts.factory.createIdentifier("Error"), undefined, [
+                                    ts.factory.createStringLiteral("SSE stream reconnection failed")
+                                ])
                             )
                         ],
                         true

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -865,51 +865,53 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                                             this.clientClass
                                         )
                                     }),
-                                    reconnectionEnabled: ts.factory.createBinaryExpression(
-                                        ts.factory.createPropertyAccessChain(
-                                            ts.factory.createPropertyAccessChain(
-                                                ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME),
-                                                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                                ts.factory.createIdentifier("stream")
-                                            ),
-                                            ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                            ts.factory.createIdentifier("reconnectionEnabled")
-                                        ),
-                                        ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                        ts.factory.createPropertyAccessChain(
-                                            ts.factory.createPropertyAccessChain(
-                                                this.clientClass.getReferenceToOptions(),
-                                                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                                ts.factory.createIdentifier("stream")
-                                            ),
-                                            ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                            ts.factory.createIdentifier("reconnectionEnabled")
-                                        )
-                                    ),
-                                    maxReconnectionAttempts: ts.factory.createBinaryExpression(
-                                        ts.factory.createPropertyAccessChain(
-                                            ts.factory.createPropertyAccessChain(
-                                                ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME),
-                                                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                                ts.factory.createIdentifier("stream")
-                                            ),
-                                            ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                            ts.factory.createIdentifier("maxReconnectionAttempts")
-                                        ),
-                                        ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                        ts.factory.createPropertyAccessChain(
-                                            ts.factory.createPropertyAccessChain(
-                                                this.clientClass.getReferenceToOptions(),
-                                                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                                ts.factory.createIdentifier("stream")
-                                            ),
-                                            ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                                            ts.factory.createIdentifier("maxReconnectionAttempts")
-                                        )
-                                    ),
-                                    reconnect: isResumableSse
-                                        ? ts.factory.createIdentifier(RECONNECT_FUNCTION_VARIABLE_NAME)
-                                        : undefined,
+                                    ...(isResumableSse
+                                        ? {
+                                              reconnectionEnabled: ts.factory.createBinaryExpression(
+                                                  ts.factory.createPropertyAccessChain(
+                                                      ts.factory.createPropertyAccessChain(
+                                                          ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME),
+                                                          ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                          ts.factory.createIdentifier("stream")
+                                                      ),
+                                                      ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                      ts.factory.createIdentifier("reconnectionEnabled")
+                                                  ),
+                                                  ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                                  ts.factory.createPropertyAccessChain(
+                                                      ts.factory.createPropertyAccessChain(
+                                                          this.clientClass.getReferenceToOptions(),
+                                                          ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                          ts.factory.createIdentifier("stream")
+                                                      ),
+                                                      ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                      ts.factory.createIdentifier("reconnectionEnabled")
+                                                  )
+                                              ),
+                                              maxReconnectionAttempts: ts.factory.createBinaryExpression(
+                                                  ts.factory.createPropertyAccessChain(
+                                                      ts.factory.createPropertyAccessChain(
+                                                          ts.factory.createIdentifier(REQUEST_OPTIONS_PARAMETER_NAME),
+                                                          ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                          ts.factory.createIdentifier("stream")
+                                                      ),
+                                                      ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                      ts.factory.createIdentifier("maxReconnectionAttempts")
+                                                  ),
+                                                  ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                                  ts.factory.createPropertyAccessChain(
+                                                      ts.factory.createPropertyAccessChain(
+                                                          this.clientClass.getReferenceToOptions(),
+                                                          ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                          ts.factory.createIdentifier("stream")
+                                                      ),
+                                                      ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                      ts.factory.createIdentifier("maxReconnectionAttempts")
+                                                  )
+                                              ),
+                                              reconnect: ts.factory.createIdentifier(RECONNECT_FUNCTION_VARIABLE_NAME)
+                                          }
+                                        : {}),
                                     parse: context.includeSerdeLayer
                                         ? ts.factory.createArrowFunction(
                                               [ts.factory.createToken(ts.SyntaxKind.AsyncKeyword)],

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -13,7 +13,10 @@ import { ErrorResolver } from "@fern-typescript/resolvers";
 import { ts } from "ts-morph";
 
 import { GeneratedSdkClientClassImpl } from "../../../GeneratedSdkClientClassImpl.js";
-import { GeneratedStreamingEndpointImplementation } from "../../GeneratedStreamingEndpointImplementation.js";
+import {
+    GeneratedStreamingEndpointImplementation,
+    RECONNECT_FUNCTION_VARIABLE_NAME
+} from "../../GeneratedStreamingEndpointImplementation.js";
 import { getAbortSignalExpression, REQUEST_OPTIONS_PARAMETER_NAME } from "../../utils/requestOptionsParameter.js";
 import { GeneratedEndpointResponse, PaginationResponseInfo } from "./GeneratedEndpointResponse.js";
 import {
@@ -815,15 +818,19 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                 )
             ];
         } else if (this.response?.type === "streaming") {
+            let isResumableSse = false;
             const eventShape = this.response.value._visit<Stream.MessageEventShape | Stream.SSEEventShape>({
-                sse: (sse) => ({
-                    type: "sse" as const,
-                    ...(sse.terminator != null
-                        ? { streamTerminator: ts.factory.createStringLiteral(sse.terminator) }
-                        : {}),
-                    ...this.getEventDiscriminator(sse.payload, context),
-                    ...(sse.resumable === true ? { resumable: ts.factory.createTrue() } : {})
-                }),
+                sse: (sse) => {
+                    isResumableSse = sse.resumable === true;
+                    return {
+                        type: "sse" as const,
+                        ...(sse.terminator != null
+                            ? { streamTerminator: ts.factory.createStringLiteral(sse.terminator) }
+                            : {}),
+                        ...this.getEventDiscriminator(sse.payload, context),
+                        ...(sse.resumable === true ? { resumable: ts.factory.createTrue() } : {})
+                    };
+                },
                 json: (json) => ({
                     type: "json",
                     messageTerminator: ts.factory.createStringLiteral(json.terminator ?? "\n")
@@ -900,6 +907,9 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                                             ts.factory.createIdentifier("maxReconnectionAttempts")
                                         )
                                     ),
+                                    reconnect: isResumableSse
+                                        ? ts.factory.createIdentifier(RECONNECT_FUNCTION_VARIABLE_NAME)
+                                        : undefined,
                                     parse: context.includeSerdeLayer
                                         ? ts.factory.createArrowFunction(
                                               [ts.factory.createToken(ts.SyntaxKind.AsyncKeyword)],

--- a/generators/typescript/utils/commons/src/core-utilities/Stream.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/Stream.ts
@@ -153,10 +153,7 @@ export class StreamImpl extends CoreUtility implements Stream {
                     }
                     if (reconnect != null) {
                         constructorProperties.push(
-                            ts.factory.createPropertyAssignment(
-                                ts.factory.createIdentifier("reconnect"),
-                                reconnect
-                            )
+                            ts.factory.createPropertyAssignment(ts.factory.createIdentifier("reconnect"), reconnect)
                         );
                     }
                     return ts.factory.createNewExpression(Stream.getExpression(), undefined, [

--- a/generators/typescript/utils/commons/src/core-utilities/Stream.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/Stream.ts
@@ -12,6 +12,7 @@ export interface Stream {
             signal: ts.Expression;
             reconnectionEnabled?: ts.Expression;
             maxReconnectionAttempts?: ts.Expression;
+            reconnect?: ts.Expression;
         }) => ts.Expression;
         _getReferenceToType: (response: ts.TypeNode) => ts.TypeNode;
     };
@@ -68,7 +69,8 @@ export class StreamImpl extends CoreUtility implements Stream {
                     eventShape,
                     signal,
                     reconnectionEnabled,
-                    maxReconnectionAttempts
+                    maxReconnectionAttempts,
+                    reconnect
                 }: {
                     stream: ts.Expression;
                     parse: ts.Expression;
@@ -76,6 +78,7 @@ export class StreamImpl extends CoreUtility implements Stream {
                     signal: ts.Expression;
                     reconnectionEnabled?: ts.Expression;
                     maxReconnectionAttempts?: ts.Expression;
+                    reconnect?: ts.Expression;
                 }): ts.Expression => {
                     const eventShapeProperties: ts.ObjectLiteralElementLike[] = [];
                     if (eventShape.type === "sse") {
@@ -145,6 +148,14 @@ export class StreamImpl extends CoreUtility implements Stream {
                             ts.factory.createPropertyAssignment(
                                 ts.factory.createIdentifier("maxReconnectionAttempts"),
                                 maxReconnectionAttempts
+                            )
+                        );
+                    }
+                    if (reconnect != null) {
+                        constructorProperties.push(
+                            ts.factory.createPropertyAssignment(
+                                ts.factory.createIdentifier("reconnect"),
+                                reconnect
                             )
                         );
                     }

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -29,8 +29,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -70,6 +72,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -140,7 +143,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -153,7 +155,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -189,7 +190,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -208,16 +208,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -237,7 +236,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -251,7 +249,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -290,16 +287,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -344,15 +340,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -217,11 +217,19 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {
+                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
+                // the next loop iteration will hit shouldReconnect and respect
+                // maxReconnectionAttempts.
+                continue;
+            }
         }
     }
 
@@ -296,11 +304,19 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {
+                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
+                // the next loop iteration will hit shouldReconnect and respect
+                // maxReconnectionAttempts.
+                continue;
+            }
         }
     }
 

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -100,6 +100,8 @@ export class Stream<T> implements AsyncIterable<T> {
     <% } %>
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({ stream, parse, eventShape, signal, reconnectionEnabled, maxReconnectionAttempts, reconnect }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
@@ -117,7 +119,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -223,11 +229,16 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
             } catch {
-                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
-                // the next loop iteration will hit shouldReconnect and respect
-                // maxReconnectionAttempts.
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
                 continue;
             }
         }
@@ -310,11 +321,16 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
             } catch {
-                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
-                // the next loop iteration will hit shouldReconnect and respect
-                // maxReconnectionAttempts.
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
                 continue;
             }
         }
@@ -335,6 +351,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -381,11 +405,32 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+<% if (streamType === "wrapper") { %>
+    private createEmptyStream(): Readable {
+        return new Readable({ read() { this.push(null); } });
+    }
+<% } else { %>
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({ start(controller) { controller.close(); } });
+    }
+<% } %>
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             }
         };
     }
@@ -405,8 +450,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -33,6 +33,15 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+        <% if (streamType === "wrapper") { %>
+        reconnect?: (lastEventId: string) => Promise<Readable | ReadableStream>;
+        <% } else { %>
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
+        <% } %>
     }
 
     interface JsonEvent {
@@ -60,6 +69,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     <% if (streamType === "wrapper") { %>
     private stream: Readable | ReadableStream;
@@ -75,16 +87,18 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+    <% if (streamType === "wrapper") { %>
+    private reconnect: ((lastEventId: string) => Promise<Readable | ReadableStream>) | undefined;
+    <% } else { %>
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+    <% } %>
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
-    constructor({ stream, parse, eventShape, signal, reconnectionEnabled, maxReconnectionAttempts }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
+    constructor({ stream, parse, eventShape, signal, reconnectionEnabled, maxReconnectionAttempts, reconnect }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
         if (eventShape.type === "sse") {
@@ -98,7 +112,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -116,127 +131,172 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            currentStream = await this.reconnect!(lastId!);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            currentStream = await this.reconnect!(lastId!);
         }
     }
 
@@ -248,6 +308,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -218,7 +218,11 @@ export class Stream<T> implements AsyncIterable<T> {
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
-            currentStream = await this.reconnect!(lastId!);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -296,7 +300,11 @@ export class Stream<T> implements AsyncIterable<T> {
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
-            currentStream = await this.reconnect!(lastId!);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -354,13 +354,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/stream/Stream.template.ts
@@ -143,6 +143,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -165,6 +172,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -200,6 +208,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -211,10 +220,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -225,11 +235,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -248,6 +258,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -271,6 +285,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -302,11 +317,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -317,11 +333,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -1,0 +1,720 @@
+/**
+ * End-to-end test for SSE stream auto-reconnection.
+ *
+ * This test spins up a real HTTP server that serves SSE events and simulates
+ * connection drops. It verifies that the Stream class transparently reconnects
+ * using the Last-Event-ID header, just as a generated SDK would in production.
+ *
+ * Run with: npx tsx --test tests/e2e/sse-reconnection.test.ts
+ */
+import http from "node:http";
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+// ---------------------------------------------------------------------------
+// Inline Stream class (compiled from Stream.template.ts, "standard" web variant)
+// This avoids import issues with the template EJS syntax.
+// ---------------------------------------------------------------------------
+
+declare namespace Stream {
+    interface Args {
+        stream: ReadableStream;
+        eventShape: JsonEvent | SseEvent;
+        signal?: AbortSignal;
+        reconnectionEnabled?: boolean;
+        maxReconnectionAttempts?: number;
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
+    }
+
+    interface JsonEvent {
+        type: "json";
+        messageTerminator: string;
+    }
+
+    interface SseEvent {
+        type: "sse";
+        streamTerminator?: string;
+        eventDiscriminator?: string;
+        resumable?: boolean;
+    }
+}
+
+interface ServerSentEvent<T> {
+    data: T;
+    id?: string;
+    retry?: number;
+    event?: string;
+}
+
+const DATA_PREFIX = "data:";
+const EVENT_PREFIX = "event:";
+const ID_PREFIX = "id:";
+const RETRY_PREFIX = "retry:";
+
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+function fromJson(json: string): unknown {
+    return JSON.parse(json);
+}
+
+class Stream<T> implements AsyncIterable<T> {
+    private stream: ReadableStream;
+    private parse: (val: unknown) => Promise<T>;
+    private prefix: string | undefined;
+    private messageTerminator: string;
+    private streamTerminator: string | undefined;
+    private eventDiscriminator: string | undefined;
+    private resumable: boolean;
+    private reconnectionEnabled: boolean;
+    private maxReconnectionAttempts: number;
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+    private controller: AbortController = new AbortController();
+    private decoder: TextDecoder | undefined;
+
+    constructor({
+        stream,
+        parse,
+        eventShape,
+        signal,
+        reconnectionEnabled,
+        maxReconnectionAttempts,
+        reconnect,
+    }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
+        this.stream = stream;
+        this.parse = parse;
+        if (eventShape.type === "sse") {
+            this.prefix = DATA_PREFIX;
+            this.messageTerminator = "\n";
+            this.streamTerminator = eventShape.streamTerminator;
+            this.eventDiscriminator = eventShape.eventDiscriminator;
+            this.resumable = eventShape.resumable ?? false;
+        } else {
+            this.messageTerminator = eventShape.messageTerminator;
+            this.resumable = false;
+        }
+        this.reconnectionEnabled = reconnectionEnabled ?? true;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
+        signal?.addEventListener("abort", () => this.controller.abort());
+
+        if (typeof TextDecoder !== "undefined") {
+            this.decoder = new TextDecoder("utf-8");
+        }
+    }
+
+    private async *iterMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
+        if (this.eventDiscriminator != null) {
+            yield* this.iterSseEvents();
+        } else {
+            yield* this.iterDataMessages();
+        }
+    }
+
+    private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
+        let reconnectAttempts = 0;
+        let currentStream: ReadableStream = this.stream;
+        let lastId: string | undefined;
+        let lastRetry: number | undefined;
+
+        while (true) {
+            const stream = readableStreamAsyncIterable<Uint8Array>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
+
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
+
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
+                        }
+                        continue;
+                    }
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
+                    }
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
+                }
+            }
+
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
+                const data = await this.parse(fromJson(dataValue));
+                yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
+            }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            currentStream = await this.reconnect!(lastId!);
+        }
+    }
+
+    private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
+        let reconnectAttempts = 0;
+        let currentStream: ReadableStream = this.stream;
+        let lastId: string | undefined;
+        let lastRetry: number | undefined;
+
+        while (true) {
+            const stream = readableStreamAsyncIterable<Uint8Array>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
+
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
+
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
+                        }
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
+                    }
+
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                    }
+                }
+            }
+
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
+            }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            currentStream = await this.reconnect!(lastId!);
+        }
+    }
+
+    private async dispatchSseEvent(dataValue: string, eventType: string | undefined): Promise<T | null> {
+        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+            return null;
+        }
+        return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+
+    private injectDiscriminator(parsed: unknown, eventType: string | undefined): unknown {
+        if (this.eventDiscriminator == null || eventType == null) {
+            return parsed;
+        }
+        if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return parsed;
+        }
+        const obj = parsed as Record<string, unknown>;
+        if (this.eventDiscriminator in obj) {
+            return parsed;
+        }
+        return { [this.eventDiscriminator]: eventType, ...obj };
+    }
+
+    async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
+        for await (const event of this.iterMessages()) {
+            yield event.data;
+        }
+    }
+
+    private decodeChunk(chunk: unknown): string {
+        if (this.decoder != null) {
+            return this.decoder.decode(chunk as BufferSource, { stream: true });
+        }
+        if (Buffer.isBuffer(chunk)) {
+            return chunk.toString("utf-8");
+        }
+        return Buffer.from(chunk as ArrayBuffer).toString("utf-8");
+    }
+}
+
+function readableStreamAsyncIterable<T>(stream: ReadableStream): AsyncIterableIterator<T> {
+    if ((stream as any)[Symbol.asyncIterator]) {
+        return (stream as any)[Symbol.asyncIterator]();
+    }
+
+    const reader = stream.getReader();
+    return {
+        async next() {
+            try {
+                const result = await reader.read();
+                if (result?.done) {
+                    reader.releaseLock();
+                }
+                return result;
+            } catch (e) {
+                reader.releaseLock();
+                throw e;
+            }
+        },
+        async return() {
+            const cancelPromise = reader.cancel();
+            reader.releaseLock();
+            await cancelPromise;
+            return { done: true, value: undefined };
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// E2E Tests
+// ---------------------------------------------------------------------------
+
+function createSseServer(handler: (req: http.IncomingMessage, res: http.ServerResponse) => void): Promise<{ server: http.Server; port: number }> {
+    return new Promise((resolve) => {
+        const server = http.createServer(handler);
+        server.listen(0, "127.0.0.1", () => {
+            const addr = server.address() as { port: number };
+            resolve({ server, port: addr.port });
+        });
+    });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+    return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("SSE Stream Reconnection E2E", () => {
+    test("reconnects on connection drop and resumes with Last-Event-ID", async () => {
+        const connectionAttempts: { lastEventId: string | undefined }[] = [];
+        let connectionCount = 0;
+
+        const { server, port } = await createSseServer((req, res) => {
+            const lastEventId = req.headers["last-event-id"] as string | undefined;
+            connectionAttempts.push({ lastEventId });
+            connectionCount++;
+
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+            });
+
+            if (connectionCount === 1) {
+                // First connection: send 3 events, then drop (no terminator)
+                res.write("id: evt-1\ndata: {\"value\": 1}\n\n");
+                res.write("id: evt-2\ndata: {\"value\": 2}\n\n");
+                res.write("id: evt-3\ndata: {\"value\": 3}\n\n");
+                res.end(); // simulate connection drop
+            } else if (connectionCount === 2) {
+                // Second connection (reconnect): send remaining events with terminator
+                res.write("id: evt-4\ndata: {\"value\": 4}\n\n");
+                res.write("id: evt-5\ndata: {\"value\": 5}\n\n");
+                res.write("data: [DONE]\n\n");
+                res.end();
+            } else {
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+        });
+
+        try {
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Initial fetch (like SDK fetcher would do)
+            const initialResponse = await fetch(url);
+
+            // Reconnect function (like the generated SDK creates)
+            const reconnect = async (lastEventId: string): Promise<ReadableStream> => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // All 5 events received seamlessly
+            assert.deepStrictEqual(messages, [
+                { value: 1 },
+                { value: 2 },
+                { value: 3 },
+                { value: 4 },
+                { value: 5 },
+            ]);
+
+            // Exactly 2 connections made
+            assert.strictEqual(connectionAttempts.length, 2);
+            // First connection had no Last-Event-ID
+            assert.strictEqual(connectionAttempts[0]!.lastEventId, undefined);
+            // Second connection sent Last-Event-ID = "evt-3"
+            assert.strictEqual(connectionAttempts[1]!.lastEventId, "evt-3");
+
+            console.log("✓ Reconnection works: got all 5 events across 2 connections");
+            console.log(`  Connection 1: no Last-Event-ID → events evt-1..evt-3`);
+            console.log(`  Connection 2: Last-Event-ID=evt-3 → events evt-4..evt-5 + [DONE]`);
+        } finally {
+            await closeServer(server);
+        }
+    });
+
+    test("handles multiple sequential reconnections", async () => {
+        const connectionAttempts: { lastEventId: string | undefined }[] = [];
+        let connectionCount = 0;
+
+        const { server, port } = await createSseServer((req, res) => {
+            const lastEventId = req.headers["last-event-id"] as string | undefined;
+            connectionAttempts.push({ lastEventId });
+            connectionCount++;
+
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+            });
+
+            if (connectionCount === 1) {
+                res.write("id: 1\ndata: {\"seq\": 1}\n\n");
+                res.end(); // drop
+            } else if (connectionCount === 2) {
+                res.write("id: 2\ndata: {\"seq\": 2}\n\n");
+                res.end(); // drop again
+            } else if (connectionCount === 3) {
+                res.write("id: 3\ndata: {\"seq\": 3}\n\n");
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+        });
+
+        try {
+            const url = `http://127.0.0.1:${port}/sse`;
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string): Promise<ReadableStream> => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            assert.deepStrictEqual(messages, [{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            assert.strictEqual(connectionAttempts.length, 3);
+            assert.strictEqual(connectionAttempts[0]!.lastEventId, undefined);
+            assert.strictEqual(connectionAttempts[1]!.lastEventId, "1");
+            assert.strictEqual(connectionAttempts[2]!.lastEventId, "2");
+
+            console.log("✓ Multiple reconnections work: 3 connections, all events received");
+        } finally {
+            await closeServer(server);
+        }
+    });
+
+    test("respects server retry directive (delays reconnection)", async () => {
+        let connectionCount = 0;
+        const connectionTimestamps: number[] = [];
+
+        const { server, port } = await createSseServer((req, res) => {
+            connectionTimestamps.push(Date.now());
+            connectionCount++;
+
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+            });
+
+            if (connectionCount === 1) {
+                // Tell client to wait 150ms before reconnecting
+                res.write("retry: 150\nid: 1\ndata: {\"msg\": \"first\"}\n\n");
+                res.end();
+            } else {
+                res.write("id: 2\ndata: {\"msg\": \"second\"}\n\n");
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+        });
+
+        try {
+            const url = `http://127.0.0.1:${port}/sse`;
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string): Promise<ReadableStream> => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ msg: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { msg: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { msg: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            assert.deepStrictEqual(messages, [{ msg: "first" }, { msg: "second" }]);
+            assert.strictEqual(connectionTimestamps.length, 2);
+
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            // Should have waited at least ~150ms (allowing 30ms variance for network)
+            assert.ok(delayMs >= 120, `Expected delay >= 120ms, got ${delayMs}ms`);
+
+            console.log(`✓ Server retry directive respected: reconnected after ${delayMs}ms (retry: 150)`);
+        } finally {
+            await closeServer(server);
+        }
+    });
+
+    test("stops after maxReconnectionAttempts when server sends no new data", async () => {
+        let connectionCount = 0;
+
+        const { server, port } = await createSseServer((req, res) => {
+            connectionCount++;
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+            });
+
+            if (connectionCount === 1) {
+                // First connection: send one event, then drop
+                res.write("id: evt-1\ndata: {\"n\": 1}\n\n");
+                res.end();
+            } else {
+                // All reconnection attempts: immediately close without sending data
+                // This simulates a server that's completely down on reconnect
+                res.end();
+            }
+        });
+
+        try {
+            const url = `http://127.0.0.1:${port}/sse`;
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string): Promise<ReadableStream> => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ n: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { n: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2, // Allow only 2 reconnect attempts
+                reconnect,
+            });
+
+            const messages: { n: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            assert.deepStrictEqual(messages, [{ n: 1 }]);
+            // 1 initial + 2 reconnect attempts = 3 total connections
+            assert.strictEqual(connectionCount, 3);
+
+            console.log("✓ Stops after maxReconnectionAttempts=2: server down on reconnect, stream ends gracefully");
+        } finally {
+            await closeServer(server);
+        }
+    });
+
+    test("does not reconnect when reconnectionEnabled is false", async () => {
+        let connectionCount = 0;
+
+        const { server, port } = await createSseServer((req, res) => {
+            connectionCount++;
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+            });
+            res.write("id: 1\ndata: {\"only\": true}\n\n");
+            res.end(); // drop without terminator
+        });
+
+        try {
+            const url = `http://127.0.0.1:${port}/sse`;
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string): Promise<ReadableStream> => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ only: boolean }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { only: boolean },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false, // Disabled!
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { only: boolean }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            assert.strictEqual(connectionCount, 1); // No reconnection attempt
+            assert.deepStrictEqual(messages, [{ only: true }]);
+
+            console.log("✓ reconnectionEnabled=false prevents reconnection");
+        } finally {
+            await closeServer(server);
+        }
+    });
+});

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -5,6 +5,18 @@
  * connection drops. It verifies that the Stream class transparently reconnects
  * using the Last-Event-ID header, just as a generated SDK would in production.
  *
+ * IMPORTANT: This file contains an inline copy of the Stream class (compiled
+ * from Stream.template.ts for the "standard" web variant). It is NOT imported
+ * from the template because the template uses EJS syntax that cannot be
+ * directly consumed by tsx/node. This means:
+ *   - Changes to Stream.template.ts must be manually mirrored here.
+ *   - The inline copy may drift from the template (e.g. decodeChunk uses
+ *     instanceof narrowing here vs. RUNTIME.type in the template).
+ *   - The primary regression gate for template output is the seed-generated
+ *     Stream.test.ts files, not this E2E test.
+ * This test's value is validating the reconnection *protocol* (Last-Event-ID,
+ * retry delays, abort, backoff) against a real HTTP server.
+ *
  * Run with: npx tsx --test tests/e2e/sse-reconnection.test.ts
  */
 import http from "node:http";

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -199,7 +199,11 @@ class Stream<T> implements AsyncIterable<T> {
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
-            currentStream = await this.reconnect!(lastId!);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -277,7 +281,11 @@ class Stream<T> implements AsyncIterable<T> {
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
-            currentStream = await this.reconnect!(lastId!);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -134,6 +134,7 @@ class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream: ReadableStream = this.stream;
         let lastId: string | undefined;
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -156,6 +157,7 @@ class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -191,6 +193,7 @@ class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -202,10 +205,11 @@ class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -216,11 +220,11 @@ class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -239,6 +243,7 @@ class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream: ReadableStream = this.stream;
         let lastId: string | undefined;
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -262,6 +267,7 @@ class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -293,11 +299,12 @@ class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -308,11 +315,11 @@ class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -829,6 +836,75 @@ describe("SSE Stream Reconnection E2E", () => {
             assert.deepStrictEqual(messages, [{ only: true }]);
 
             console.log("✓ reconnectionEnabled=false prevents reconnection");
+        } finally {
+            await closeServer(server);
+        }
+    });
+
+    test("does not skip an event when the drop lands after id: but before the event boundary", async () => {
+        const connectionAttempts: { lastEventId: string | undefined }[] = [];
+        let connectionCount = 0;
+
+        const { server, port } = await createSseServer((req, res) => {
+            const lastEventId = req.headers["last-event-id"] as string | undefined;
+            connectionAttempts.push({ lastEventId });
+            connectionCount++;
+
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+            });
+
+            if (connectionCount === 1) {
+                // evt-1 is fully dispatched, then evt-2's id: arrives but the
+                // connection drops before evt-2's data + blank line. evt-2 must
+                // NOT be considered "seen" — reconnect must resume from evt-1.
+                res.write("id: evt-1\ndata: {\"value\": 1}\n\n");
+                res.write("id: evt-2\n");
+                res.end(); // drop mid-event
+            } else {
+                // Server resumes from the last *dispatched* id (evt-1) and
+                // re-sends evt-2 in full.
+                res.write("id: evt-2\ndata: {\"value\": 2}\n\n");
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+        });
+
+        try {
+            const url = `http://127.0.0.1:${port}/sse`;
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string): Promise<ReadableStream> => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return assertBody(response);
+            };
+
+            const stream = new Stream<{ value: number }>({
+                stream: assertBody(initialResponse),
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // No event lost: both value 1 and value 2 arrive.
+            assert.deepStrictEqual(messages, [{ value: 1 }, { value: 2 }]);
+            assert.strictEqual(connectionAttempts.length, 2);
+            // Reconnect resumes from the last *dispatched* id (evt-1), NOT the
+            // parsed-but-undispatched evt-2.
+            assert.strictEqual(at(connectionAttempts, 1).lastEventId, "evt-1");
+
+            console.log("✓ Mid-event drop resumes from last dispatched id (evt-1), no event skipped");
         } finally {
             await closeServer(server);
         }

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -196,11 +196,19 @@ class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {
+                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
+                // the next loop iteration will hit shouldReconnect and respect
+                // maxReconnectionAttempts.
+                continue;
+            }
         }
     }
 
@@ -275,11 +283,19 @@ class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {
+                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
+                // the next loop iteration will hit shouldReconnect and respect
+                // maxReconnectionAttempts.
+                continue;
+            }
         }
     }
 

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -52,6 +52,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 function fromJson(json: string): unknown {
@@ -121,7 +122,6 @@ class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<Uint8Array>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -134,7 +134,6 @@ class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -170,7 +169,6 @@ class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -189,16 +187,15 @@ class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -218,7 +215,6 @@ class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -232,7 +228,6 @@ class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -271,16 +266,15 @@ class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -319,11 +313,23 @@ class Stream<T> implements AsyncIterable<T> {
     }
 
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     private injectDiscriminator(parsed: unknown, eventType: string | undefined): unknown {

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -72,6 +72,8 @@ class Stream<T> implements AsyncIterable<T> {
     private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -97,7 +99,11 @@ class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         if (typeof TextDecoder !== "undefined") {
             this.decoder = new TextDecoder("utf-8");
@@ -202,11 +208,16 @@ class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
             } catch {
-                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
-                // the next loop iteration will hit shouldReconnect and respect
-                // maxReconnectionAttempts.
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
                 continue;
             }
         }
@@ -289,11 +300,16 @@ class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
             } catch {
-                // Treat a failed reconnect (e.g. HTTP error) like an empty stream:
-                // the next loop iteration will hit shouldReconnect and respect
-                // maxReconnectionAttempts.
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
                 continue;
             }
         }
@@ -308,6 +324,9 @@ class Stream<T> implements AsyncIterable<T> {
 
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -362,26 +381,48 @@ class Stream<T> implements AsyncIterable<T> {
         return { [this.eventDiscriminator]: eventType, ...obj };
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({ start(controller) { controller.close(); } });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 
     private decodeChunk(chunk: unknown): string {
-        if (this.decoder != null) {
-            return this.decoder.decode(chunk as BufferSource, { stream: true });
+        if (this.decoder != null && (chunk instanceof Uint8Array || chunk instanceof ArrayBuffer)) {
+            return this.decoder.decode(chunk, { stream: true });
         }
         if (Buffer.isBuffer(chunk)) {
             return chunk.toString("utf-8");
         }
-        return Buffer.from(chunk as ArrayBuffer).toString("utf-8");
+        if (chunk instanceof ArrayBuffer) {
+            return Buffer.from(chunk).toString("utf-8");
+        }
+        return String(chunk);
     }
 }
 
+function hasAsyncIterator<T>(obj: object): obj is AsyncIterable<T> {
+    return Symbol.asyncIterator in obj;
+}
+
 function readableStreamAsyncIterable<T>(stream: ReadableStream): AsyncIterableIterator<T> {
-    if ((stream as any)[Symbol.asyncIterator]) {
-        return (stream as any)[Symbol.asyncIterator]();
+    if (hasAsyncIterator<T>(stream)) {
+        return stream[Symbol.asyncIterator]();
     }
 
     const reader = stream.getReader();
@@ -408,6 +449,26 @@ function readableStreamAsyncIterable<T>(stream: ReadableStream): AsyncIterableIt
             return this;
         },
     };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assertBody(response: Response): ReadableStream {
+    const body = response.body;
+    if (body == null) {
+        throw new Error("response body is null");
+    }
+    return body;
+}
+
+function at<T>(arr: T[], index: number): T {
+    const val = arr[index];
+    if (val === undefined) {
+        throw new Error(`expected element at index ${index}`);
+    }
+    return val;
 }
 
 // ---------------------------------------------------------------------------
@@ -473,11 +534,11 @@ describe("SSE Stream Reconnection E2E", () => {
                 const response = await fetch(url, {
                     headers: { "Last-Event-ID": lastEventId },
                 });
-                return response.body!;
+                return assertBody(response);
             };
 
             const stream = new Stream<{ value: number }>({
-                stream: initialResponse.body!,
+                stream: assertBody(initialResponse),
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -502,9 +563,9 @@ describe("SSE Stream Reconnection E2E", () => {
             // Exactly 2 connections made
             assert.strictEqual(connectionAttempts.length, 2);
             // First connection had no Last-Event-ID
-            assert.strictEqual(connectionAttempts[0]!.lastEventId, undefined);
+            assert.strictEqual(at(connectionAttempts, 0).lastEventId, undefined);
             // Second connection sent Last-Event-ID = "evt-3"
-            assert.strictEqual(connectionAttempts[1]!.lastEventId, "evt-3");
+            assert.strictEqual(at(connectionAttempts, 1).lastEventId, "evt-3");
 
             console.log("✓ Reconnection works: got all 5 events across 2 connections");
             console.log(`  Connection 1: no Last-Event-ID → events evt-1..evt-3`);
@@ -550,11 +611,11 @@ describe("SSE Stream Reconnection E2E", () => {
                 const response = await fetch(url, {
                     headers: { "Last-Event-ID": lastEventId },
                 });
-                return response.body!;
+                return assertBody(response);
             };
 
             const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
+                stream: assertBody(initialResponse),
                 parse: async (val: unknown) => val as { seq: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -569,9 +630,9 @@ describe("SSE Stream Reconnection E2E", () => {
 
             assert.deepStrictEqual(messages, [{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
             assert.strictEqual(connectionAttempts.length, 3);
-            assert.strictEqual(connectionAttempts[0]!.lastEventId, undefined);
-            assert.strictEqual(connectionAttempts[1]!.lastEventId, "1");
-            assert.strictEqual(connectionAttempts[2]!.lastEventId, "2");
+            assert.strictEqual(at(connectionAttempts, 0).lastEventId, undefined);
+            assert.strictEqual(at(connectionAttempts, 1).lastEventId, "1");
+            assert.strictEqual(at(connectionAttempts, 2).lastEventId, "2");
 
             console.log("✓ Multiple reconnections work: 3 connections, all events received");
         } finally {
@@ -612,11 +673,11 @@ describe("SSE Stream Reconnection E2E", () => {
                 const response = await fetch(url, {
                     headers: { "Last-Event-ID": lastEventId },
                 });
-                return response.body!;
+                return assertBody(response);
             };
 
             const stream = new Stream<{ msg: string }>({
-                stream: initialResponse.body!,
+                stream: assertBody(initialResponse),
                 parse: async (val: unknown) => val as { msg: string },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -632,7 +693,7 @@ describe("SSE Stream Reconnection E2E", () => {
             assert.deepStrictEqual(messages, [{ msg: "first" }, { msg: "second" }]);
             assert.strictEqual(connectionTimestamps.length, 2);
 
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            const delayMs = at(connectionTimestamps, 1) - at(connectionTimestamps, 0);
             // Should have waited at least ~150ms (allowing 30ms variance for network)
             assert.ok(delayMs >= 120, `Expected delay >= 120ms, got ${delayMs}ms`);
 
@@ -672,11 +733,11 @@ describe("SSE Stream Reconnection E2E", () => {
                 const response = await fetch(url, {
                     headers: { "Last-Event-ID": lastEventId },
                 });
-                return response.body!;
+                return assertBody(response);
             };
 
             const stream = new Stream<{ n: number }>({
-                stream: initialResponse.body!,
+                stream: assertBody(initialResponse),
                 parse: async (val: unknown) => val as { n: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -722,11 +783,11 @@ describe("SSE Stream Reconnection E2E", () => {
                 const response = await fetch(url, {
                     headers: { "Last-Event-ID": lastEventId },
                 });
-                return response.body!;
+                return assertBody(response);
             };
 
             const stream = new Stream<{ only: boolean }>({
-                stream: initialResponse.body!,
+                stream: assertBody(initialResponse),
                 parse: async (val: unknown) => val as { only: boolean },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: false, // Disabled!

--- a/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/e2e/sse-reconnection.test.ts
@@ -392,6 +392,19 @@ class Stream<T> implements AsyncIterable<T> {
         }
     }
 
+    public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
+        const self = this;
+        return {
+            async *[Symbol.asyncIterator]() {
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
+            },
+        };
+    }
+
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
         try {
             for await (const event of this.iterMessages()) {

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1356,8 +1356,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1404,9 +1405,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1,6 +1,7 @@
 <% if (streamType === "wrapper") { %>
 import { Readable } from "stream";
 <% } %>
+import http from "http";
 import { Stream, ServerSentEvent } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1217,8 +1218,8 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                // Return a stream that immediately ends (premature EOF)
-                return createReadableStream(["id: x\ndata: {\"value\": 99}\n\n"]);
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
             };
 
             const firstStream = createReadableStream([
@@ -1240,7 +1241,8 @@ describe("Stream", () => {
                 messages.push(message);
             }
 
-            // First stream yields 1, then each reconnect yields 99, all hitting EOF without terminator
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
             expect(reconnectCallCount).toBe(3);
         });
 
@@ -1325,6 +1327,295 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }]);
             expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach((done) => {
+            if (server) {
+                server.close(done);
+            } else {
+                done();
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write("id: evt-1\ndata: {\"value\": 1}\n\n");
+                    res.write("id: evt-2\ndata: {\"value\": 2}\n\n");
+                    res.write("id: evt-3\ndata: {\"value\": 3}\n\n");
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write("id: evt-4\ndata: {\"value\": 4}\n\n");
+                    res.write("id: evt-5\ndata: {\"value\": 5}\n\n");
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([
+                { value: 1 },
+                { value: 2 },
+                { value: 3 },
+                { value: 4 },
+                { value: 5 },
+            ]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]!.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]!.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write("id: 1\ndata: {\"seq\": 1}\n\n");
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write("id: 2\ndata: {\"seq\": 2}\n\n");
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write("id: 3\ndata: {\"seq\": 3}\n\n");
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]!.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]!.lastEventId).toBe("1");
+            expect(connectionAttempts[2]!.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write("retry: 100\nid: 1\ndata: {\"value\": \"first\"}\n\n");
+                    res.end();
+                } else {
+                    res.write("id: 2\ndata: {\"value\": \"second\"}\n\n");
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write("id: evt-1\ndata: {\"attempt\": 1}\n\n");
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1137,8 +1137,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: firstStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: true,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
                 maxReconnectionAttempts: 5,
                 reconnect,
@@ -1168,8 +1167,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: mockStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: true,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: false,
                 maxReconnectionAttempts: 5,
                 reconnect,
@@ -1198,8 +1196,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: mockStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: false,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
                 reconnectionEnabled: true,
                 maxReconnectionAttempts: 5,
                 reconnect,
@@ -1229,8 +1226,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: firstStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: true,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
                 maxReconnectionAttempts: 3,
                 reconnect,
@@ -1261,8 +1257,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: mockStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: true,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
                 maxReconnectionAttempts: 5,
                 reconnect,
@@ -1285,8 +1280,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: mockStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: true,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
                 maxReconnectionAttempts: 5,
             });
@@ -1313,8 +1307,7 @@ describe("Stream", () => {
             const stream = new Stream({
                 stream: mockStream,
                 parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]" },
-                resumable: true,
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
                 maxReconnectionAttempts: 5,
                 reconnect,
@@ -1334,11 +1327,9 @@ describe("Stream", () => {
         let server: http.Server;
         let port: number;
 
-        afterEach((done) => {
+        afterEach(async () => {
             if (server) {
-                server.close(done);
-            } else {
-                done();
+                await new Promise<void>((resolve) => server.close(() => resolve()));
             }
         });
 

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1521,6 +1521,72 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["id: 2\ndata: {\"value\": 2}\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1152,6 +1152,47 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream([
+                "id: evt-1\ndata: {\"value\": 1}\n\n",
+                "id: evt-2\n",
+            ]);
+            const secondStream = createReadableStream([
+                "id: evt-2\ndata: {\"value\": 2}\n\n",
+                "data: [DONE]\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream([
                 "id: 1\ndata: {\"value\": 1}\n\n",

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1323,6 +1323,189 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(["id: 1\ndata: {\"value\": 1}\n\n"]),
+                createReadableStream(["id: 2\ndata: {\"value\": 2}\n\n"]),
+                createReadableStream(["id: 3\ndata: {\"value\": 3}\n\ndata: [DONE]\n\n"]),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(["id: 1\ndata: {\"value\": 1}\n\n"]),
+                createReadableStream(["id: 2\ndata: {\"value\": 2}\n\n"]),
+                createReadableStream(["id: 3\ndata: {\"value\": 3}\n\ndata: [DONE]\n\n"]),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+                "id: 2\ndata: {\"value\": 2}\n\n",
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["id: 99\ndata: {\"value\": 99}\n\ndata: [DONE]\n\n"]);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+                "id: 2\ndata: {\"value\": 2}\n\n",
+                "id: 3\ndata: [DONE]\n\n",
+                "id: 4\ndata: {\"value\": 4}\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1,7 +1,6 @@
 <% if (streamType === "wrapper") { %>
 import { Readable } from "stream";
 <% } %>
-import http from "http";
 import { Stream, ServerSentEvent } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1377,12 +1376,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1415,11 +1422,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1506,292 +1521,6 @@ describe("Stream", () => {
         });
     });
 
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write("id: evt-1\ndata: {\"value\": 1}\n\n");
-                    res.write("id: evt-2\ndata: {\"value\": 2}\n\n");
-                    res.write("id: evt-3\ndata: {\"value\": 3}\n\n");
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write("id: evt-4\ndata: {\"value\": 4}\n\n");
-                    res.write("id: evt-5\ndata: {\"value\": 5}\n\n");
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([
-                { value: 1 },
-                { value: 2 },
-                { value: 3 },
-                { value: 4 },
-                { value: 5 },
-            ]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]!.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]!.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write("id: 1\ndata: {\"seq\": 1}\n\n");
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write("id: 2\ndata: {\"seq\": 2}\n\n");
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write("id: 3\ndata: {\"seq\": 3}\n\n");
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]!.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]!.lastEventId).toBe("1");
-            expect(connectionAttempts[2]!.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write("retry: 100\nid: 1\ndata: {\"value\": \"first\"}\n\n");
-                    res.end();
-                } else {
-                    res.write("id: 2\ndata: {\"value\": \"second\"}\n\n");
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write("id: evt-1\ndata: {\"attempt\": 1}\n\n");
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
-        });
-    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/stream/Stream.test.template.ts
@@ -1113,6 +1113,220 @@ describe("Stream", () => {
             expect(messages).toEqual([{ value: 1 }]);
         });
     });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+                "id: 2\ndata: {\"value\": 2}\n\n",
+            ]);
+            const secondStream = createReadableStream([
+                "id: 3\ndata: {\"value\": 3}\n\n",
+                "data: [DONE]\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: true,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: true,
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: false,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends (premature EOF)
+                return createReadableStream(["id: x\ndata: {\"value\": 99}\n\n"]);
+            };
+
+            const firstStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: true,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then each reconnect yields 99, all hitting EOF without terminator
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+                "data: [DONE]\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: true,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream([
+                "id: 1\ndata: {\"value\": 1}\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: true,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream([
+                "data: {\"value\": 1}\n\n",
+            ]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]" },
+                resumable: true,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-event-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/client/Client.ts
@@ -62,11 +62,6 @@ export class CompletionsClient {
                         type: "sse",
                         streamTerminator: "[[DONE]]",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -132,11 +127,6 @@ export class CompletionsClient {
                         type: "sse",
                         streamTerminator: "[DONE]",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -202,11 +192,6 @@ export class CompletionsClient {
                         type: "sse",
                         eventDiscriminator: "type",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -278,11 +263,6 @@ export class CompletionsClient {
                         streamTerminator: "[DONE]",
                         eventDiscriminator: "event",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/Client.ts
@@ -65,11 +65,6 @@ export class SeedApiClient {
                         type: "sse",
                         eventDiscriminator: "event",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -135,11 +130,6 @@ export class SeedApiClient {
                         type: "sse",
                         eventDiscriminator: "event",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -199,11 +189,6 @@ export class SeedApiClient {
                     eventShape: {
                         type: "sse",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -263,11 +248,6 @@ export class SeedApiClient {
                     eventShape: {
                         type: "sse",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -328,11 +308,6 @@ export class SeedApiClient {
                         type: "sse",
                         eventDiscriminator: "event",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -399,11 +374,6 @@ export class SeedApiClient {
                     eventShape: {
                         type: "sse",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -468,11 +438,6 @@ export class SeedApiClient {
                     eventShape: {
                         type: "sse",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -535,11 +500,6 @@ export class SeedApiClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -668,11 +628,6 @@ export class SeedApiClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -857,11 +812,6 @@ export class SeedApiClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -1050,11 +1000,6 @@ export class SeedApiClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -1182,11 +1127,6 @@ export class SeedApiClient {
                     eventShape: {
                         type: "sse",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-events-resumable/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/api/resources/completions/client/Client.ts
@@ -75,6 +75,9 @@ export class CompletionsClient {
             if (!_reconnectResponse.ok) {
                 throw new Error("SSE stream reconnection failed");
             }
+            if (_reconnectResponse.body == null) {
+                throw new Error("SSE stream reconnection failed: empty response body");
+            }
             return _reconnectResponse.body;
         };
         if (_response.ok) {
@@ -151,11 +154,6 @@ export class CompletionsClient {
                         type: "sse",
                         streamTerminator: "[[DONE]]",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/server-sent-events-resumable/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/api/resources/completions/client/Client.ts
@@ -52,6 +52,31 @@ export class CompletionsClient {
             fetchFn: this._options?.fetch,
             logging: this._options.logging,
         });
+        const _reconnect = async (lastEventId: string) => {
+            const _reconnectResponse = await core.fetcher<ReadableStream>({
+                url: core.url.join(
+                    (await core.Supplier.get(this._options.baseUrl)) ??
+                        (await core.Supplier.get(this._options.environment)),
+                    "stream",
+                ),
+                method: "POST",
+                headers: { ..._headers, "Last-Event-ID": lastEventId },
+                contentType: "application/json",
+                queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
+                requestType: "json",
+                body: request,
+                responseType: "sse",
+                timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
+                maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
+                abortSignal: requestOptions?.abortSignal,
+                fetchFn: this._options?.fetch,
+                logging: this._options.logging,
+            });
+            if (!_reconnectResponse.ok) {
+                throw new Error("SSE stream reconnection failed");
+            }
+            return _reconnectResponse.body;
+        };
         if (_response.ok) {
             return {
                 data: new core.Stream({
@@ -68,6 +93,7 @@ export class CompletionsClient {
                     maxReconnectionAttempts:
                         requestOptions?.stream?.maxReconnectionAttempts ??
                         this._options?.stream?.maxReconnectionAttempts,
+                    reconnect: _reconnect,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-events/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-events/src/api/resources/completions/client/Client.ts
+++ b/seed/ts-sdk/server-sent-events/src/api/resources/completions/client/Client.ts
@@ -62,11 +62,6 @@ export class CompletionsClient {
                         type: "sse",
                         streamTerminator: "[[DONE]]",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };
@@ -123,11 +118,6 @@ export class CompletionsClient {
                     eventShape: {
                         type: "sse",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/ts-sdk/streaming-parameter/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming-parameter/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming-parameter/src/api/resources/dummy/client/Client.ts
@@ -62,11 +62,6 @@ export class DummyClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
@@ -62,11 +62,6 @@ export class DummyClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/serde-layer/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
@@ -77,11 +77,6 @@ export class DummyClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -211,11 +211,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -290,11 +293,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -23,8 +23,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -61,6 +63,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -134,7 +137,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -147,7 +149,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -183,7 +184,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -202,16 +202,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -231,7 +230,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -245,7 +243,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -284,16 +281,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -338,15 +334,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -346,13 +346,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -137,6 +137,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -159,6 +166,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -194,6 +202,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -205,10 +214,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -219,11 +229,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -241,6 +251,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -264,6 +278,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -295,11 +310,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -310,11 +326,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -86,6 +86,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -111,7 +113,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -217,8 +223,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -299,8 +314,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -319,6 +343,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -365,11 +397,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): ReadableStream {
+        return new ReadableStream({
+            start(controller) {
+                controller.close();
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -389,8 +440,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/stream/Stream.ts
@@ -27,6 +27,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<ReadableStream>;
     }
 
     interface JsonEvent {
@@ -54,6 +60,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: ReadableStream;
 
@@ -66,12 +75,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -82,6 +91,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -96,7 +106,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -114,127 +125,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -246,6 +310,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1256,6 +1256,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1098,6 +1098,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1,4 +1,3 @@
-import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1308,12 +1307,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1346,11 +1353,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1434,287 +1449,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1287,8 +1287,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1335,9 +1336,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1451,6 +1451,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/stream/Stream.test.ts
@@ -1,3 +1,4 @@
+import http from "http";
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1060,6 +1061,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/wrapper/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/wrapper/.fern/metadata.json
@@ -7,8 +7,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
@@ -63,11 +63,6 @@ export class DummyClient {
                         type: "json",
                         messageTerminator: "\n",
                     },
-                    reconnectionEnabled:
-                        requestOptions?.stream?.reconnectionEnabled ?? this._options?.stream?.reconnectionEnabled,
-                    maxReconnectionAttempts:
-                        requestOptions?.stream?.maxReconnectionAttempts ??
-                        this._options?.stream?.maxReconnectionAttempts,
                 }),
                 rawResponse: _response.rawResponse,
             };

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -1,4 +1,4 @@
-import type { Readable } from "stream";
+import { Readable } from "stream";
 
 import { fromJson } from "../json.js";
 import { RUNTIME } from "../runtime/index.js";
@@ -88,6 +88,8 @@ export class Stream<T> implements AsyncIterable<T> {
 
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
+    private externalSignal: AbortSignal | undefined;
+    private onExternalAbort: (() => void) | undefined;
 
     constructor({
         stream,
@@ -113,7 +115,11 @@ export class Stream<T> implements AsyncIterable<T> {
         this.reconnectionEnabled = reconnectionEnabled ?? true;
         this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
         this.reconnect = reconnect;
-        signal?.addEventListener("abort", () => this.controller.abort());
+        if (signal != null) {
+            this.externalSignal = signal;
+            this.onExternalAbort = () => this.controller.abort();
+            signal.addEventListener("abort", this.onExternalAbort, { once: true });
+        }
 
         // Initialize shared TextDecoder
         if (typeof TextDecoder !== "undefined") {
@@ -219,8 +225,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -301,8 +316,17 @@ export class Stream<T> implements AsyncIterable<T> {
                 return;
             }
             try {
-                currentStream = await reconnectFn(lastId);
-            } catch {}
+                const reconnected = await reconnectFn(lastId);
+                if (reconnected == null) {
+                    currentStream = this.createEmptyStream();
+                    continue;
+                }
+                currentStream = reconnected;
+            } catch {
+                // Failed reconnect (e.g. HTTP error); assign an empty stream
+                // so the next iteration is a safe no-op before shouldReconnect.
+                currentStream = this.createEmptyStream();
+            }
         }
     }
 
@@ -321,6 +345,14 @@ export class Stream<T> implements AsyncIterable<T> {
      */
     private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
         if (!this.resumable) {
+            return false;
+        }
+        if (this.streamTerminator == null) {
+            // Without a terminator the client cannot distinguish a
+            // completed stream from a dropped connection. Combined
+            // with the reset-on-progress semantics of reconnectAttempts,
+            // a server that emits ≥1 event per connection without a
+            // terminator would reconnect unboundedly.
             return false;
         }
         if (!this.reconnectionEnabled) {
@@ -367,11 +399,30 @@ export class Stream<T> implements AsyncIterable<T> {
         });
     }
 
+    private createEmptyStream(): Readable {
+        return new Readable({
+            read() {
+                this.push(null);
+            },
+        });
+    }
+
+    private removeAbortListener(): void {
+        if (this.externalSignal != null && this.onExternalAbort != null) {
+            this.externalSignal.removeEventListener("abort", this.onExternalAbort);
+            this.onExternalAbort = undefined;
+        }
+    }
+
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {
         const self = this;
         return {
             async *[Symbol.asyncIterator]() {
-                yield* self.iterMessages();
+                try {
+                    yield* self.iterMessages();
+                } finally {
+                    self.removeAbortListener();
+                }
             },
         };
     }
@@ -391,8 +442,12 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
-        for await (const event of this.iterMessages()) {
-            yield event.data;
+        try {
+            for await (const event of this.iterMessages()) {
+                yield event.data;
+            }
+        } finally {
+            this.removeAbortListener();
         }
     }
 

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -348,13 +348,16 @@ export class Stream<T> implements AsyncIterable<T> {
             return false;
         }
         if (this.streamTerminator == null) {
-            // Without a terminator the client cannot distinguish a
-            // completed stream from a dropped connection. Combined
-            // with the reset-on-progress semantics of reconnectAttempts,
-            // a server that emits ≥1 event per connection without a
-            // terminator would reconnect unboundedly.
+            // Without a terminator the client cannot distinguish a completed
+            // stream from a dropped connection, so reconnection is disabled.
             return false;
         }
+        // NOTE: When a terminator IS configured but the server never sends it
+        // (e.g. it drops the connection after emitting events every time),
+        // maxReconnectionAttempts is a per-consecutive-failure cap — each
+        // yielded event resets the counter. This matches EventSource semantics
+        // but means such a server can cause unbounded reconnections. Callers
+        // concerned about this should impose a wall-clock budget externally.
         if (!this.reconnectionEnabled) {
             return false;
         }

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -139,6 +139,13 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // The id of the most recently *dispatched* event. Per the WHATWG
+        // EventSource spec, the "last event ID" is only committed when an event
+        // is dispatched, not when the `id:` line is parsed. Reconnecting with a
+        // parsed-but-undispatched id would skip an event that was never yielded
+        // (e.g. if the connection drops after `id:` but before the event's
+        // terminating blank line), so reconnection uses lastDispatchedId.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -161,6 +168,7 @@ export class Stream<T> implements AsyncIterable<T> {
                             }
                             const data = await this.parse(fromJson(dataValue));
                             yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                             dataValue = undefined;
                         }
@@ -196,6 +204,7 @@ export class Stream<T> implements AsyncIterable<T> {
                         }
                         const data = await this.parse(fromJson(line));
                         yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        lastDispatchedId = lastId;
                         reconnectAttempts = 0;
                     }
                 }
@@ -207,10 +216,11 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                lastDispatchedId = lastId;
                 reconnectAttempts = 0;
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -221,11 +231,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;
@@ -243,6 +253,10 @@ export class Stream<T> implements AsyncIterable<T> {
         let reconnectAttempts = 0;
         let currentStream = this.stream;
         let lastId: string | undefined;
+        // See iterDataMessages: reconnection uses the last *dispatched* id (per
+        // the EventSource spec), not the last *parsed* id, to avoid skipping an
+        // event that was never yielded when a drop lands mid-event.
+        let lastDispatchedId: string | undefined;
         let lastRetry: number | undefined;
 
         while (true) {
@@ -266,6 +280,7 @@ export class Stream<T> implements AsyncIterable<T> {
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            lastDispatchedId = lastId;
                             reconnectAttempts = 0;
                         }
                         eventType = undefined;
@@ -297,11 +312,12 @@ export class Stream<T> implements AsyncIterable<T> {
                 const data = await this.dispatchSseEvent(dataValue, eventType);
                 if (data != null) {
                     yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    lastDispatchedId = lastId;
                     reconnectAttempts = 0;
                 }
             }
 
-            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+            if (!this.shouldReconnect(lastDispatchedId, reconnectAttempts)) {
                 return;
             }
 
@@ -312,11 +328,11 @@ export class Stream<T> implements AsyncIterable<T> {
             }
             // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
-            if (reconnectFn == null || lastId == null) {
+            if (reconnectFn == null || lastDispatchedId == null) {
                 return;
             }
             try {
-                const reconnected = await reconnectFn(lastId);
+                const reconnected = await reconnectFn(lastDispatchedId);
                 if (reconnected == null) {
                     currentStream = this.createEmptyStream();
                     continue;

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -29,6 +29,12 @@ export declare namespace Stream {
          * resumable SSE endpoints. Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
+        /**
+         * A function that re-issues the HTTP request with the Last-Event-ID header
+         * and returns the new response body stream. Required for reconnection to work.
+         */
+
+        reconnect?: (lastEventId: string) => Promise<Readable | ReadableStream>;
     }
 
     interface JsonEvent {
@@ -56,6 +62,9 @@ const EVENT_PREFIX = "event:";
 const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
+const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export class Stream<T> implements AsyncIterable<T> {
     private stream: Readable | ReadableStream;
 
@@ -68,12 +77,12 @@ export class Stream<T> implements AsyncIterable<T> {
     private messageTerminator: string;
     private streamTerminator: string | undefined;
     private eventDiscriminator: string | undefined;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private resumable: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
     private reconnectionEnabled: boolean;
-    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: plumbed for future reconnection logic
-    private maxReconnectionAttempts: number | undefined;
+    private maxReconnectionAttempts: number;
+
+    private reconnect: ((lastEventId: string) => Promise<Readable | ReadableStream>) | undefined;
+
     private controller: AbortController = new AbortController();
     private decoder: TextDecoder | undefined;
 
@@ -84,6 +93,7 @@ export class Stream<T> implements AsyncIterable<T> {
         signal,
         reconnectionEnabled,
         maxReconnectionAttempts,
+        reconnect,
     }: Stream.Args & { parse: (val: unknown) => Promise<T> }) {
         this.stream = stream;
         this.parse = parse;
@@ -98,7 +108,8 @@ export class Stream<T> implements AsyncIterable<T> {
             this.resumable = false;
         }
         this.reconnectionEnabled = reconnectionEnabled ?? true;
-        this.maxReconnectionAttempts = maxReconnectionAttempts;
+        this.maxReconnectionAttempts = maxReconnectionAttempts ?? DEFAULT_MAX_RECONNECTION_ATTEMPTS;
+        this.reconnect = reconnect;
         signal?.addEventListener("abort", () => this.controller.abort());
 
         // Initialize shared TextDecoder
@@ -116,127 +127,180 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     private async *iterDataMessages(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
-        let dataValue: string | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
-                const line = buf.slice(0, terminatorIndex);
-                buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (this.prefix != null && dataValue != null) {
-                        if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf(this.messageTerminator)) >= 0) {
+                    const line = buf.slice(0, terminatorIndex);
+                    buf = buf.slice(terminatorIndex + this.messageTerminator.length);
+
+                    if (!line.trim()) {
+                        if (this.prefix != null && dataValue != null) {
+                            if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            const data = await this.parse(fromJson(dataValue));
+                            yield { data, id: lastId, retry: lastRetry, event: undefined };
+                            reconnectAttempts = 0;
+                            dataValue = undefined;
                         }
-                        const data = await this.parse(fromJson(dataValue));
-                        yield { data, id: lastId, retry: lastRetry, event: undefined };
-                        dataValue = undefined;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                    continue;
-                }
-                if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
-                    }
-                    continue;
-                }
-
-                if (this.prefix != null) {
-                    const prefixIndex = line.indexOf(this.prefix);
-                    if (prefixIndex === -1) {
                         continue;
                     }
-                    const val = line.slice(prefixIndex + this.prefix.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else {
-                    if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                        return;
+
+                    if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                        continue;
                     }
-                    const data = await this.parse(fromJson(line));
-                    yield { data, id: lastId, retry: lastRetry, event: undefined };
+                    if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
+                        continue;
+                    }
+
+                    if (this.prefix != null) {
+                        const prefixIndex = line.indexOf(this.prefix);
+                        if (prefixIndex === -1) {
+                            continue;
+                        }
+                        const val = line.slice(prefixIndex + this.prefix.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else {
+                        if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
+                            terminatorReached = true;
+                            return;
+                        }
+                        const data = await this.parse(fromJson(line));
+                        yield { data, id: lastId, retry: lastRetry, event: undefined };
+                        reconnectAttempts = 0;
+                    }
                 }
             }
-        }
 
-        if (this.prefix != null && dataValue != null) {
-            if (this.streamTerminator == null || !dataValue.includes(this.streamTerminator)) {
+            if (this.prefix != null && dataValue != null) {
+                if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
+                    return;
+                }
                 const data = await this.parse(fromJson(dataValue));
                 yield { data, id: lastId, retry: lastRetry, event: undefined };
+                reconnectAttempts = 0;
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
     private async *iterSseEvents(): AsyncGenerator<ServerSentEvent<T>, void> {
-        const stream = readableStreamAsyncIterable<any>(this.stream);
-        let buf = "";
-        let eventType: string | undefined;
-        let dataValue: string | undefined;
+        let reconnectAttempts = 0;
+        let currentStream = this.stream;
         let lastId: string | undefined;
         let lastRetry: number | undefined;
 
-        for await (const chunk of stream) {
-            buf += this.decodeChunk(chunk);
+        while (true) {
+            const stream = readableStreamAsyncIterable<any>(currentStream);
+            let buf = "";
+            let eventType: string | undefined;
+            let dataValue: string | undefined;
+            let terminatorReached = false;
 
-            let terminatorIndex: number;
-            while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
-                const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
-                buf = buf.slice(terminatorIndex + 1);
+            for await (const chunk of stream) {
+                buf += this.decodeChunk(chunk);
 
-                if (!line.trim()) {
-                    if (dataValue != null) {
-                        const data = await this.dispatchSseEvent(dataValue, eventType);
-                        if (data == null) {
-                            return;
+                let terminatorIndex: number;
+                while ((terminatorIndex = buf.indexOf("\n")) >= 0) {
+                    const line = buf.slice(0, terminatorIndex).replace(/\r$/, "");
+                    buf = buf.slice(terminatorIndex + 1);
+
+                    if (!line.trim()) {
+                        if (dataValue != null) {
+                            const data = await this.dispatchSseEvent(dataValue, eventType);
+                            if (data == null) {
+                                terminatorReached = true;
+                                return;
+                            }
+                            yield { data, id: lastId, retry: lastRetry, event: eventType };
+                            reconnectAttempts = 0;
                         }
-                        yield { data, id: lastId, retry: lastRetry, event: eventType };
+                        eventType = undefined;
+                        dataValue = undefined;
+                        continue;
                     }
-                    eventType = undefined;
-                    dataValue = undefined;
-                    continue;
-                }
 
-                if (line.startsWith(EVENT_PREFIX)) {
-                    eventType = line.slice(EVENT_PREFIX.length).trim();
-                } else if (line.startsWith(DATA_PREFIX)) {
-                    const val = line.slice(DATA_PREFIX.length).trim();
-                    dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
-                } else if (line.startsWith(ID_PREFIX)) {
-                    const idValue = line.slice(ID_PREFIX.length).trim();
-                    if (!idValue.includes("\0")) {
-                        lastId = idValue;
-                    }
-                } else if (line.startsWith(RETRY_PREFIX)) {
-                    const retryValue = line.slice(RETRY_PREFIX.length).trim();
-                    const parsed = parseInt(retryValue, 10);
-                    if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
-                        lastRetry = parsed;
+                    if (line.startsWith(EVENT_PREFIX)) {
+                        eventType = line.slice(EVENT_PREFIX.length).trim();
+                    } else if (line.startsWith(DATA_PREFIX)) {
+                        const val = line.slice(DATA_PREFIX.length).trim();
+                        dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
+                    } else if (line.startsWith(ID_PREFIX)) {
+                        const idValue = line.slice(ID_PREFIX.length).trim();
+                        if (!idValue.includes("\0")) {
+                            lastId = idValue;
+                        }
+                    } else if (line.startsWith(RETRY_PREFIX)) {
+                        const retryValue = line.slice(RETRY_PREFIX.length).trim();
+                        const parsed = parseInt(retryValue, 10);
+                        if (!Number.isNaN(parsed) && String(parsed) === retryValue) {
+                            lastRetry = parsed;
+                        }
                     }
                 }
             }
-        }
 
-        if (dataValue != null) {
-            const data = await this.dispatchSseEvent(dataValue, eventType);
-            if (data != null) {
-                yield { data, id: lastId, retry: lastRetry, event: eventType };
+            if (dataValue != null) {
+                const data = await this.dispatchSseEvent(dataValue, eventType);
+                if (data != null) {
+                    yield { data, id: lastId, retry: lastRetry, event: eventType };
+                    reconnectAttempts = 0;
+                }
             }
+
+            if (terminatorReached) {
+                return;
+            }
+
+            if (!this.shouldReconnect(lastId, reconnectAttempts)) {
+                return;
+            }
+
+            reconnectAttempts++;
+            await this.delayReconnect(lastRetry);
+            const reconnectFn = this.reconnect;
+            if (reconnectFn == null || lastId == null) {
+                return;
+            }
+            currentStream = await reconnectFn(lastId);
         }
     }
 
@@ -248,6 +312,43 @@ export class Stream<T> implements AsyncIterable<T> {
             return null;
         }
         return this.parse(this.injectDiscriminator(fromJson(dataValue), eventType));
+    }
+
+    /**
+     * Determines whether a reconnection attempt should be made.
+     */
+    private shouldReconnect(lastId: string | undefined, reconnectAttempts: number): boolean {
+        if (!this.resumable) {
+            return false;
+        }
+        if (!this.reconnectionEnabled) {
+            return false;
+        }
+        if (this.reconnect == null) {
+            return false;
+        }
+        if (lastId == null || lastId === "") {
+            return false;
+        }
+        if (reconnectAttempts >= this.maxReconnectionAttempts) {
+            return false;
+        }
+        if (this.controller.signal.aborted) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Delays before reconnecting, honoring server-sent retry directives clamped
+     * to MAX_RECONNECT_DELAY_MS.
+     */
+    private async delayReconnect(lastRetry: number | undefined): Promise<void> {
+        if (lastRetry == null || lastRetry <= 0) {
+            return;
+        }
+        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -213,11 +213,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 
@@ -292,11 +295,14 @@ export class Stream<T> implements AsyncIterable<T> {
             if (this.controller.signal.aborted) {
                 return;
             }
+            // Re-check after async delay; needed for TypeScript narrowing.
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
             }
-            currentStream = await reconnectFn(lastId);
+            try {
+                currentStream = await reconnectFn(lastId);
+            } catch {}
         }
     }
 

--- a/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/stream/Stream.ts
@@ -25,8 +25,10 @@ export declare namespace Stream {
          */
         reconnectionEnabled?: boolean;
         /**
-         * Maximum number of transparent mid-stream reconnect attempts on
-         * resumable SSE endpoints. Has no effect on non-resumable endpoints.
+         * Maximum number of consecutive failed reconnect attempts on resumable SSE
+         * endpoints before giving up. The counter resets to zero each time a
+         * reconnected stream successfully yields at least one event (i.e. makes
+         * progress). Has no effect on non-resumable endpoints.
          */
         maxReconnectionAttempts?: number;
         /**
@@ -63,6 +65,7 @@ const ID_PREFIX = "id:";
 const RETRY_PREFIX = "retry:";
 
 const DEFAULT_MAX_RECONNECTION_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export class Stream<T> implements AsyncIterable<T> {
@@ -136,7 +139,6 @@ export class Stream<T> implements AsyncIterable<T> {
             const stream = readableStreamAsyncIterable<any>(currentStream);
             let buf = "";
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -149,7 +151,6 @@ export class Stream<T> implements AsyncIterable<T> {
                     if (!line.trim()) {
                         if (this.prefix != null && dataValue != null) {
                             if (this.streamTerminator != null && dataValue.includes(this.streamTerminator)) {
-                                terminatorReached = true;
                                 return;
                             }
                             const data = await this.parse(fromJson(dataValue));
@@ -185,7 +186,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         dataValue = dataValue != null ? `${dataValue}\n${val}` : val;
                     } else {
                         if (this.streamTerminator != null && line.includes(this.streamTerminator)) {
-                            terminatorReached = true;
                             return;
                         }
                         const data = await this.parse(fromJson(line));
@@ -204,16 +204,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 reconnectAttempts = 0;
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -233,7 +232,6 @@ export class Stream<T> implements AsyncIterable<T> {
             let buf = "";
             let eventType: string | undefined;
             let dataValue: string | undefined;
-            let terminatorReached = false;
 
             for await (const chunk of stream) {
                 buf += this.decodeChunk(chunk);
@@ -247,7 +245,6 @@ export class Stream<T> implements AsyncIterable<T> {
                         if (dataValue != null) {
                             const data = await this.dispatchSseEvent(dataValue, eventType);
                             if (data == null) {
-                                terminatorReached = true;
                                 return;
                             }
                             yield { data, id: lastId, retry: lastRetry, event: eventType };
@@ -286,16 +283,15 @@ export class Stream<T> implements AsyncIterable<T> {
                 }
             }
 
-            if (terminatorReached) {
-                return;
-            }
-
             if (!this.shouldReconnect(lastId, reconnectAttempts)) {
                 return;
             }
 
             reconnectAttempts++;
             await this.delayReconnect(lastRetry);
+            if (this.controller.signal.aborted) {
+                return;
+            }
             const reconnectFn = this.reconnect;
             if (reconnectFn == null || lastId == null) {
                 return;
@@ -340,15 +336,29 @@ export class Stream<T> implements AsyncIterable<T> {
     }
 
     /**
-     * Delays before reconnecting, honoring server-sent retry directives clamped
-     * to MAX_RECONNECT_DELAY_MS.
+     * Delays before reconnecting, using a server-sent retry directive if provided
+     * (clamped to MAX_RECONNECT_DELAY_MS), otherwise falling back to
+     * DEFAULT_RECONNECT_DELAY_MS. The delay is abortable: if the stream's abort
+     * signal fires during the wait, the promise resolves immediately.
      */
     private async delayReconnect(lastRetry: number | undefined): Promise<void> {
-        if (lastRetry == null || lastRetry <= 0) {
+        const base = lastRetry != null && lastRetry > 0 ? lastRetry : DEFAULT_RECONNECT_DELAY_MS;
+        const delay = Math.min(base, MAX_RECONNECT_DELAY_MS);
+        const signal = this.controller.signal;
+        if (signal.aborted) {
             return;
         }
-        const delay = Math.min(lastRetry, MAX_RECONNECT_DELAY_MS);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, delay);
+            const onAbort = (): void => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
     }
 
     public withMetadata(): AsyncIterable<ServerSentEvent<T>> {

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1,5 +1,5 @@
-import http from "http";
 import { Readable } from "stream";
+
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1309,12 +1309,20 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
             const startTime = Date.now();
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1347,11 +1355,19 @@ describe("Stream", () => {
             let reconnectCallCount = 0;
             const reconnect = async (_lastEventId: string) => {
                 reconnectCallCount++;
-                return streams[reconnectCallCount]!;
+                const s = streams[reconnectCallCount];
+                if (s == null) {
+                    throw new Error(`unexpected reconnect call ${reconnectCallCount}`);
+                }
+                return s;
             };
 
+            const first = streams[0];
+            if (first == null) {
+                throw new Error("missing first stream");
+            }
             const stream = new Stream({
-                stream: streams[0]!,
+                stream: first,
                 parse: async (val: unknown) => val as { value: number },
                 eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
                 reconnectionEnabled: true,
@@ -1435,287 +1451,6 @@ describe("Stream", () => {
             // Should stop at [DONE] and not yield event 4 or attempt reconnection
             expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
             expect(reconnectCallCount).toBe(0);
-        });
-    });
-
-    describe("SSE stream reconnection E2E (real HTTP server)", () => {
-        let server: http.Server;
-        let port: number;
-
-        afterEach(async () => {
-            if (server) {
-                await new Promise<void>((resolve) => server.close(() => resolve()));
-            }
-        });
-
-        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
-            // Track connection attempts and Last-Event-ID headers received
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send events 1-3, then drop (no terminator)
-                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
-                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
-                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
-                    // Abruptly end the response to simulate a connection drop
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
-                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
-                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                } else {
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            // Start the server on a random available port
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            // Make the initial fetch request
-            const initialResponse = await fetch(url);
-            const initialStream = initialResponse.body!;
-
-            // Create the reconnect function (simulates what the generated SDK does)
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            // Create the Stream instance with reconnection enabled
-            const stream = new Stream<{ value: number }>({
-                stream: initialStream,
-                parse: async (val: unknown) => val as { value: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            // Collect all messages
-            const messages: { value: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
-            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
-
-            // Verify there were exactly 2 connections
-            expect(connectionAttempts.length).toBe(2);
-            // First connection had no Last-Event-ID
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            // Second connection (reconnect) had Last-Event-ID = "evt-3"
-            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
-        });
-
-        it("should handle multiple reconnections with a real server", async () => {
-            const connectionAttempts: { lastEventId: string | undefined }[] = [];
-            let connectionCount = 0;
-
-            server = http.createServer((req, res) => {
-                const lastEventId = req.headers["last-event-id"] as string | undefined;
-                connectionAttempts.push({ lastEventId });
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send 1 event, then drop
-                    res.write('id: 1\ndata: {"seq": 1}\n\n');
-                    res.end();
-                } else if (connectionCount === 2) {
-                    // Second connection: send 1 event, then drop again
-                    res.write('id: 2\ndata: {"seq": 2}\n\n');
-                    res.end();
-                } else if (connectionCount === 3) {
-                    // Third connection: send final event with terminator
-                    res.write('id: 3\ndata: {"seq": 3}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ seq: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { seq: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 5,
-                reconnect,
-            });
-
-            const messages: { seq: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
-            expect(connectionAttempts.length).toBe(3);
-            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
-            expect(connectionAttempts[1]?.lastEventId).toBe("1");
-            expect(connectionAttempts[2]?.lastEventId).toBe("2");
-        });
-
-        it("should respect server retry directive during reconnection", async () => {
-            let connectionCount = 0;
-            const connectionTimestamps: number[] = [];
-
-            server = http.createServer((_req, res) => {
-                connectionTimestamps.push(Date.now());
-                connectionCount++;
-
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // Send retry directive of 100ms, then drop
-                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
-                    res.end();
-                } else {
-                    res.write('id: 2\ndata: {"value": "second"}\n\n');
-                    res.write("data: [DONE]\n\n");
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ value: string }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { value: string },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 3,
-                reconnect,
-            });
-
-            const messages: { value: string }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
-            // Verify there was a delay between connections (at least the 100ms retry)
-            expect(connectionTimestamps.length).toBe(2);
-            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
-            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
-        });
-
-        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
-            let connectionCount = 0;
-
-            server = http.createServer((_req, res) => {
-                connectionCount++;
-                res.writeHead(200, {
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
-                });
-
-                if (connectionCount === 1) {
-                    // First connection: send one event, then drop
-                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
-                    res.end();
-                } else {
-                    // Reconnect attempts: immediately close without data (server down)
-                    res.end();
-                }
-            });
-
-            await new Promise<void>((resolve) => {
-                server.listen(0, "127.0.0.1", () => resolve());
-            });
-            const addr = server.address() as { port: number };
-            port = addr.port;
-            const url = `http://127.0.0.1:${port}/sse`;
-
-            const initialResponse = await fetch(url);
-
-            const reconnect = async (lastEventId: string) => {
-                const response = await fetch(url, {
-                    headers: { "Last-Event-ID": lastEventId },
-                });
-                return response.body!;
-            };
-
-            const stream = new Stream<{ attempt: number }>({
-                stream: initialResponse.body!,
-                parse: async (val: unknown) => val as { attempt: number },
-                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
-                reconnectionEnabled: true,
-                maxReconnectionAttempts: 2,
-                reconnect,
-            });
-
-            const messages: { attempt: number }[] = [];
-            for await (const message of stream) {
-                messages.push(message);
-            }
-
-            // Got only the event from the first connection
-            expect(messages).toEqual([{ attempt: 1 }]);
-            // Initial + 2 reconnect attempts = 3 connections total
-            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1,5 +1,5 @@
+import http from "http";
 import { Readable } from "stream";
-
 import { type ServerSentEvent, Stream } from "../../../src/core/stream/Stream";
 
 describe("Stream", () => {
@@ -1062,6 +1062,479 @@ describe("Stream", () => {
             }
 
             expect(messages).toEqual([{ value: 1 }]);
+        });
+    });
+
+    describe("SSE stream reconnection", () => {
+        it("should reconnect on premature EOF when resumable", async () => {
+            const firstStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+            ]);
+            const secondStream = createReadableStream(['id: 3\ndata: {"value": 3}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("2");
+        });
+
+        it("should not reconnect when reconnectionEnabled is false", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: false,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect when not resumable", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: false },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should respect maxReconnectionAttempts", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // Return a stream that immediately ends without data (server down)
+                return createReadableStream([]);
+            };
+
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // First stream yields 1, then reconnection attempts get empty streams
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(3);
+        });
+
+        it("should not reconnect when stream ends with terminator", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should not reconnect without a reconnect function", async () => {
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+        });
+
+        it("should not reconnect without a lastId", async () => {
+            const mockStream = createReadableStream(['data: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection E2E (real HTTP server)", () => {
+        let server: http.Server;
+        let port: number;
+
+        afterEach(async () => {
+            if (server) {
+                await new Promise<void>((resolve) => server.close(() => resolve()));
+            }
+        });
+
+        it("should reconnect to a real SSE server on connection drop and resume with Last-Event-ID", async () => {
+            // Track connection attempts and Last-Event-ID headers received
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send events 1-3, then drop (no terminator)
+                    res.write('id: evt-1\ndata: {"value": 1}\n\n');
+                    res.write('id: evt-2\ndata: {"value": 2}\n\n');
+                    res.write('id: evt-3\ndata: {"value": 3}\n\n');
+                    // Abruptly end the response to simulate a connection drop
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection (reconnect): verify Last-Event-ID and send remaining events
+                    res.write('id: evt-4\ndata: {"value": 4}\n\n');
+                    res.write('id: evt-5\ndata: {"value": 5}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                } else {
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            // Start the server on a random available port
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            // Make the initial fetch request
+            const initialResponse = await fetch(url);
+            const initialStream = initialResponse.body!;
+
+            // Create the reconnect function (simulates what the generated SDK does)
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            // Create the Stream instance with reconnection enabled
+            const stream = new Stream<{ value: number }>({
+                stream: initialStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            // Collect all messages
+            const messages: { value: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Verify we got all 5 events (3 from first connection + 2 from reconnect)
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }, { value: 5 }]);
+
+            // Verify there were exactly 2 connections
+            expect(connectionAttempts.length).toBe(2);
+            // First connection had no Last-Event-ID
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            // Second connection (reconnect) had Last-Event-ID = "evt-3"
+            expect(connectionAttempts[1]?.lastEventId).toBe("evt-3");
+        });
+
+        it("should handle multiple reconnections with a real server", async () => {
+            const connectionAttempts: { lastEventId: string | undefined }[] = [];
+            let connectionCount = 0;
+
+            server = http.createServer((req, res) => {
+                const lastEventId = req.headers["last-event-id"] as string | undefined;
+                connectionAttempts.push({ lastEventId });
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send 1 event, then drop
+                    res.write('id: 1\ndata: {"seq": 1}\n\n');
+                    res.end();
+                } else if (connectionCount === 2) {
+                    // Second connection: send 1 event, then drop again
+                    res.write('id: 2\ndata: {"seq": 2}\n\n');
+                    res.end();
+                } else if (connectionCount === 3) {
+                    // Third connection: send final event with terminator
+                    res.write('id: 3\ndata: {"seq": 3}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ seq: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { seq: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: { seq: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+            expect(connectionAttempts.length).toBe(3);
+            expect(connectionAttempts[0]?.lastEventId).toBeUndefined();
+            expect(connectionAttempts[1]?.lastEventId).toBe("1");
+            expect(connectionAttempts[2]?.lastEventId).toBe("2");
+        });
+
+        it("should respect server retry directive during reconnection", async () => {
+            let connectionCount = 0;
+            const connectionTimestamps: number[] = [];
+
+            server = http.createServer((_req, res) => {
+                connectionTimestamps.push(Date.now());
+                connectionCount++;
+
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // Send retry directive of 100ms, then drop
+                    res.write('retry: 100\nid: 1\ndata: {"value": "first"}\n\n');
+                    res.end();
+                } else {
+                    res.write('id: 2\ndata: {"value": "second"}\n\n');
+                    res.write("data: [DONE]\n\n");
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ value: string }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { value: string },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 3,
+                reconnect,
+            });
+
+            const messages: { value: string }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: "first" }, { value: "second" }]);
+            // Verify there was a delay between connections (at least the 100ms retry)
+            expect(connectionTimestamps.length).toBe(2);
+            const delayMs = connectionTimestamps[1]! - connectionTimestamps[0]!;
+            expect(delayMs).toBeGreaterThanOrEqual(90); // Allow small timing variance
+        });
+
+        it("should stop reconnecting after maxReconnectionAttempts with a real server", async () => {
+            let connectionCount = 0;
+
+            server = http.createServer((_req, res) => {
+                connectionCount++;
+                res.writeHead(200, {
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                });
+
+                if (connectionCount === 1) {
+                    // First connection: send one event, then drop
+                    res.write('id: evt-1\ndata: {"attempt": 1}\n\n');
+                    res.end();
+                } else {
+                    // Reconnect attempts: immediately close without data (server down)
+                    res.end();
+                }
+            });
+
+            await new Promise<void>((resolve) => {
+                server.listen(0, "127.0.0.1", () => resolve());
+            });
+            const addr = server.address() as { port: number };
+            port = addr.port;
+            const url = `http://127.0.0.1:${port}/sse`;
+
+            const initialResponse = await fetch(url);
+
+            const reconnect = async (lastEventId: string) => {
+                const response = await fetch(url, {
+                    headers: { "Last-Event-ID": lastEventId },
+                });
+                return response.body!;
+            };
+
+            const stream = new Stream<{ attempt: number }>({
+                stream: initialResponse.body!,
+                parse: async (val: unknown) => val as { attempt: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: { attempt: number }[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Got only the event from the first connection
+            expect(messages).toEqual([{ attempt: 1 }]);
+            // Initial + 2 reconnect attempts = 3 connections total
+            expect(connectionCount).toBe(3);
         });
     });
 });

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1257,6 +1257,187 @@ describe("Stream", () => {
         });
     });
 
+    describe("SSE stream reconnection - abort during delay", () => {
+        it("should stop promptly when aborted during reconnect delay", async () => {
+            const firstStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const abortController = new AbortController();
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                signal: abortController.signal,
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            const startTime = Date.now();
+
+            // Abort after a short delay (while the stream is in its reconnect delay)
+            setTimeout(() => abortController.abort(), 50);
+
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            const elapsed = Date.now() - startTime;
+            // Should have stopped well before the default 1000ms reconnect delay completes
+            expect(elapsed).toBeLessThan(500);
+            expect(messages).toEqual([{ value: 1 }]);
+            // reconnect should NOT have been called since we aborted during the delay
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - backoff with progress", () => {
+        it("should apply default backoff even when server sends no retry directive", async () => {
+            // Server yields 1 event then drops on each connection (no retry: field)
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const startTime = Date.now();
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            const totalElapsed = Date.now() - startTime;
+            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+        });
+
+        it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {
+            // Server yields 1 event per connection, then drops (no terminator, no retry).
+            // reconnectAttempts resets on progress, so the cap is per-consecutive-failed-reconnects.
+            // With data yielded each time, reconnects reset and should keep going until terminator.
+            const streams = [
+                createReadableStream(['id: 1\ndata: {"value": 1}\n\n']),
+                createReadableStream(['id: 2\ndata: {"value": 2}\n\n']),
+                createReadableStream(['id: 3\ndata: {"value": 3}\n\ndata: [DONE]\n\n']),
+            ];
+
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return streams[reconnectCallCount]!;
+            };
+
+            const stream = new Stream({
+                stream: streams[0]!,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 1,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Even with maxReconnectionAttempts=1, since each reconnect yields data
+            // the counter resets; all 3 events are received.
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
+
+    describe("SSE stream reconnection - terminator stops without extra reconnect", () => {
+        it("should stop immediately on terminator with zero reconnect calls", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(["data: [DONE]\n\n"]);
+            };
+
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "data: [DONE]\n\n",
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+
+        it("should stop immediately on terminator mid-stream without extra reconnect", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 99\ndata: {"value": 99}\n\ndata: [DONE]\n\n']);
+            };
+
+            // Terminator arrives in the middle of a stream that still has more data buffered
+            const mockStream = createReadableStream([
+                'id: 1\ndata: {"value": 1}\n\n',
+                'id: 2\ndata: {"value": 2}\n\n',
+                "id: 3\ndata: [DONE]\n\n",
+                'id: 4\ndata: {"value": 4}\n\n',
+            ]);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Should stop at [DONE] and not yield event 4 or attempt reconnection
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
     describe("SSE stream reconnection E2E (real HTTP server)", () => {
         let server: http.Server;
         let port: number;

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1100,6 +1100,41 @@ describe("Stream", () => {
             expect(lastReceivedEventId).toBe("2");
         });
 
+        it("should reconnect using the last dispatched id, not a parsed-but-undispatched id", async () => {
+            // evt-1 is fully dispatched; evt-2's id: line is parsed but the
+            // stream ends before evt-2's data + blank line, so evt-2 is never
+            // yielded. Reconnection must resume from evt-1 (the last dispatched
+            // id), otherwise evt-2 would be silently skipped.
+            const firstStream = createReadableStream(['id: evt-1\ndata: {"value": 1}\n\n', "id: evt-2\n"]);
+            const secondStream = createReadableStream(['id: evt-2\ndata: {"value": 2}\n\n', "data: [DONE]\n\n"]);
+
+            let reconnectCallCount = 0;
+            let lastReceivedEventId: string | undefined;
+            const reconnect = async (lastEventId: string) => {
+                reconnectCallCount++;
+                lastReceivedEventId = lastEventId;
+                return secondStream;
+            };
+
+            const stream = new Stream({
+                stream: firstStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }, { value: 2 }]);
+            expect(reconnectCallCount).toBe(1);
+            expect(lastReceivedEventId).toBe("evt-1");
+        });
+
         it("should not reconnect when reconnectionEnabled is false", async () => {
             const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
 

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1453,6 +1453,68 @@ describe("Stream", () => {
             expect(reconnectCallCount).toBe(0);
         });
     });
+
+    describe("SSE stream reconnection - no terminator prevents reconnect", () => {
+        it("should not attempt reconnection when no streamTerminator is configured", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                return createReadableStream(['id: 2\ndata: {"value": 2}\n\n']);
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 5,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            // Without a streamTerminator, shouldReconnect returns false
+            // to avoid a reconnect storm.
+            expect(messages).toEqual([{ value: 1 }]);
+            expect(reconnectCallCount).toBe(0);
+        });
+    });
+
+    describe("SSE stream reconnection - null reconnect body", () => {
+        it("should treat null reconnect body as a failed attempt", async () => {
+            let reconnectCallCount = 0;
+            const reconnect = async (_lastEventId: string) => {
+                reconnectCallCount++;
+                // @ts-expect-error Intentionally returning null to test null-body handling
+                return null;
+            };
+
+            const mockStream = createReadableStream(['id: 1\ndata: {"value": 1}\n\n']);
+
+            const stream = new Stream({
+                stream: mockStream,
+                parse: async (val: unknown) => val as { value: number },
+                eventShape: { type: "sse", streamTerminator: "[DONE]", resumable: true },
+                reconnectionEnabled: true,
+                maxReconnectionAttempts: 2,
+                reconnect,
+            });
+
+            const messages: unknown[] = [];
+            for await (const message of stream) {
+                messages.push(message);
+            }
+
+            expect(messages).toEqual([{ value: 1 }]);
+            // Both reconnect attempts returned null, exhausting maxReconnectionAttempts
+            expect(reconnectCallCount).toBe(2);
+        });
+    });
 });
 
 // Helper function to create a ReadableStream from string chunks

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/stream/Stream.test.ts
@@ -1289,8 +1289,9 @@ describe("Stream", () => {
             }
 
             const elapsed = Date.now() - startTime;
-            // Should have stopped well before the default 1000ms reconnect delay completes
-            expect(elapsed).toBeLessThan(500);
+            // Should have stopped well before the default 1000ms reconnect delay completes.
+            // Use a generous upper bound to avoid flakiness on slow CI runners.
+            expect(elapsed).toBeLessThan(800);
             expect(messages).toEqual([{ value: 1 }]);
             // reconnect should NOT have been called since we aborted during the delay
             expect(reconnectCallCount).toBe(0);
@@ -1337,9 +1338,10 @@ describe("Stream", () => {
 
             expect(messages).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
             expect(reconnectCallCount).toBe(2);
-            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each)
+            // Total elapsed time should be at least 2 * DEFAULT_RECONNECT_DELAY_MS (~1000ms each).
+            // Use a slightly relaxed lower bound to tolerate timer jitter on slow CI.
             const totalElapsed = Date.now() - startTime;
-            expect(totalElapsed).toBeGreaterThanOrEqual(1800);
+            expect(totalElapsed).toBeGreaterThanOrEqual(1500);
         });
 
         it("should respect maxReconnectionAttempts even when each reconnect yields data", async () => {


### PR DESCRIPTION
## Description

Implements transparent mid-stream SSE reconnection for `resumable: true` TypeScript SDK endpoints. On connection drop, the `Stream` runtime re-issues the request with a `Last-Event-ID` header via a generated `_reconnect` callback.

## Changes Made

### Runtime (`Stream.template.ts`)
- Reconnect loop in both `iterDataMessages` and `iterSseEvents` with `shouldReconnect` gating on `resumable`, `streamTerminator != null`, `reconnectionEnabled`, `reconnect != null`, `lastId`, attempt cap, and abort signal
- `delayReconnect` with abortable delay (abort listener clears timeout + resolves early), post-delay abort re-check before calling `reconnectFn`
- `DEFAULT_RECONNECT_DELAY_MS = 1_000` minimum backoff even without server `retry:` directive; server value clamped to `MAX_RECONNECT_DELAY_MS = 30_000`
- `shouldReconnect` returns `false` when `streamTerminator == null` — prevents reconnect storm on terminator-less endpoints
- Null check after `await reconnectFn(lastId)` — null body (e.g. 204/304) treated as failed reconnect via `createEmptyStream()`
- `createEmptyStream()` helper assigned on catch/null paths — avoids re-iterating drained `currentStream`
- Removed dead `terminatorReached` flag (immediate `return` after each assignment made the later guard unreachable)
- Abort listener leak fix: `externalSignal`/`onExternalAbort` stored as instance fields, `removeAbortListener()` called in `finally` blocks
- JSDoc on `maxReconnectionAttempts` documents reset-on-progress (per-consecutive-failed) semantics

### Generator wiring
- `GeneratedStreamingEndpointImplementation.ts`: generates `_reconnect` arrow function with `Last-Event-ID` header for resumable SSE endpoints; includes null body guard (`if (_reconnectResponse.body == null) throw`)
- `GeneratedThrowingEndpointResponse.ts`: `reconnectionEnabled`, `maxReconnectionAttempts`, and `reconnect` only emitted for resumable SSE endpoints (previously emitted for all streaming endpoints)
- `Stream.ts` (commons): wires new constructor params (`reconnectionEnabled`, `maxReconnectionAttempts`, `reconnect`)

### Tests
- Unit tests in `Stream.test.template.ts`: no-terminator prevents reconnect, null body treated as failed attempt, abort-during-delay stops promptly, default backoff applies, terminator stops without triggering reconnect
- E2E tests in `sse-reconnection.test.ts`: 5 tests with real HTTP server (basic reconnect, multiple reconnects, retry directive, max attempts, disabled)
- E2E inline Stream class includes `withMetadata()` and uses type-safe helpers (`assertBody`, `at`, `hasAsyncIterator`) instead of `!` and `as any`
- Timing assertions use generous bounds to avoid CI flakiness

### Generated output
- All 8 streaming seed fixtures regenerated (`server-sent-events-resumable`, `server-sent-events`, `server-sent-event-examples`, `server-sent-events-openapi`, `streaming/*`, `streaming-parameter`)
- Non-resumable streaming endpoints no longer emit dead `reconnectionEnabled`/`maxReconnectionAttempts` options

## Testing
- [x] Unit tests added (5 new reconnection test cases in template)
- [x] E2E tests added (5 tests with real HTTP server)
- [x] All 8 seed fixtures regenerated and passing
- [x] Snapshot tests updated
- [x] Biome formatting passes
- [x] TypeScript compilation passes

Link to Devin session: https://app.devin.ai/sessions/e8bc7dce89d141feadc89b5f948721aa
Requested by: @Swimburger