### PR TITLE
fix(cli): stop AI example enhancement adding an empty request body to bodyless endpoints

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-ai-examples-empty-request-body.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ai-examples-empty-request-body.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix AI example enhancement attaching an empty JSON request body (`{}`) to endpoints
+    that have no request body (e.g. DELETE endpoints). This caused docs code snippets to
+    render `-d '{}'` and a `Content-Type: application/json` header for bodyless endpoints.
+  type: fix

--- a/packages/cli/register/src/ai-example-enhancer/__test__/resolveEnhancedRequestBody.test.ts
+++ b/packages/cli/register/src/ai-example-enhancer/__test__/resolveEnhancedRequestBody.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEnhancedRequestBody } from "../enhanceExamplesWithAI.js";
+
+describe("resolveEnhancedRequestBody", () => {
+    it("drops an empty object body when the endpoint had no request example", () => {
+        expect(resolveEnhancedRequestBody({}, undefined)).toBeUndefined();
+        expect(resolveEnhancedRequestBody({}, null)).toBeUndefined();
+    });
+
+    it("drops a null/undefined body when the endpoint had no request example", () => {
+        expect(resolveEnhancedRequestBody(undefined, undefined)).toBeUndefined();
+        expect(resolveEnhancedRequestBody(null, undefined)).toBeUndefined();
+    });
+
+    it("keeps a non-empty body even when the endpoint had no request example", () => {
+        expect(resolveEnhancedRequestBody({ name: "Fern" }, undefined)).toEqual({ name: "Fern" });
+    });
+
+    it("keeps an empty object body when the original example was an empty object", () => {
+        expect(resolveEnhancedRequestBody({}, {})).toEqual({});
+    });
+
+    it("keeps the body when the original example exists", () => {
+        expect(resolveEnhancedRequestBody({ name: "Fern" }, { name: "string" })).toEqual({ name: "Fern" });
+    });
+});

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -8,7 +8,7 @@ import { readFile, writeFile } from "fs/promises";
 import * as yaml from "js-yaml";
 import { OpenAPIV3 } from "openapi-types";
 import { join } from "path";
-import { filterRequestBody, isFdrTypedValueWrapper, unwrapExampleValue } from "./filterHelpers.js";
+import { filterRequestBody, isEmptyObject, isFdrTypedValueWrapper, unwrapExampleValue } from "./filterHelpers.js";
 import { LambdaExampleEnhancer } from "./lambdaClient.js";
 import { SpinnerStatusCoordinator } from "./spinnerStatusCoordinator.js";
 import {
@@ -1241,7 +1241,7 @@ async function processEndpoint(
 
             return {
                 endpointKey,
-                enhancedReq: filteredBody,
+                enhancedReq: resolveEnhancedRequestBody(filteredBody, request.originalRequestExample),
                 enhancedRes: result.enhancedResponseExample,
                 extractedHeaders: Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined,
                 extractedPathParams: Object.keys(mergedPathParams).length > 0 ? mergedPathParams : undefined,
@@ -1253,7 +1253,7 @@ async function processEndpoint(
         context.logger.debug(`No changes needed for ${workItem.endpoint.method} ${workItem.example.path}`);
         return {
             endpointKey,
-            enhancedReq: result.enhancedRequestExample,
+            enhancedReq: resolveEnhancedRequestBody(result.enhancedRequestExample, request.originalRequestExample),
             enhancedRes: result.enhancedResponseExample
         };
     } catch (error) {
@@ -1676,6 +1676,18 @@ export function unwrapLambdaBodyEnvelope(value: unknown): { wasWrapped: boolean;
         return { wasWrapped: true, inner: (value as Record<string, unknown>).body };
     }
     return { wasWrapped: false, inner: value };
+}
+
+/**
+ * Endpoints without a request body (e.g. DELETE) must not gain one during enhancement:
+ * once path/query/header params are filtered out of the AI's request example, an empty
+ * object would otherwise be attached as a JSON body and rendered in code snippets.
+ */
+export function resolveEnhancedRequestBody(filteredBody: unknown, originalRequestExample: unknown): unknown {
+    if (originalRequestExample == null && isEmptyObject(filteredBody)) {
+        return undefined;
+    }
+    return filteredBody;
 }
 
 /**


### PR DESCRIPTION
## Description
DELETE (and other bodyless) endpoints were rendering curl examples with `-d '{}'` and a `Content-Type: application/json` header in docs (reported on sigma.ferndocs.com's `DELETE /v2/accountTypes/{accountTypeId}`).

Root cause: during AI example enhancement (`enhanceExamplesWithAI`), the Lambda may return a request example for an endpoint that has no request body (typically containing path/query params). After `filterRequestBody` extracts those params, the leftover `{}` was still attached as a JSON request body:

```ts
// applyEnhancementResults
if (enhancementResult.enhancedReq !== undefined) {
    ...
    enhancedExample.requestBodyV3 = { type: "json", value: enhancementResult.enhancedReq }; // value: {}
}
```

FDR then renders a `{ type: "json" }` body → curl snippet gets `-d '{}'` + `Content-Type: application/json`.

Note: `writeAiExamplesOverride` already guarded this case with `isEmptyObject`; the in-memory apply path did not.

## Changes Made
- Added `resolveEnhancedRequestBody(filteredBody, originalRequestExample)`: returns `undefined` when the endpoint had no original request example and the filtered enhanced body is empty, so no request body example is attached.
- Applied it to both return paths in the single-work-item enhancer (post-filter and the "no changes" path).
- Added changelog entry `packages/cli/cli/changes/unreleased/fix-ai-examples-empty-request-body.yml`.

## Testing
- [x] Unit tests added/updated (`resolveEnhancedRequestBody.test.ts`, 5 cases; full `ai-example-enhancer` suite passes: 63/63)
- [x] Manual testing completed (verified via IR generation on the affected customer config that the endpoint has no request body in the spec/IR, so the `{}` was introduced only by the enhancement step)


Link to Devin session: https://app.devin.ai/sessions/7c7e204b226046b2b39a3c88d2c6d736
Requested by: @cadesark
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->