### PR TITLE
fix(generator-cli): commit replay lockfile when no-patches flow skips [fern-replay] commit

### DIFF
--- a/packages/generator-cli/changes/unreleased/fix-stale-lockfile-advance.yml
+++ b/packages/generator-cli/changes/unreleased/fix-stale-lockfile-advance.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix replay lockfile not advancing in the no-patches flow when zero new
+    patches are detected. The lockfile's current_generation was saved to disk
+    but never committed, causing previousGenerationSha to remain stale and
+    autoversion diffs to accumulate across runs.
+  type: fix

--- a/packages/generator-cli/src/__test__/replay-advanced.test.ts
+++ b/packages/generator-cli/src/__test__/replay-advanced.test.ts
@@ -304,6 +304,60 @@ describe("ReplayStep integration", { tags: ["slow", "flaky"] }, () => {
 });
 
 // ---------------------------------------------------------------------------
+// describe("lockfile advance commit (no-patches, zero new patches)")
+// ---------------------------------------------------------------------------
+
+describe("lockfile advance commit (no-patches, zero new patches)", { tags: ["slow", "flaky"] }, () => {
+    it("commits the lockfile when replay saved it but didn't create a [fern-replay] commit", async () => {
+        const setup = await setupRepoWithGeneration();
+        const repoPath = setup.repoPath;
+        try {
+            const originalLock = readFileSync(join(repoPath, ".fern", "replay.lock"), "utf-8");
+            const originalCurrentGen = setup.generationSha;
+
+            // Stage new generated files to simulate a regeneration with no user patches.
+            // The content differs from v1 so prepareReplay creates a new [fern-generated] commit.
+            writeFileSync(
+                join(repoPath, "src/client.ts"),
+                'export class Client {\n  baseUrl = "https://api.example.com";\n  version = "2";\n}\n'
+            );
+            gitExec(["add", "."], repoPath);
+
+            const mockLogger: PipelineLogger = {
+                debug: vi.fn(),
+                info: vi.fn(),
+                warn: vi.fn(),
+                error: vi.fn()
+            };
+
+            // stageOnly: false so commitLockfileIfUncommitted runs
+            const config: ReplayStepConfig = { enabled: true, stageOnly: false };
+            const step = new ReplayStep(repoPath, mockLogger, config);
+
+            const result = await step.execute(emptyContext);
+
+            expect(result.executed).toBe(true);
+            expect(result.success).toBe(true);
+
+            // The lockfile must NOT have uncommitted changes — the fix commits it.
+            const lockfileStatus = gitExec(["status", "--porcelain", "--", ".fern/replay.lock"], repoPath);
+            expect(lockfileStatus).toBe("");
+
+            // The lockfile's current_generation must have advanced from the original.
+            const updatedLock = readFileSync(join(repoPath, ".fern", "replay.lock"), "utf-8");
+            expect(updatedLock).not.toBe(originalLock);
+            expect(updatedLock).not.toContain(`current_generation: ${originalCurrentGen}`);
+
+            // A commit with the lockfile advance message must exist in git log.
+            const log = gitExec(["log", "--oneline", "-10"], repoPath);
+            expect(log).toContain("[fern-replay]");
+        } finally {
+            await setup.cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
 // describe("fernignore idempotency")
 // ---------------------------------------------------------------------------
 

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { replayApply, replayRun } from "../../replay/replay-run";
 import type { PipelineLogger } from "../PipelineLogger";
 import type { PipelineContext, ReplayStepConfig, ReplayStepResult } from "../types";
@@ -65,20 +66,39 @@ export class ReplayStep extends BaseStep {
             };
         }
 
+        const stageOnly = this.config.stageOnly ?? false;
         const result =
             prepared != null
                 ? await replayApply(prepared, {
-                      stageOnly: this.config.stageOnly ?? false,
+                      stageOnly,
                       logger: this.logger
                   })
                 : await replayRun({
                       outputDir: this.outputDir,
                       cliVersion: this.cliVersion,
                       generatorVersions: this.generatorVersions,
-                      stageOnly: this.config.stageOnly ?? false,
+                      stageOnly,
                       skipApplication: this.config.skipApplication,
                       logger: this.logger
                   });
+
+        // The replay service updates the lockfile's `current_generation` in
+        // memory during prepare and writes it to disk via `lockManager.save()`
+        // during apply. However, in the no-patches flow with zero new patches,
+        // no `[fern-replay]` commit is created — the lockfile update is left as
+        // an uncommitted change. Since `skipCommit = true` for non-first-
+        // generation flows, GithubStep won't commit it either, so the advance
+        // is silently lost. On the next run the stale `current_generation`
+        // causes `previousGenerationSha` to point at an old commit, producing
+        // cumulative diffs and duplicate changelog entries.
+        //
+        // Commit the lockfile here when it was modified but not committed by
+        // the replay service. This is safe even after a crash (best-effort:
+        // either the save happened and we commit, or it didn't and this is a
+        // no-op).
+        if (!stageOnly) {
+            this.commitLockfileIfUncommitted();
+        }
 
         if (result.failureReason != null) {
             // Prepare or apply crashed at runtime — surface via replayCrashed so
@@ -147,5 +167,35 @@ export class ReplayStep extends BaseStep {
             })),
             warnings: report.warnings
         };
+    }
+
+    /**
+     * Commits `.fern/replay.lock` when replay saved the lockfile to disk but
+     * didn't create a `[fern-replay]` commit (e.g. no-patches flow with zero
+     * new patches). Without this, `skipCommit = true` in GithubStep drops the
+     * lockfile advance, freezing `previousGenerationSha` across runs.
+     */
+    private commitLockfileIfUncommitted(): void {
+        try {
+            const status = execFileSync(
+                "git",
+                ["status", "--porcelain", "--", ".fern/replay.lock"],
+                { cwd: this.outputDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+            ).trim();
+            if (status.length === 0) {
+                return;
+            }
+            execFileSync("git", ["add", "--", ".fern/replay.lock"], {
+                cwd: this.outputDir,
+                stdio: "pipe"
+            });
+            execFileSync("git", ["commit", "-m", "[fern-replay] advance lockfile"], {
+                cwd: this.outputDir,
+                stdio: "pipe"
+            });
+            this.logger.debug("ReplayStep: committed uncommitted lockfile advance.");
+        } catch {
+            // Best-effort — don't fail the pipeline on lockfile commit issues.
+        }
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "child_process";
 import { replayApply, replayRun } from "../../replay/replay-run";
+import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "../github/constants";
 import type { PipelineLogger } from "../PipelineLogger";
 import type { PipelineContext, ReplayStepConfig, ReplayStepResult } from "../types";
 import { BaseStep } from "./BaseStep";
@@ -189,13 +190,14 @@ export class ReplayStep extends BaseStep {
                 cwd: this.outputDir,
                 stdio: "pipe"
             });
-            execFileSync("git", ["commit", "-m", "[fern-replay] advance lockfile"], {
-                cwd: this.outputDir,
-                stdio: "pipe"
-            });
+            execFileSync(
+                "git",
+                ["-c", `user.name=${FERN_BOT_NAME}`, "-c", `user.email=${FERN_BOT_EMAIL}`, "commit", "-m", "[fern-replay] advance lockfile"],
+                { cwd: this.outputDir, stdio: "pipe" }
+            );
             this.logger.debug("ReplayStep: committed uncommitted lockfile advance.");
-        } catch {
-            // Best-effort — don't fail the pipeline on lockfile commit issues.
+        } catch (error) {
+            this.logger.debug("ReplayStep: failed to commit lockfile advance: " + String(error));
         }
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -177,11 +177,11 @@ export class ReplayStep extends BaseStep {
      */
     private commitLockfileIfUncommitted(): void {
         try {
-            const status = execFileSync(
-                "git",
-                ["status", "--porcelain", "--", ".fern/replay.lock"],
-                { cwd: this.outputDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-            ).trim();
+            const status = execFileSync("git", ["status", "--porcelain", "--", ".fern/replay.lock"], {
+                cwd: this.outputDir,
+                encoding: "utf-8",
+                stdio: ["pipe", "pipe", "pipe"]
+            }).trim();
             if (status.length === 0) {
                 return;
             }

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -192,7 +192,15 @@ export class ReplayStep extends BaseStep {
             });
             execFileSync(
                 "git",
-                ["-c", `user.name=${FERN_BOT_NAME}`, "-c", `user.email=${FERN_BOT_EMAIL}`, "commit", "-m", "[fern-replay] advance lockfile"],
+                [
+                    "-c",
+                    `user.name=${FERN_BOT_NAME}`,
+                    "-c",
+                    `user.email=${FERN_BOT_EMAIL}`,
+                    "commit",
+                    "-m",
+                    "[fern-replay] advance lockfile"
+                ],
                 { cwd: this.outputDir, stdio: "pipe" }
             );
             this.logger.debug("ReplayStep: committed uncommitted lockfile advance.");


### PR DESCRIPTION
## Description
Closes #16870

When the replay service selects the **no-patches flow** and detects **zero new patches**, it calls `lockManager.save()` (advancing `current_generation` on disk) but skips the `[fern-replay]` commit (gated behind `if (newPatches.length > 0)`). Because `deriveSkipCommit()` returns `true` for non-first-generation flows, GithubStep never calls `commitAllChanges()` either — the lockfile advance is silently dropped from the PR.

On the next run, `previousGenerationSha` reads the stale `current_generation`, so `AutoVersionStep` diffs against an old base commit and produces cumulative changelogs that re-announce features shipped weeks ago.

## Changes Made

**`ReplayStep.ts`** — After `replayApply`/`replayRun` returns (and before the result is mapped), call `commitLockfileIfUncommitted()`:

```typescript
// Check if .fern/replay.lock has uncommitted changes
private commitLockfileIfUncommitted(): void {
    const status = git status --porcelain -- .fern/replay.lock
    if (status is non-empty) {
        git add -- .fern/replay.lock
        git commit -m "[fern-replay] advance lockfile"
    }
}
```

This is best-effort (wrapped in try/catch) and is a no-op when:
- The replay service already committed the lockfile (normal-regeneration / skip-application flows)
- `lockManager.save()` was never reached (crash before save)
- `stageOnly: true` (staging mode skips the commit)

**`replay-advanced.test.ts`** — New test `"commits the lockfile when replay saved it but didn't create a [fern-replay] commit"`: sets up a repo in the no-patches-zero-new-patches scenario and verifies the lockfile advance is committed and `current_generation` has advanced.

- [x] Unit tests added/updated
- [x] Changelog entry added (`packages/generator-cli/changes/unreleased/fix-stale-lockfile-advance.yml`)

Link to Devin session: https://app.devin.ai/sessions/06e56c84a97840d08d3e5819f4e345e5
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->