### PR TITLE
fix(typescript): rename inlined path params that collide with body properties

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-rename-colliding-inlined-path-parameters.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-rename-colliding-inlined-path-parameters.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    When an inlined path parameter (`inlinePathParameters: true`) shares its property name with an
+    inlined request-body property (e.g. a `{idType}` path parameter and an `idType` body field),
+    the request wrapper now keeps both fields by renaming the path parameter with a `PathParam`
+    suffix (e.g. `idTypePathParam`). Previously the two values were collapsed into a single shared
+    field, which made it impossible to send different values for the URL path and the request body.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/__test__/EndpointRequests.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/EndpointRequests.test.ts
@@ -291,6 +291,10 @@ function createMockGeneratedRequestWrapper() {
             propertyName: caseConverter.camelUnsafe(pp.name),
             safeName: caseConverter.camelUnsafe(pp.name)
         }),
+        getInlinedPathParameterPropertyName: (pp: FernIr.PathParameter) => ({
+            propertyName: caseConverter.camelUnsafe(pp.name),
+            safeName: caseConverter.camelUnsafe(pp.name)
+        }),
         getPropertyNameOfNonLiteralHeader: (h: FernIr.HttpHeader) => ({
             propertyName: caseConverter.camelUnsafe(h.name),
             safeName: caseConverter.camelUnsafe(h.name)

--- a/generators/typescript/sdk/client-class-generator/src/__test__/RequestParameters.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/RequestParameters.test.ts
@@ -115,6 +115,10 @@ function createMockGeneratedRequestWrapper(opts?: {
             propertyName: caseConverter.camelUnsafe(pp.name),
             safeName: caseConverter.camelUnsafe(pp.name)
         }),
+        getInlinedPathParameterPropertyName: (pp: FernIr.PathParameter) => ({
+            propertyName: caseConverter.camelUnsafe(pp.name),
+            safeName: caseConverter.camelUnsafe(pp.name)
+        }),
         getPropertyNameOfNonLiteralHeader: (h: FernIr.HttpHeader) => ({
             propertyName: caseConverter.camelUnsafe(h.name),
             safeName: caseConverter.camelUnsafe(h.name)

--- a/generators/typescript/sdk/client-class-generator/src/request-parameter/RequestWrapperParameter.ts
+++ b/generators/typescript/sdk/client-class-generator/src/request-parameter/RequestWrapperParameter.ts
@@ -180,16 +180,7 @@ export class RequestWrapperParameter extends AbstractRequestParameter {
             throw new Error("Path parameter does not exist: " + pathParameterKey);
         }
         const generatedRequestWrapper = this.getGeneratedRequestWrapper(context);
-        const propertyName = generatedRequestWrapper.getPropertyNameOfPathParameter(pathParameter);
-        const collidingPathParamPropertyNames = generatedRequestWrapper.getCollidingPathParameterPropertyNames(context);
-        if (collidingPathParamPropertyNames.has(propertyName.propertyName)) {
-            // The path parameter shares its name with a body property, so it is not destructured out
-            // of the request. Reference it through the request body so the value is sent in both the
-            // URL path and the request body.
-            const bodyReference =
-                this.getReferenceToRequestBody(context) ?? ts.factory.createIdentifier(this.getRequestParameterName());
-            return createMemberAccess(bodyReference, propertyName.propertyName);
-        }
+        const propertyName = generatedRequestWrapper.getInlinedPathParameterPropertyName(pathParameter, context);
         return ts.factory.createIdentifier(this.getAliasForNonBodyProperty(propertyName));
     }
 
@@ -308,12 +299,4 @@ export class RequestWrapperParameter extends AbstractRequestParameter {
         }
         return undefined;
     }
-}
-
-const VALID_IDENTIFIER_REGEX = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-
-function createMemberAccess(object: ts.Expression, propertyName: string): ts.Expression {
-    return VALID_IDENTIFIER_REGEX.test(propertyName)
-        ? ts.factory.createPropertyAccessExpression(object, propertyName)
-        : ts.factory.createElementAccessExpression(object, ts.factory.createStringLiteral(propertyName));
 }

--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperExampleImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperExampleImpl.ts
@@ -110,21 +110,16 @@ export class GeneratedRequestWrapperExampleImpl implements GeneratedRequestWrapp
         }
 
         const pathParams = [...this.example.servicePathParameters, ...this.example.endpointPathParameters];
-        const collidingPathParamPropertyNames = generatedType.getCollidingPathParameterPropertyNames(context);
 
-        return pathParams
-            .filter(
-                (pathParam) =>
-                    !collidingPathParamPropertyNames.has(
-                        generatedType.getPropertyNameOfPathParameterFromName(pathParam.name).propertyName
-                    )
-            )
-            .map((pathParam) => {
-                const propertyName = generatedType.getPropertyNameOfPathParameterFromName(pathParam.name).propertyName;
-                const value = context.type.getGeneratedExample(pathParam.value).build(context, opts);
+        return pathParams.map((pathParam) => {
+            const propertyName = generatedType.getInlinedPathParameterPropertyNameFromName(
+                pathParam.name,
+                context
+            ).propertyName;
+            const value = context.type.getGeneratedExample(pathParam.value).build(context, opts);
 
-                return ts.factory.createPropertyAssignment(getPropertyKey(propertyName), value);
-            });
+            return ts.factory.createPropertyAssignment(getPropertyKey(propertyName), value);
+        });
     }
 
     private buildQueryParamProperties(

--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
@@ -754,14 +754,48 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
         if (!collidingPathParamPropertyNames.has(base.propertyName)) {
             return base;
         }
-        const bodyPropertyNames = this.getInlinedBodyPropertyNames(context);
+        const reservedPropertyNames = this.getReservedWrapperPropertyNames(context, base.propertyName);
         let propertyName = appendPathParamSuffix(base.propertyName);
         let safeName = appendPathParamSuffix(base.safeName);
-        while (bodyPropertyNames.has(propertyName)) {
+        while (reservedPropertyNames.has(propertyName)) {
             propertyName = `${propertyName}_`;
             safeName = `${safeName}_`;
         }
         return { propertyName, safeName };
+    }
+
+    /**
+     * Property names already used by other members of the request wrapper (body properties,
+     * path parameters, query parameters, headers, and inlined file properties). Used to
+     * disambiguate the suffixed name of a renamed colliding path parameter.
+     */
+    private getReservedWrapperPropertyNames(context: FileContext, excludedPathParamName: string): Set<string> {
+        const reserved = this.getInlinedBodyPropertyNames(context);
+        for (const pathParameter of this.getPathParamsForRequestWrapper(context)) {
+            const propertyName = this.getPropertyNameOfPathParameter(pathParameter).propertyName;
+            if (propertyName !== excludedPathParamName) {
+                reserved.add(propertyName);
+            }
+        }
+        const collidingQueryParamWireValues = this.resolveQueryParameterNameConflicts
+            ? this.getCollidingQueryParamWireValues(context)
+            : new Set<string>();
+        for (const queryParameter of this.getAllQueryParameters()) {
+            reserved.add(
+                collidingQueryParamWireValues.has(getWireValue(queryParameter.name))
+                    ? this.getOverriddenPropertyNameOfQueryParameter(queryParameter).propertyName
+                    : this.getPropertyNameOfQueryParameter(queryParameter).propertyName
+            );
+        }
+        for (const header of this.getAllNonLiteralHeaders(context)) {
+            reserved.add(this.getPropertyNameOfNonLiteralHeader(header).propertyName);
+        }
+        if (this.inlineFileProperties) {
+            for (const fileProperty of this.getAllFileUploadProperties()) {
+                reserved.add(this.getPropertyNameOfFileParameter(fileProperty).propertyName);
+            }
+        }
+        return reserved;
     }
 
     public getPropertyNameOfPathParameterFromName(name: FernIr.NameOrString): RequestWrapperNonBodyProperty {

--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
@@ -193,16 +193,8 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
             ? this.getCollidingQueryParamWireValues(context)
             : new Set<string>();
 
-        // When an inlined path parameter shares its property name with a body property, emit only
-        // the body property to avoid a duplicate interface member. The shared field is used for both
-        // the URL path and the request body.
-        const collidingPathParamPropertyNames = this.getCollidingPathParameterPropertyNames(context);
-
         for (const pathParameter of this.getPathParamsForRequestWrapper(context)) {
-            const propertyName = this.getPropertyNameOfPathParameter(pathParameter);
-            if (collidingPathParamPropertyNames.has(propertyName.propertyName)) {
-                continue;
-            }
+            const propertyName = this.getInlinedPathParameterPropertyName(pathParameter, context);
             const type = context.type.getReferenceToType(pathParameter.valueType);
             const hasDefaultValue = this.hasDefaultValue(pathParameter.valueType, context);
             const hasClientDefault = pathParameter.clientDefault != null;
@@ -537,19 +529,10 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
             ? this.getCollidingQueryParamWireValues(context)
             : new Set<string>();
 
-        // Path parameters that collide with a body property are not destructured out of the request,
-        // so they remain part of the spread request body (and are referenced for the URL via the body).
-        const collidingPathParamPropertyNames = this.getCollidingPathParameterPropertyNames(context);
-
         const properties = [
-            ...this.getPathParamsForRequestWrapper(context)
-                .filter(
-                    (pathParameter) =>
-                        !collidingPathParamPropertyNames.has(
-                            this.getPropertyNameOfPathParameter(pathParameter).propertyName
-                        )
-                )
-                .map((pathParameter) => this.getPropertyNameOfPathParameter(pathParameter)),
+            ...this.getPathParamsForRequestWrapper(context).map((pathParameter) =>
+                this.getInlinedPathParameterPropertyName(pathParameter, context)
+            ),
             ...this.getAllQueryParameters().map((queryParameter) =>
                 collidingQueryParamWireValues.has(getWireValue(queryParameter.name))
                     ? this.getOverriddenPropertyNameOfQueryParameter(queryParameter)
@@ -573,25 +556,14 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
             ? this.getCollidingQueryParamWireValues(context)
             : new Set<string>();
 
-        // Path parameters that collide with a body property are not destructured out of the request,
-        // so they remain part of the spread request body (and are referenced for the URL via the body).
-        const collidingPathParamPropertyNames = this.getCollidingPathParameterPropertyNames(context);
-
         const properties: RequestWrapperNonBodyPropertyWithData[] = [
-            ...this.getPathParamsForRequestWrapper(context)
-                .filter(
-                    (pathParameter) =>
-                        !collidingPathParamPropertyNames.has(
-                            this.getPropertyNameOfPathParameter(pathParameter).propertyName
-                        )
-                )
-                .map((pathParameter) => ({
-                    ...this.getPropertyNameOfPathParameter(pathParameter),
-                    originalParameter: {
-                        type: "path" as const,
-                        parameter: pathParameter
-                    }
-                })),
+            ...this.getPathParamsForRequestWrapper(context).map((pathParameter) => ({
+                ...this.getInlinedPathParameterPropertyName(pathParameter, context),
+                originalParameter: {
+                    type: "path" as const,
+                    parameter: pathParameter
+                }
+            })),
             ...this.getAllQueryParameters().map((queryParameter) => ({
                 ...(collidingQueryParamWireValues.has(getWireValue(queryParameter.name))
                     ? this.getOverriddenPropertyNameOfQueryParameter(queryParameter)
@@ -764,6 +736,32 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
 
     public getPropertyNameOfPathParameter(pathParameter: FernIr.PathParameter): RequestWrapperNonBodyProperty {
         return this.getPropertyNameOfPathParameterFromName(pathParameter.name);
+    }
+
+    public getInlinedPathParameterPropertyName(
+        pathParameter: FernIr.PathParameter,
+        context: FileContext
+    ): RequestWrapperNonBodyProperty {
+        return this.getInlinedPathParameterPropertyNameFromName(pathParameter.name, context);
+    }
+
+    public getInlinedPathParameterPropertyNameFromName(
+        name: FernIr.NameOrString,
+        context: FileContext
+    ): RequestWrapperNonBodyProperty {
+        const base = this.getPropertyNameOfPathParameterFromName(name);
+        const collidingPathParamPropertyNames = this.getCollidingPathParameterPropertyNames(context);
+        if (!collidingPathParamPropertyNames.has(base.propertyName)) {
+            return base;
+        }
+        const bodyPropertyNames = this.getInlinedBodyPropertyNames(context);
+        let propertyName = appendPathParamSuffix(base.propertyName);
+        let safeName = appendPathParamSuffix(base.safeName);
+        while (bodyPropertyNames.has(propertyName)) {
+            propertyName = `${propertyName}_`;
+            safeName = `${safeName}_`;
+        }
+        return { propertyName, safeName };
     }
 
     public getPropertyNameOfPathParameterFromName(name: FernIr.NameOrString): RequestWrapperNonBodyProperty {
@@ -1132,9 +1130,9 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
      * When path parameters are inlined into the request wrapper (`inlinePathParameters: true`),
      * a path parameter can share its property name with an inlined body property (e.g. a `{idType}`
      * path param and an `idType` body field). Emitting both would produce a duplicate interface
-     * member (TS2300) and the client would destructure the path param out of the body, dropping it
-     * from the request payload. In that case the body property serves as the single shared field:
-     * the value is read for the URL path and also sent in the body.
+     * member (TS2300). Colliding path parameters are renamed with a `PathParam` suffix so both
+     * values remain independently settable (the path parameter for the URL, the body property for
+     * the request payload).
      */
     public getCollidingPathParameterPropertyNames(context: FileContext): Set<string> {
         const colliding = new Set<string>();
@@ -1169,4 +1167,8 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
             propertyName: this.retainOriginalCasing ? getOriginalName(name) : this.case.camelUnsafe(name)
         };
     }
+}
+
+function appendPathParamSuffix(name: string): string {
+    return name.includes("_") ? `${name}_path_param` : `${name}PathParam`;
 }

--- a/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperExampleImpl.test.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperExampleImpl.test.ts
@@ -95,7 +95,14 @@ function createMockContext(opts?: {
         getInlinedRequestBodyPropertyKeyFromName: (name: FernIr.NameAndWireValueOrString) => ({
             propertyName: caseConverter.camelUnsafe(name)
         }),
-        getCollidingPathParameterPropertyNames: () => new Set<string>(opts?.collidingPathParameterPropertyNames ?? [])
+        getCollidingPathParameterPropertyNames: () => new Set<string>(opts?.collidingPathParameterPropertyNames ?? []),
+        getInlinedPathParameterPropertyNameFromName: (name: FernIr.NameOrString) => {
+            const propertyName = caseConverter.camelUnsafe(name);
+            if ((opts?.collidingPathParameterPropertyNames ?? []).includes(propertyName)) {
+                return { propertyName: `${propertyName}PathParam` };
+            }
+            return { propertyName };
+        }
     };
 
     return {
@@ -1000,7 +1007,7 @@ describe("GeneratedRequestWrapperExampleImpl", () => {
             expect(text).toContain("content");
         });
 
-        it("omits path params that collide with a body property to avoid duplicate keys", () => {
+        it("renames path params that collide with a body property to avoid duplicate keys", () => {
             const impl = createImpl({
                 example: createExampleEndpointCall({
                     endpointPathParameters: [
@@ -1030,6 +1037,7 @@ describe("GeneratedRequestWrapperExampleImpl", () => {
             const text = getTextOfTsNode(result);
 
             expect(text.match(/idType:/g)?.length ?? 0).toBe(1);
+            expect(text.match(/idTypePathParam:/g)?.length ?? 0).toBe(1);
         });
     });
 

--- a/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperImpl.test.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperImpl.test.ts
@@ -398,6 +398,34 @@ describe("GeneratedRequestWrapperImpl", () => {
             expect(sourceFile.getText()).toMatchSnapshot();
         });
 
+        it("renames inlined path parameters that collide with body properties", () => {
+            const body = createInlinedRequestBody({
+                properties: [
+                    createInlinedRequestBodyProperty("idType", STRING_TYPE),
+                    createInlinedRequestBodyProperty("oldValue", STRING_TYPE),
+                    createInlinedRequestBodyProperty("newValue", STRING_TYPE)
+                ]
+            });
+            const init = createDefaultInit({
+                shouldInlinePathParameters: true,
+                endpoint: createHttpEndpoint({
+                    pathParameters: [createPathParameter("idType", "ENDPOINT")],
+                    requestBody: FernIr.HttpRequestBody.inlinedRequestBody(body),
+                    sdkRequest: createSdkRequestWrapper()
+                })
+            });
+            const wrapper = new GeneratedRequestWrapperImpl(init);
+            const { context, sourceFile } = createMockContext({
+                shouldInlinePathParameters: true
+            });
+
+            wrapper.writeToFile(context);
+            const text = sourceFile.getText();
+            expect(text).toContain("idTypePathParam: string");
+            expect(text).toContain("idType: string");
+            expect(text).toMatchSnapshot();
+        });
+
         it("generates interface with inlined request body properties", () => {
             const body = createInlinedRequestBody({
                 properties: [

--- a/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperImpl.test.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperImpl.test.ts
@@ -426,6 +426,58 @@ describe("GeneratedRequestWrapperImpl", () => {
             expect(text).toMatchSnapshot();
         });
 
+        it("disambiguates renamed path parameter when the suffixed name is also taken", () => {
+            const body = createInlinedRequestBody({
+                properties: [
+                    createInlinedRequestBodyProperty("idType", STRING_TYPE),
+                    createInlinedRequestBodyProperty("idTypePathParam", STRING_TYPE)
+                ]
+            });
+            const init = createDefaultInit({
+                shouldInlinePathParameters: true,
+                endpoint: createHttpEndpoint({
+                    pathParameters: [createPathParameter("idType", "ENDPOINT")],
+                    requestBody: FernIr.HttpRequestBody.inlinedRequestBody(body),
+                    sdkRequest: createSdkRequestWrapper()
+                })
+            });
+            const wrapper = new GeneratedRequestWrapperImpl(init);
+            const { context, sourceFile } = createMockContext({
+                shouldInlinePathParameters: true
+            });
+
+            wrapper.writeToFile(context);
+            const text = sourceFile.getText();
+            expect(text).toContain("idTypePathParam_: string");
+            expect(text).toContain("idTypePathParam: string");
+            expect(text).toContain("idType: string");
+            expect(text).toMatchSnapshot();
+        });
+
+        it("disambiguates renamed path parameter when the suffixed name collides with a query parameter", () => {
+            const body = createInlinedRequestBody({
+                properties: [createInlinedRequestBodyProperty("idType", STRING_TYPE)]
+            });
+            const init = createDefaultInit({
+                shouldInlinePathParameters: true,
+                endpoint: createHttpEndpoint({
+                    pathParameters: [createPathParameter("idType", "ENDPOINT")],
+                    queryParameters: [createQueryParameter("idTypePathParam", STRING_TYPE)],
+                    requestBody: FernIr.HttpRequestBody.inlinedRequestBody(body),
+                    sdkRequest: createSdkRequestWrapper()
+                })
+            });
+            const wrapper = new GeneratedRequestWrapperImpl(init);
+            const { context, sourceFile } = createMockContext({
+                shouldInlinePathParameters: true
+            });
+
+            wrapper.writeToFile(context);
+            const text = sourceFile.getText();
+            expect(text).toContain("idTypePathParam_: string");
+            expect(text).toMatchSnapshot();
+        });
+
         it("generates interface with inlined request body properties", () => {
             const body = createInlinedRequestBody({
                 properties: [

--- a/generators/typescript/sdk/request-wrapper-generator/src/__test__/__snapshots__/GeneratedRequestWrapperImpl.test.ts.snap
+++ b/generators/typescript/sdk/request-wrapper-generator/src/__test__/__snapshots__/GeneratedRequestWrapperImpl.test.ts.snap
@@ -262,6 +262,16 @@ exports[`GeneratedRequestWrapperImpl > writeToFile > generates interface with re
 "
 `;
 
+exports[`GeneratedRequestWrapperImpl > writeToFile > renames inlined path parameters that collide with body properties 1`] = `
+"export interface TestRequest {
+    idTypePathParam: string;
+    idType: string;
+    oldValue: string;
+    newValue: string;
+}
+"
+`;
+
 exports[`GeneratedRequestWrapperImpl > writeToFile - enableInlineTypes > does not generate namespace module when no inline properties exist 1`] = `
 "export interface TestRequest {
     name: string;

--- a/generators/typescript/sdk/request-wrapper-generator/src/__test__/__snapshots__/GeneratedRequestWrapperImpl.test.ts.snap
+++ b/generators/typescript/sdk/request-wrapper-generator/src/__test__/__snapshots__/GeneratedRequestWrapperImpl.test.ts.snap
@@ -117,6 +117,24 @@ exports[`GeneratedRequestWrapperImpl > withQueryParameter > wraps in !== undefin
 }"
 `;
 
+exports[`GeneratedRequestWrapperImpl > writeToFile > disambiguates renamed path parameter when the suffixed name collides with a query parameter 1`] = `
+"export interface TestRequest {
+    idTypePathParam_: string;
+    idTypePathParam: string;
+    idType: string;
+}
+"
+`;
+
+exports[`GeneratedRequestWrapperImpl > writeToFile > disambiguates renamed path parameter when the suffixed name is also taken 1`] = `
+"export interface TestRequest {
+    idTypePathParam_: string;
+    idType: string;
+    idTypePathParam: string;
+}
+"
+`;
+
 exports[`GeneratedRequestWrapperImpl > writeToFile > does not include path parameters when shouldInlinePathParameters is false 1`] = `
 "export interface TestRequest {
 }

--- a/generators/typescript/utils/contexts/src/sdk-context/request-wrapper/GeneratedRequestWrapper.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/request-wrapper/GeneratedRequestWrapper.ts
@@ -38,6 +38,14 @@ export interface GeneratedRequestWrapper extends GeneratedFile<FileContext> {
     getPropertyNameOfQueryParameterFromName: (name: FernIr.NameAndWireValueOrString) => RequestWrapperNonBodyProperty;
     getPropertyNameOfPathParameter: (pathParameter: FernIr.PathParameter) => RequestWrapperNonBodyProperty;
     getPropertyNameOfPathParameterFromName: (name: FernIr.NameOrString) => RequestWrapperNonBodyProperty;
+    getInlinedPathParameterPropertyName: (
+        pathParameter: FernIr.PathParameter,
+        context: FileContext
+    ) => RequestWrapperNonBodyProperty;
+    getInlinedPathParameterPropertyNameFromName: (
+        name: FernIr.NameOrString,
+        context: FileContext
+    ) => RequestWrapperNonBodyProperty;
     getPropertyNameOfNonLiteralHeader: (header: FernIr.HttpHeader) => RequestWrapperNonBodyProperty;
     getPropertyNameOfNonLiteralHeaderFromName: (name: FernIr.NameAndWireValueOrString) => RequestWrapperNonBodyProperty;
     withQueryParameter: (args: {

--- a/seed/ts-sdk/ts-path-param-body-conflict/.fern/metadata.json
+++ b/seed/ts-sdk/ts-path-param-body-conflict/.fern/metadata.json
@@ -6,8 +6,7 @@
         "inlinePathParameters": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/ts-path-param-body-conflict/README.md
+++ b/seed/ts-sdk/ts-path-param-body-conflict/README.md
@@ -44,6 +44,7 @@ import { SeedTsPathParamBodyConflictClient } from "@fern/ts-path-param-body-conf
 
 const client = new SeedTsPathParamBodyConflictClient({ environment: "YOUR_BASE_URL" });
 await client.identifiers.update({
+    idTypePathParam: "phone",
     idType: "phone",
     oldValue: "+13175556789",
     newValue: "+13175556798"

--- a/seed/ts-sdk/ts-path-param-body-conflict/reference.md
+++ b/seed/ts-sdk/ts-path-param-body-conflict/reference.md
@@ -28,6 +28,7 @@ Update an identifier whose path param shares a name with a body property.
 
 ```typescript
 await client.identifiers.update({
+    idTypePathParam: "phone",
     idType: "phone",
     oldValue: "+13175556789",
     newValue: "+13175556798"

--- a/seed/ts-sdk/ts-path-param-body-conflict/snippet.json
+++ b/seed/ts-sdk/ts-path-param-body-conflict/snippet.json
@@ -8,7 +8,7 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedTsPathParamBodyConflictClient } from \"@fern/ts-path-param-body-conflict\";\n\nconst client = new SeedTsPathParamBodyConflictClient({ environment: \"YOUR_BASE_URL\" });\nawait client.identifiers.update({\n    idType: \"phone\",\n    oldValue: \"+13175556789\",\n    newValue: \"+13175556798\"\n});\n"
+                "client": "import { SeedTsPathParamBodyConflictClient } from \"@fern/ts-path-param-body-conflict\";\n\nconst client = new SeedTsPathParamBodyConflictClient({ environment: \"YOUR_BASE_URL\" });\nawait client.identifiers.update({\n    idTypePathParam: \"phone\",\n    idType: \"phone\",\n    oldValue: \"+13175556789\",\n    newValue: \"+13175556798\"\n});\n"
             }
         }
     ],

--- a/seed/ts-sdk/ts-path-param-body-conflict/src/api/resources/identifiers/client/Client.ts
+++ b/seed/ts-sdk/ts-path-param-body-conflict/src/api/resources/identifiers/client/Client.ts
@@ -29,6 +29,7 @@ export class IdentifiersClient {
      *
      * @example
      *     await client.identifiers.update({
+     *         idTypePathParam: "phone",
      *         idType: "phone",
      *         oldValue: "+13175556789",
      *         newValue: "+13175556798"
@@ -45,19 +46,20 @@ export class IdentifiersClient {
         request: SeedTsPathParamBodyConflict.IdentifierUpdate,
         requestOptions?: IdentifiersClient.RequestOptions,
     ): Promise<core.WithRawResponse<SeedTsPathParamBodyConflict.IdentifierUpdateResponse>> {
+        const { idTypePathParam, ..._body } = request;
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(this._options?.headers, requestOptions?.headers);
         const _response = await core.fetcher({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)),
-                `/identifiers/${core.url.encodePathParam(request.idType)}`,
+                `/identifiers/${core.url.encodePathParam(idTypePathParam)}`,
             ),
             method: "PATCH",
             headers: _headers,
             contentType: "application/json",
             queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
             requestType: "json",
-            body: request,
+            body: _body,
             timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
             maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/seed/ts-sdk/ts-path-param-body-conflict/src/api/resources/identifiers/client/requests/IdentifierUpdate.ts
+++ b/seed/ts-sdk/ts-path-param-body-conflict/src/api/resources/identifiers/client/requests/IdentifierUpdate.ts
@@ -3,12 +3,15 @@
 /**
  * @example
  *     {
+ *         idTypePathParam: "phone",
  *         idType: "phone",
  *         oldValue: "+13175556789",
  *         newValue: "+13175556798"
  *     }
  */
 export interface IdentifierUpdate {
+    /** The current identifier type in the URL path. */
+    idTypePathParam: string;
     /** The new identifier type to set in the body. */
     idType: string;
     oldValue: string;

--- a/seed/ts-sdk/ts-path-param-body-conflict/tests/wire/identifiers.test.ts
+++ b/seed/ts-sdk/ts-path-param-body-conflict/tests/wire/identifiers.test.ts
@@ -20,6 +20,7 @@ describe("IdentifiersClient", () => {
             .build();
 
         const response = await client.identifiers.update({
+            idTypePathParam: "phone",
             idType: "phone",
             oldValue: "+13175556789",
             newValue: "+13175556798",


### PR DESCRIPTION
## Description
With `inlinePathParameters: true`, a path parameter that shares its property name with an inlined request-body property (e.g. Twilio's `PATCH /Identifiers/{idType}` with an `idType` body field) was collapsed into a single shared request field (behavior from 3.73.2). That fixed the TS2300 duplicate-member error but made it impossible to send distinct values for the URL path and the body.

The request wrapper now keeps both fields by renaming the colliding path parameter with a `PathParam` suffix:

```ts
export interface IdentifierUpdate {
    idTypePathParam: string; // used for the URL path
    idType: string;          // sent in the request body
    oldValue: string;
    newValue: string;
}
```

Client code destructures the renamed field and sends the body untouched:

```ts
const { idTypePathParam, ..._body } = request;
// url: `/identifiers/${encodePathParam(idTypePathParam)}`, body: _body
```

## Changes Made
- `GeneratedRequestWrapperImpl`: new `getInlinedPathParameterPropertyName(FromName)` that appends a `PathParam` suffix (snake-cased `_path_param` for snake naming); interface emission, `getNonBodyKeys`, and `getNonBodyKeysWithData` now emit the renamed property instead of skipping it
- If the suffixed name is itself taken, it is disambiguated with trailing `_` against **all** other request-wrapper property names (body properties, other path params, query params — including collision-overridden names, non-literal headers, and inlined file properties) via `getReservedWrapperPropertyNames`
- `RequestWrapperParameter.getReferenceToPathParameter`: reference the renamed destructured property instead of reading the value through the request body
- `GeneratedRequestWrapperExampleImpl`: examples emit the renamed path-param key alongside the body property
- Regenerated `seed/ts-sdk/ts-path-param-body-conflict` output (interface, client, wire test, reference/snippets)
- Changelog entry under `generators/typescript/sdk/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (`GeneratedRequestWrapperImpl.test.ts` snapshots for the rename and both disambiguation cases — suffixed name colliding with a body property and with a query parameter; updated example-impl collision test)
- [x] Manual testing completed (`pnpm seed test --generator ts-sdk --fixture ts-path-param-body-conflict` passes; generated fixture's own vitest suite incl. wire test passes)

Link to Devin session: https://app.devin.ai/sessions/bdbdc092891f474cb895bfccca27d148
Requested by: @iamnamananand996