### PR TITLE
fix(csharp): align SSE stream reconnection with reference implementation

### DIFF
--- a/generators/csharp/base/src/AsIs.ts
+++ b/generators/csharp/base/src/AsIs.ts
@@ -112,6 +112,9 @@ export const AsIsFiles = {
             "test/Pagination/StepOffsetTest.Template.cs",
             "test/Pagination/StringCursorTest.Template.cs"
         ],
+        Sse: {
+            SseReconnectHelperTests: "test/Sse/SseReconnectHelperTests.Template.cs"
+        },
         WebSockets: {
             AsyncLockTests: "test/WebSockets/AsyncLockTests.Template.cs",
             DisconnectionInfoTests: "test/WebSockets/DisconnectionInfoTests.Template.cs",

--- a/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
+++ b/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
@@ -186,6 +186,11 @@ internal static class SseReconnectHelper
                 continue;
             }
 
+            // Successful reconnect — clear any stale failure so it doesn't
+            // cause a misleading IOException if a later cap-exhaustion occurs
+            // via empty-body reconnects (which don't set lastReconnectException).
+            lastReconnectException = null;
+
             // Only dispose the old response after a new one is successfully obtained.
             if (isReconnectedResponse)
             {

--- a/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
+++ b/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
@@ -12,6 +12,7 @@ namespace <%= namespace%>;
 internal static class SseReconnectHelper
 {
     private const int DefaultMaxReconnectAttempts = 5;
+    private static readonly TimeSpan DefaultReconnectDelay = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromSeconds(30);
 
     /// <summary>
@@ -25,13 +26,16 @@ internal static class SseReconnectHelper
     /// </param>
     /// <param name="maxReconnectAttempts">
     /// The maximum number of consecutive reconnection attempts before giving up.
-    /// Defaults to <c>5</c> when <c>null</c>.
+    /// Defaults to <c>5</c> when <c>null</c>. The counter resets to zero each
+    /// time a reconnected stream successfully yields at least one event.
     /// </param>
     /// <param name="disableReconnection">
     /// When <c>true</c>, reconnection is disabled and the stream ends on premature EOF.
     /// </param>
     /// <param name="terminator">
-    /// The SSE data value that signals the end of the stream.
+    /// The SSE data value that signals the end of the stream. When <c>null</c>,
+    /// reconnection is disabled because the client cannot distinguish a completed
+    /// stream from a dropped connection.
     /// </param>
     /// <param name="cancellationToken">A token to cancel the enumeration.</param>
     /// <returns>An async enumerable of <see cref="SseItem{T}"/> items.</returns>
@@ -48,6 +52,13 @@ internal static class SseReconnectHelper
         var maxAttempts = maxReconnectAttempts ?? DefaultMaxReconnectAttempts;
         var reconnectAttempts = 0;
         var isReconnectedResponse = false;
+        // Track the last event ID from the most recently *dispatched* (yielded)
+        // event, not the last parsed id. Per the WHATWG EventSource spec the
+        // "last event ID" is only committed when an event is dispatched — if a
+        // connection drops after an id: line but before the event's terminating
+        // blank line, reconnecting with the parsed-but-undispatched id would
+        // skip an event that was never delivered to the caller.
+        string? lastDispatchedEventId = null;
 
         while (true)
         {
@@ -98,6 +109,15 @@ internal static class SseReconnectHelper
                     }
 
                     yield return item;
+                    // Capture parser.LastEventId immediately after a successful
+                    // dispatch — at this point it reflects the just-dispatched
+                    // event's id. We must snapshot it before the next
+                    // MoveNextAsync could partially update it with a new id:
+                    // line from an incomplete event.
+                    if (!string.IsNullOrEmpty(parser.LastEventId))
+                    {
+                        lastDispatchedEventId = parser.LastEventId;
+                    }
                     reconnectAttempts = 0;
                 }
             }
@@ -111,9 +131,13 @@ internal static class SseReconnectHelper
                 yield break;
             }
 
+            // Determine whether reconnection should be attempted.
+            // Without a terminator the client cannot distinguish "stream
+            // completed" from "connection dropped", so reconnection is disabled.
             if (
                 disableReconnection
-                || string.IsNullOrEmpty(parser.LastEventId)
+                || terminator == null
+                || string.IsNullOrEmpty(lastDispatchedEventId)
                 || reconnectAttempts >= maxAttempts
             )
             {
@@ -128,25 +152,35 @@ internal static class SseReconnectHelper
 
             reconnectAttempts++;
 
-            var delay = parser.ReconnectionInterval;
+            // Use the server-sent retry interval if available; otherwise fall
+            // back to DefaultReconnectDelay (1s) to avoid hammering the server.
+            var delay = parser.ReconnectionInterval > TimeSpan.Zero
+                ? parser.ReconnectionInterval
+                : DefaultReconnectDelay;
             if (delay > MaxReconnectDelay)
             {
                 delay = MaxReconnectDelay;
             }
-            if (delay > TimeSpan.Zero)
-            {
-                await global::System.Threading.Tasks.Task
-                    .Delay(delay, cancellationToken)
-                    .ConfigureAwait(false);
-            }
+            await global::System.Threading.Tasks.Task
+                .Delay(delay, cancellationToken)
+                .ConfigureAwait(false);
 
             if (isReconnectedResponse)
             {
                 response.Raw?.Dispose();
             }
 
-            response = await reconnectFn(parser.LastEventId, cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                response = await reconnectFn(lastDispatchedEventId!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // Failed reconnect (e.g. HTTP error or null body). Treat as a
+                // failed attempt — the next loop iteration will check the cap.
+                continue;
+            }
             isReconnectedResponse = true;
         }
     }

--- a/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
+++ b/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
@@ -165,22 +165,27 @@ internal static class SseReconnectHelper
                 .Delay(delay, cancellationToken)
                 .ConfigureAwait(false);
 
+            ApiResponse newResponse;
+            try
+            {
+                newResponse = await reconnectFn(lastDispatchedEventId!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Failed reconnect (e.g. HTTP error or null body). Treat as a
+                // failed attempt — the next loop iteration will check the cap.
+                // Do NOT dispose the previous response here: we need it to stay
+                // valid in case the retry loop re-enters the stream-read path.
+                continue;
+            }
+
+            // Only dispose the old response after a new one is successfully obtained.
             if (isReconnectedResponse)
             {
                 response.Raw?.Dispose();
             }
-
-            try
-            {
-                response = await reconnectFn(lastDispatchedEventId!, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch
-            {
-                // Failed reconnect (e.g. HTTP error or null body). Treat as a
-                // failed attempt — the next loop iteration will check the cap.
-                continue;
-            }
+            response = newResponse;
             isReconnectedResponse = true;
         }
     }

--- a/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
+++ b/generators/csharp/base/src/asIs/SseReconnectHelper.Template.cs
@@ -59,6 +59,7 @@ internal static class SseReconnectHelper
         // blank line, reconnecting with the parsed-but-undispatched id would
         // skip an event that was never delivered to the caller.
         string? lastDispatchedEventId = null;
+        Exception? lastReconnectException = null;
 
         while (true)
         {
@@ -141,10 +142,14 @@ internal static class SseReconnectHelper
                 || reconnectAttempts >= maxAttempts
             )
             {
-                if (streamDropped)
+                if (streamDropped || lastReconnectException != null)
                 {
                     throw new IOException(
-                        "SSE stream connection lost and reconnection was not attempted."
+                        "SSE stream connection lost and reconnection "
+                            + (lastReconnectException != null
+                                ? "failed after exhausting all attempts."
+                                : "was not attempted."),
+                        lastReconnectException
                     );
                 }
                 yield break;
@@ -171,12 +176,13 @@ internal static class SseReconnectHelper
                 newResponse = await reconnectFn(lastDispatchedEventId!, cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
                 // Failed reconnect (e.g. HTTP error or null body). Treat as a
                 // failed attempt — the next loop iteration will check the cap.
                 // Do NOT dispose the previous response here: we need it to stay
                 // valid in case the retry loop re-enters the stream-read path.
+                lastReconnectException = ex;
                 continue;
             }
 

--- a/generators/csharp/base/src/asIs/test/Sse/SseReconnectHelperTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Sse/SseReconnectHelperTests.Template.cs
@@ -1,0 +1,512 @@
+using global::System.IO;
+using global::System.Net;
+using global::System.Net.ServerSentEvents;
+using global::System.Text;
+using NUnit.Framework;
+using <%= namespace%>.Core;
+
+namespace <%= testNamespace%>.Core.Sse;
+
+/// <summary>
+/// Unit and integration tests for <see cref="SseReconnectHelper"/>.
+/// Exercises reconnection behaviors: terminator gating, default backoff,
+/// last-dispatched-id correctness, reconnect cap with reset, cancellation,
+/// disableReconnection flag, and null-body handling.
+/// </summary>
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+public class SseReconnectHelperTests
+{
+    private const int TimeoutMs = 10000;
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a minimal <see cref="ApiResponse"/> wrapping the given SSE text.
+    /// </summary>
+    private static ApiResponse CreateSseResponse(string sseText)
+    {
+        var content = new StringContent(sseText, Encoding.UTF8, "text/event-stream");
+        var httpResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        return new ApiResponse { StatusCode = 200, Raw = httpResponse };
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ApiResponse"/> whose content stream throws
+    /// <see cref="IOException"/> on read (simulates a dropped connection).
+    /// </summary>
+    private static ApiResponse CreateDroppedResponse(string sseTextBeforeDrop)
+    {
+        var stream = new DroppingStream(sseTextBeforeDrop);
+        var content = new StreamContent(stream);
+        content.Headers.ContentType =
+            new System.Net.Http.Headers.MediaTypeHeaderValue("text/event-stream");
+        var httpResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        return new ApiResponse { StatusCode = 200, Raw = httpResponse };
+    }
+
+    /// <summary>
+    /// A stream that returns the initial text then throws IOException (simulating a drop).
+    /// </summary>
+    private sealed class DroppingStream : Stream
+    {
+        private readonly byte[] _data;
+        private int _position;
+        private bool _hasReadAll;
+
+        public DroppingStream(string initialText)
+        {
+            _data = Encoding.UTF8.GetBytes(initialText);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _data.Length;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var remaining = _data.Length - _position;
+            if (remaining <= 0)
+            {
+                _hasReadAll = true;
+                throw new IOException("Connection dropped");
+            }
+            var toCopy = Math.Min(count, remaining);
+            Array.Copy(_data, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return toCopy;
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken
+        )
+        {
+            var remaining = _data.Length - _position;
+            if (remaining <= 0)
+            {
+                _hasReadAll = true;
+                throw new IOException("Connection dropped");
+            }
+            var toCopy = Math.Min(count, remaining);
+            Array.Copy(_data, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return Task.FromResult(toCopy);
+        }
+
+#if NET5_0_OR_GREATER
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var remaining = _data.Length - _position;
+            if (remaining <= 0)
+            {
+                _hasReadAll = true;
+                throw new IOException("Connection dropped");
+            }
+            var toCopy = Math.Min(buffer.Length, remaining);
+            _data.AsSpan(_position, toCopy).CopyTo(buffer.Span);
+            _position += toCopy;
+            return new ValueTask<int>(toCopy);
+        }
+#endif
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+    }
+
+    // ─── Test: No terminator → no reconnect ─────────────────────────────
+
+    [Test]
+    public async Task NoTerminator_DoesNotReconnect_StreamEndsOnEof()
+    {
+        // When terminator is null, the helper cannot distinguish a completed
+        // stream from a dropped connection, so it must NOT reconnect.
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\ndata: {\"value\":2}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCalled = false;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCalled = true;
+                    return Task.FromResult(CreateSseResponse("id: evt-3\ndata: {\"value\":3}\n\n"));
+                },
+                maxReconnectAttempts: 5,
+                disableReconnection: false,
+                terminator: null // No terminator!
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(reconnectCalled, Is.False, "Should not reconnect when terminator is null");
+        Assert.That(items, Has.Count.EqualTo(2));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
+    }
+
+    // ─── Test: Default 1s backoff when no retry: directive ───────────────
+
+    [Test]
+    public async Task DefaultBackoff_WaitsAtLeast900ms_WhenNoRetryDirective()
+    {
+        // Without a server retry: directive, the helper should wait ~1s
+        // (DefaultReconnectDelay) before reconnecting — NOT zero.
+        var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText1);
+        var reconnectTimestamp = DateTime.MinValue;
+        var initialTimestamp = DateTime.UtcNow;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectTimestamp = DateTime.UtcNow;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(items, Has.Count.EqualTo(2));
+        var elapsed = reconnectTimestamp - initialTimestamp;
+        Assert.That(
+            elapsed.TotalMilliseconds,
+            Is.GreaterThanOrEqualTo(900),
+            $"Expected >= 900ms delay before reconnect, got {elapsed.TotalMilliseconds}ms"
+        );
+    }
+
+    // ─── Test: Server retry: directive is respected and clamped ──────────
+
+    [Test]
+    public async Task ServerRetry_IsRespectedAndClamped()
+    {
+        // Server sends retry: 200; helper should wait ~200ms before reconnect.
+        var sseText1 = "retry: 200\nid: evt-1\ndata: {\"value\":1}\n\n";
+        var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText1);
+        var reconnectTimestamp = DateTime.MinValue;
+        var initialTimestamp = DateTime.UtcNow;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectTimestamp = DateTime.UtcNow;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(items, Has.Count.EqualTo(2));
+        var elapsed = reconnectTimestamp - initialTimestamp;
+        // Should be at least ~150ms (allowing variance)
+        Assert.That(
+            elapsed.TotalMilliseconds,
+            Is.GreaterThanOrEqualTo(150),
+            $"Expected >= 150ms (server retry: 200), got {elapsed.TotalMilliseconds}ms"
+        );
+    }
+
+    // ─── Test: Mid-event drop sends Last-Event-ID from last dispatched ──
+
+    [Test]
+    public async Task MidEventDrop_ReconnectsWithLastDispatchedId_NotParsedId()
+    {
+        // evt-1 is fully dispatched. Then id: evt-2 is parsed but the
+        // connection drops before evt-2's data/blank line. Reconnection
+        // must use "evt-1" (last dispatched), NOT "evt-2" (last parsed).
+        var sseTextWithDrop = "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\n";
+        var initialResponse = CreateDroppedResponse(sseTextWithDrop);
+        string? receivedLastEventId = null;
+        var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    receivedLastEventId = lastId;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(
+            receivedLastEventId,
+            Is.EqualTo("evt-1"),
+            "Should reconnect with last *dispatched* id, not the parsed-but-undispatched id"
+        );
+        Assert.That(items, Has.Count.EqualTo(2));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
+    }
+
+    // ─── Test: maxReconnectAttempts cap with reset on progress ───────────
+
+    [Test]
+    public async Task MaxReconnectAttempts_CapsReconnects_ResetsOnProgress()
+    {
+        // Set maxReconnectAttempts=2. First drop yields no data on reconnect
+        // (counts 1), second drop also no data (counts 2), stops.
+        var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var emptyResponse = ""; // No events
+        var initialResponse = CreateSseResponse(sseText1);
+        var reconnectCount = 0;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCount++;
+                    return Task.FromResult(CreateSseResponse(emptyResponse));
+                },
+                maxReconnectAttempts: 2,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        // Got only the initial event
+        Assert.That(items, Has.Count.EqualTo(1));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        // Reconnected exactly 2 times before giving up
+        Assert.That(reconnectCount, Is.EqualTo(2));
+    }
+
+    // ─── Test: disableReconnection prevents reconnection ────────────────
+
+    [Test]
+    public async Task DisableReconnection_PreventsReconnect()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCalled = false;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCalled = true;
+                    return Task.FromResult(
+                        CreateSseResponse("id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n")
+                    );
+                },
+                maxReconnectAttempts: 5,
+                disableReconnection: true, // Disabled!
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(reconnectCalled, Is.False, "Should not reconnect when disabled");
+        Assert.That(items, Has.Count.EqualTo(1));
+    }
+
+    // ─── Test: Cancellation during backoff stops promptly ───────────────
+
+    [Test]
+    public async Task Cancellation_DuringBackoff_StopsPromptly()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        using var cts = new CancellationTokenSource();
+
+        var items = new List<string>();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        // Cancel after 200ms (well before the 1s default backoff completes)
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+        try
+        {
+            await foreach (
+                var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                    initialResponse,
+                    (lastId, ct) =>
+                    {
+                        // Should not be reached because cancellation fires during delay
+                        return Task.FromResult(
+                            CreateSseResponse("id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n")
+                        );
+                    },
+                    maxReconnectAttempts: 5,
+                    disableReconnection: false,
+                    terminator: "[DONE]",
+                    cancellationToken: cts.Token
+                )
+            )
+            {
+                items.Add(item.Data);
+            }
+            Assert.Fail("Expected OperationCanceledException");
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — Task.Delay throws on cancellation
+        }
+
+        sw.Stop();
+        Assert.That(items, Has.Count.EqualTo(1));
+        // Should have stopped well before the full 1s delay
+        Assert.That(
+            sw.ElapsedMilliseconds,
+            Is.LessThan(800),
+            $"Cancellation should stop promptly, took {sw.ElapsedMilliseconds}ms"
+        );
+    }
+
+    // ─── Test: Reconnect function failure treated as failed attempt ──────
+
+    [Test]
+    public async Task ReconnectFnThrows_TreatedAsFailedAttempt()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCount = 0;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCount++;
+                    throw new HttpRequestException("Server returned 500");
+                },
+                maxReconnectAttempts: 2,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(items, Has.Count.EqualTo(1));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        // Should have retried up to the max
+        Assert.That(reconnectCount, Is.EqualTo(2));
+    }
+
+    // ─── Test: Normal reconnection works end-to-end ─────────────────────
+
+    [Test]
+    public async Task Reconnection_EndToEnd_AllEventsReceived()
+    {
+        var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\ndata: {\"value\":2}\n\n";
+        var sseText2 =
+            "id: evt-3\ndata: {\"value\":3}\n\nid: evt-4\ndata: {\"value\":4}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText1);
+        string? receivedLastEventId = null;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    receivedLastEventId = lastId;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(receivedLastEventId, Is.EqualTo("evt-2"));
+        Assert.That(items, Has.Count.EqualTo(4));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
+        Assert.That(items[2], Is.EqualTo("{\"value\":3}"));
+        Assert.That(items[3], Is.EqualTo("{\"value\":4}"));
+    }
+
+    // ─── Test: Terminator stops stream without reconnection ─────────────
+
+    [Test]
+    public async Task Terminator_StopsStream_NoReconnection()
+    {
+        var sseText =
+            "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCalled = false;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCalled = true;
+                    return Task.FromResult(CreateSseResponse(""));
+                },
+                maxReconnectAttempts: 5,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(reconnectCalled, Is.False, "Should not reconnect when terminator is reached");
+        Assert.That(items, Has.Count.EqualTo(2));
+    }
+}

--- a/generators/csharp/base/src/asIs/test/Sse/SseReconnectHelperTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Sse/SseReconnectHelperTests.Template.cs
@@ -268,13 +268,13 @@ public class SseReconnectHelperTests
         Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
     }
 
-    // ─── Test: maxReconnectAttempts cap with reset on progress ───────────
+    // ─── Test: maxReconnectAttempts caps consecutive failures ────────────
 
     [Test]
-    public async Task MaxReconnectAttempts_CapsReconnects_ResetsOnProgress()
+    public async Task MaxReconnectAttempts_CapsConsecutiveFailures()
     {
-        // Set maxReconnectAttempts=2. First drop yields no data on reconnect
-        // (counts 1), second drop also no data (counts 2), stops.
+        // Set maxReconnectAttempts=2. Each reconnect returns an empty body
+        // (no events, no terminator) so attempts accumulate until the cap.
         var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
         var emptyResponse = ""; // No events
         var initialResponse = CreateSseResponse(sseText1);
@@ -391,37 +391,80 @@ public class SseReconnectHelperTests
         );
     }
 
-    // ─── Test: Reconnect function failure treated as failed attempt ──────
+    // ─── Test: Reconnect function failure throws after exhausting cap ────
 
     [Test]
-    public async Task ReconnectFnThrows_TreatedAsFailedAttempt()
+    public void ReconnectFnThrows_SurfacesIOException_AfterExhaustingCap()
     {
         var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
         var initialResponse = CreateSseResponse(sseText);
         var reconnectCount = 0;
 
         var items = new List<string>();
-        await foreach (
-            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
-                initialResponse,
-                (lastId, ct) =>
-                {
-                    reconnectCount++;
-                    throw new HttpRequestException("Server returned 500");
-                },
-                maxReconnectAttempts: 2,
-                disableReconnection: false,
-                terminator: "[DONE]"
-            )
-        )
+        var ex = Assert.ThrowsAsync<IOException>(async () =>
         {
-            items.Add(item.Data);
-        }
+            await foreach (
+                var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                    initialResponse,
+                    (lastId, ct) =>
+                    {
+                        reconnectCount++;
+                        throw new HttpRequestException("Server returned 500");
+                    },
+                    maxReconnectAttempts: 2,
+                    disableReconnection: false,
+                    terminator: "[DONE]"
+                )
+            )
+            {
+                items.Add(item.Data);
+            }
+        });
 
         Assert.That(items, Has.Count.EqualTo(1));
         Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
         // Should have retried up to the max
         Assert.That(reconnectCount, Is.EqualTo(2));
+        // Inner exception should be the last reconnect failure
+        Assert.That(ex!.InnerException, Is.TypeOf<HttpRequestException>());
+        Assert.That(
+            ex.Message,
+            Does.Contain("failed after exhausting all attempts")
+        );
+    }
+
+    // ─── Test: Cancellation in reconnectFn propagates immediately ─────────
+
+    [Test]
+    public void Cancellation_InReconnectFn_PropagatesImmediately()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        using var cts = new CancellationTokenSource();
+
+        var items = new List<string>();
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (
+                var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                    initialResponse,
+                    (lastId, ct) =>
+                    {
+                        cts.Cancel();
+                        throw new OperationCanceledException(ct);
+                    },
+                    maxReconnectAttempts: 5,
+                    disableReconnection: false,
+                    terminator: "[DONE]",
+                    cancellationToken: cts.Token
+                )
+            )
+            {
+                items.Add(item.Data);
+            }
+        });
+
+        Assert.That(items, Has.Count.EqualTo(1));
     }
 
     // ─── Test: Normal reconnection works end-to-end ─────────────────────

--- a/generators/csharp/base/src/asIs/test/Sse/SseReconnectHelperTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Sse/SseReconnectHelperTests.Template.cs
@@ -17,8 +17,6 @@ namespace <%= testNamespace%>.Core.Sse;
 [Parallelizable(ParallelScope.Children)]
 public class SseReconnectHelperTests
 {
-    private const int TimeoutMs = 10000;
-
     // ─── Helpers ─────────────────────────────────────────────────────────
 
     /// <summary>
@@ -52,7 +50,6 @@ public class SseReconnectHelperTests
     {
         private readonly byte[] _data;
         private int _position;
-        private bool _hasReadAll;
 
         public DroppingStream(string initialText)
         {
@@ -74,7 +71,6 @@ public class SseReconnectHelperTests
             var remaining = _data.Length - _position;
             if (remaining <= 0)
             {
-                _hasReadAll = true;
                 throw new IOException("Connection dropped");
             }
             var toCopy = Math.Min(count, remaining);
@@ -93,7 +89,6 @@ public class SseReconnectHelperTests
             var remaining = _data.Length - _position;
             if (remaining <= 0)
             {
-                _hasReadAll = true;
                 throw new IOException("Connection dropped");
             }
             var toCopy = Math.Min(count, remaining);
@@ -111,7 +106,6 @@ public class SseReconnectHelperTests
             var remaining = _data.Length - _position;
             if (remaining <= 0)
             {
-                _hasReadAll = true;
                 throw new IOException("Connection dropped");
             }
             var toCopy = Math.Min(buffer.Length, remaining);
@@ -174,18 +168,13 @@ public class SseReconnectHelperTests
         var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
         var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
         var initialResponse = CreateSseResponse(sseText1);
-        var reconnectTimestamp = DateTime.MinValue;
-        var initialTimestamp = DateTime.UtcNow;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
 
         var items = new List<string>();
         await foreach (
             var item in SseReconnectHelper.EnumerateWithReconnectAsync(
                 initialResponse,
-                (lastId, ct) =>
-                {
-                    reconnectTimestamp = DateTime.UtcNow;
-                    return Task.FromResult(CreateSseResponse(sseText2));
-                },
+                (lastId, ct) => Task.FromResult(CreateSseResponse(sseText2)),
                 maxReconnectAttempts: 3,
                 disableReconnection: false,
                 terminator: "[DONE]"
@@ -195,12 +184,12 @@ public class SseReconnectHelperTests
             items.Add(item.Data);
         }
 
+        sw.Stop();
         Assert.That(items, Has.Count.EqualTo(2));
-        var elapsed = reconnectTimestamp - initialTimestamp;
         Assert.That(
-            elapsed.TotalMilliseconds,
+            sw.ElapsedMilliseconds,
             Is.GreaterThanOrEqualTo(900),
-            $"Expected >= 900ms delay before reconnect, got {elapsed.TotalMilliseconds}ms"
+            $"Expected >= 900ms delay before reconnect, got {sw.ElapsedMilliseconds}ms"
         );
     }
 
@@ -213,18 +202,13 @@ public class SseReconnectHelperTests
         var sseText1 = "retry: 200\nid: evt-1\ndata: {\"value\":1}\n\n";
         var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
         var initialResponse = CreateSseResponse(sseText1);
-        var reconnectTimestamp = DateTime.MinValue;
-        var initialTimestamp = DateTime.UtcNow;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
 
         var items = new List<string>();
         await foreach (
             var item in SseReconnectHelper.EnumerateWithReconnectAsync(
                 initialResponse,
-                (lastId, ct) =>
-                {
-                    reconnectTimestamp = DateTime.UtcNow;
-                    return Task.FromResult(CreateSseResponse(sseText2));
-                },
+                (lastId, ct) => Task.FromResult(CreateSseResponse(sseText2)),
                 maxReconnectAttempts: 3,
                 disableReconnection: false,
                 terminator: "[DONE]"
@@ -234,13 +218,12 @@ public class SseReconnectHelperTests
             items.Add(item.Data);
         }
 
+        sw.Stop();
         Assert.That(items, Has.Count.EqualTo(2));
-        var elapsed = reconnectTimestamp - initialTimestamp;
-        // Should be at least ~150ms (allowing variance)
         Assert.That(
-            elapsed.TotalMilliseconds,
+            sw.ElapsedMilliseconds,
             Is.GreaterThanOrEqualTo(150),
-            $"Expected >= 150ms (server retry: 200), got {elapsed.TotalMilliseconds}ms"
+            $"Expected >= 150ms (server retry: 200), got {sw.ElapsedMilliseconds}ms"
         );
     }
 

--- a/generators/csharp/sdk/changes/unreleased/fix-sse-reconnection-parity.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-sse-reconnection-parity.yml
@@ -6,6 +6,11 @@
     server sends no retry: directive (previously zero delay).
     (3) Use the last *dispatched* event ID for reconnection rather than the
     last *parsed* id, preventing silent event loss on mid-event drops.
-    (4) Treat reconnect function failures (exceptions/null body) as failed
-    attempts that consume the retry cap, rather than propagating unhandled.
+    (4) Treat reconnect function failures as consumed attempts; throw
+    IOException with the last failure as InnerException when the cap is
+    exhausted, instead of silently truncating the stream.
+    (5) Let OperationCanceledException propagate immediately from reconnectFn
+    instead of swallowing it as a retry attempt.
+    (6) Dispose the old HTTP response only after a new one is successfully
+    obtained, preventing ObjectDisposedException on retry.
   type: fix

--- a/generators/csharp/sdk/changes/unreleased/fix-sse-reconnection-parity.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-sse-reconnection-parity.yml
@@ -1,0 +1,11 @@
+- summary: |
+    Fix SSE stream reconnection correctness to match the reference implementation:
+    (1) Do not reconnect when no terminator is configured (the client cannot
+    distinguish a completed stream from a dropped connection).
+    (2) Apply a default 1-second backoff between reconnect attempts when the
+    server sends no retry: directive (previously zero delay).
+    (3) Use the last *dispatched* event ID for reconnection rather than the
+    last *parsed* id, preventing silent event loss on mid-event drops.
+    (4) Treat reconnect function failures (exceptions/null body) as failed
+    attempts that consume the retry cap, rather than propagating unhandled.
+  type: fix

--- a/generators/csharp/sdk/src/SdkGeneratorContext.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorContext.ts
@@ -254,6 +254,9 @@ export class SdkGeneratorContext extends GeneratorContext {
         if (this.hasWebSocketEndpoints) {
             Object.values(AsIsFiles.Test.WebSockets).forEach((file) => files.push(file));
         }
+        if (this.hasResumableSseEndpoints) {
+            Object.values(AsIsFiles.Test.Sse).forEach((file) => files.push(file));
+        }
 
         return files;
     }

--- a/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/Sse/SseReconnectHelperTests.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/Sse/SseReconnectHelperTests.cs
@@ -272,13 +272,13 @@ public class SseReconnectHelperTests
         Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
     }
 
-    // ─── Test: maxReconnectAttempts cap with reset on progress ───────────
+    // ─── Test: maxReconnectAttempts caps consecutive failures ────────────
 
     [Test]
-    public async Task MaxReconnectAttempts_CapsReconnects_ResetsOnProgress()
+    public async Task MaxReconnectAttempts_CapsConsecutiveFailures()
     {
-        // Set maxReconnectAttempts=2. First drop yields no data on reconnect
-        // (counts 1), second drop also no data (counts 2), stops.
+        // Set maxReconnectAttempts=2. Each reconnect returns an empty body
+        // (no events, no terminator) so attempts accumulate until the cap.
         var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
         var emptyResponse = ""; // No events
         var initialResponse = CreateSseResponse(sseText1);
@@ -395,37 +395,77 @@ public class SseReconnectHelperTests
         );
     }
 
-    // ─── Test: Reconnect function failure treated as failed attempt ──────
+    // ─── Test: Reconnect function failure throws after exhausting cap ────
 
     [Test]
-    public async Task ReconnectFnThrows_TreatedAsFailedAttempt()
+    public void ReconnectFnThrows_SurfacesIOException_AfterExhaustingCap()
     {
         var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
         var initialResponse = CreateSseResponse(sseText);
         var reconnectCount = 0;
 
         var items = new List<string>();
-        await foreach (
-            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
-                initialResponse,
-                (lastId, ct) =>
-                {
-                    reconnectCount++;
-                    throw new HttpRequestException("Server returned 500");
-                },
-                maxReconnectAttempts: 2,
-                disableReconnection: false,
-                terminator: "[DONE]"
-            )
-        )
+        var ex = Assert.ThrowsAsync<IOException>(async () =>
         {
-            items.Add(item.Data);
-        }
+            await foreach (
+                var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                    initialResponse,
+                    (lastId, ct) =>
+                    {
+                        reconnectCount++;
+                        throw new HttpRequestException("Server returned 500");
+                    },
+                    maxReconnectAttempts: 2,
+                    disableReconnection: false,
+                    terminator: "[DONE]"
+                )
+            )
+            {
+                items.Add(item.Data);
+            }
+        });
 
         Assert.That(items, Has.Count.EqualTo(1));
         Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
         // Should have retried up to the max
         Assert.That(reconnectCount, Is.EqualTo(2));
+        // Inner exception should be the last reconnect failure
+        Assert.That(ex!.InnerException, Is.TypeOf<HttpRequestException>());
+        Assert.That(ex.Message, Does.Contain("failed after exhausting all attempts"));
+    }
+
+    // ─── Test: Cancellation in reconnectFn propagates immediately ─────────
+
+    [Test]
+    public void Cancellation_InReconnectFn_PropagatesImmediately()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        using var cts = new CancellationTokenSource();
+
+        var items = new List<string>();
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (
+                var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                    initialResponse,
+                    (lastId, ct) =>
+                    {
+                        cts.Cancel();
+                        throw new OperationCanceledException(ct);
+                    },
+                    maxReconnectAttempts: 5,
+                    disableReconnection: false,
+                    terminator: "[DONE]",
+                    cancellationToken: cts.Token
+                )
+            )
+            {
+                items.Add(item.Data);
+            }
+        });
+
+        Assert.That(items, Has.Count.EqualTo(1));
     }
 
     // ─── Test: Normal reconnection works end-to-end ─────────────────────

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/Sse/SseReconnectHelperTests.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/Sse/SseReconnectHelperTests.cs
@@ -1,0 +1,516 @@
+using global::System.IO;
+using global::System.Net;
+using global::System.Net.ServerSentEvents;
+using global::System.Text;
+using NUnit.Framework;
+using SeedServerSentEventsResumable.Core;
+
+namespace SeedServerSentEventsResumable.Test.Core.Sse;
+
+/// <summary>
+/// Unit and integration tests for <see cref="SseReconnectHelper"/>.
+/// Exercises reconnection behaviors: terminator gating, default backoff,
+/// last-dispatched-id correctness, reconnect cap with reset, cancellation,
+/// disableReconnection flag, and null-body handling.
+/// </summary>
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+public class SseReconnectHelperTests
+{
+    private const int TimeoutMs = 10000;
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a minimal <see cref="ApiResponse"/> wrapping the given SSE text.
+    /// </summary>
+    private static ApiResponse CreateSseResponse(string sseText)
+    {
+        var content = new StringContent(sseText, Encoding.UTF8, "text/event-stream");
+        var httpResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        return new ApiResponse { StatusCode = 200, Raw = httpResponse };
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ApiResponse"/> whose content stream throws
+    /// <see cref="IOException"/> on read (simulates a dropped connection).
+    /// </summary>
+    private static ApiResponse CreateDroppedResponse(string sseTextBeforeDrop)
+    {
+        var stream = new DroppingStream(sseTextBeforeDrop);
+        var content = new StreamContent(stream);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+            "text/event-stream"
+        );
+        var httpResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        return new ApiResponse { StatusCode = 200, Raw = httpResponse };
+    }
+
+    /// <summary>
+    /// A stream that returns the initial text then throws IOException (simulating a drop).
+    /// </summary>
+    private sealed class DroppingStream : Stream
+    {
+        private readonly byte[] _data;
+        private int _position;
+        private bool _hasReadAll;
+
+        public DroppingStream(string initialText)
+        {
+            _data = Encoding.UTF8.GetBytes(initialText);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _data.Length;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var remaining = _data.Length - _position;
+            if (remaining <= 0)
+            {
+                _hasReadAll = true;
+                throw new IOException("Connection dropped");
+            }
+            var toCopy = Math.Min(count, remaining);
+            Array.Copy(_data, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return toCopy;
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken
+        )
+        {
+            var remaining = _data.Length - _position;
+            if (remaining <= 0)
+            {
+                _hasReadAll = true;
+                throw new IOException("Connection dropped");
+            }
+            var toCopy = Math.Min(count, remaining);
+            Array.Copy(_data, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return Task.FromResult(toCopy);
+        }
+
+#if NET5_0_OR_GREATER
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var remaining = _data.Length - _position;
+            if (remaining <= 0)
+            {
+                _hasReadAll = true;
+                throw new IOException("Connection dropped");
+            }
+            var toCopy = Math.Min(buffer.Length, remaining);
+            _data.AsSpan(_position, toCopy).CopyTo(buffer.Span);
+            _position += toCopy;
+            return new ValueTask<int>(toCopy);
+        }
+#endif
+
+        public override void Flush() { }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+    }
+
+    // ─── Test: No terminator → no reconnect ─────────────────────────────
+
+    [Test]
+    public async Task NoTerminator_DoesNotReconnect_StreamEndsOnEof()
+    {
+        // When terminator is null, the helper cannot distinguish a completed
+        // stream from a dropped connection, so it must NOT reconnect.
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\ndata: {\"value\":2}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCalled = false;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCalled = true;
+                    return Task.FromResult(CreateSseResponse("id: evt-3\ndata: {\"value\":3}\n\n"));
+                },
+                maxReconnectAttempts: 5,
+                disableReconnection: false,
+                terminator: null // No terminator!
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(reconnectCalled, Is.False, "Should not reconnect when terminator is null");
+        Assert.That(items, Has.Count.EqualTo(2));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
+    }
+
+    // ─── Test: Default 1s backoff when no retry: directive ───────────────
+
+    [Test]
+    public async Task DefaultBackoff_WaitsAtLeast900ms_WhenNoRetryDirective()
+    {
+        // Without a server retry: directive, the helper should wait ~1s
+        // (DefaultReconnectDelay) before reconnecting — NOT zero.
+        var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText1);
+        var reconnectTimestamp = DateTime.MinValue;
+        var initialTimestamp = DateTime.UtcNow;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectTimestamp = DateTime.UtcNow;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(items, Has.Count.EqualTo(2));
+        var elapsed = reconnectTimestamp - initialTimestamp;
+        Assert.That(
+            elapsed.TotalMilliseconds,
+            Is.GreaterThanOrEqualTo(900),
+            $"Expected >= 900ms delay before reconnect, got {elapsed.TotalMilliseconds}ms"
+        );
+    }
+
+    // ─── Test: Server retry: directive is respected and clamped ──────────
+
+    [Test]
+    public async Task ServerRetry_IsRespectedAndClamped()
+    {
+        // Server sends retry: 200; helper should wait ~200ms before reconnect.
+        var sseText1 = "retry: 200\nid: evt-1\ndata: {\"value\":1}\n\n";
+        var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText1);
+        var reconnectTimestamp = DateTime.MinValue;
+        var initialTimestamp = DateTime.UtcNow;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectTimestamp = DateTime.UtcNow;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(items, Has.Count.EqualTo(2));
+        var elapsed = reconnectTimestamp - initialTimestamp;
+        // Should be at least ~150ms (allowing variance)
+        Assert.That(
+            elapsed.TotalMilliseconds,
+            Is.GreaterThanOrEqualTo(150),
+            $"Expected >= 150ms (server retry: 200), got {elapsed.TotalMilliseconds}ms"
+        );
+    }
+
+    // ─── Test: Mid-event drop sends Last-Event-ID from last dispatched ──
+
+    [Test]
+    public async Task MidEventDrop_ReconnectsWithLastDispatchedId_NotParsedId()
+    {
+        // evt-1 is fully dispatched. Then id: evt-2 is parsed but the
+        // connection drops before evt-2's data/blank line. Reconnection
+        // must use "evt-1" (last dispatched), NOT "evt-2" (last parsed).
+        var sseTextWithDrop = "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\n";
+        var initialResponse = CreateDroppedResponse(sseTextWithDrop);
+        string? receivedLastEventId = null;
+        var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    receivedLastEventId = lastId;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(
+            receivedLastEventId,
+            Is.EqualTo("evt-1"),
+            "Should reconnect with last *dispatched* id, not the parsed-but-undispatched id"
+        );
+        Assert.That(items, Has.Count.EqualTo(2));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
+    }
+
+    // ─── Test: maxReconnectAttempts cap with reset on progress ───────────
+
+    [Test]
+    public async Task MaxReconnectAttempts_CapsReconnects_ResetsOnProgress()
+    {
+        // Set maxReconnectAttempts=2. First drop yields no data on reconnect
+        // (counts 1), second drop also no data (counts 2), stops.
+        var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var emptyResponse = ""; // No events
+        var initialResponse = CreateSseResponse(sseText1);
+        var reconnectCount = 0;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCount++;
+                    return Task.FromResult(CreateSseResponse(emptyResponse));
+                },
+                maxReconnectAttempts: 2,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        // Got only the initial event
+        Assert.That(items, Has.Count.EqualTo(1));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        // Reconnected exactly 2 times before giving up
+        Assert.That(reconnectCount, Is.EqualTo(2));
+    }
+
+    // ─── Test: disableReconnection prevents reconnection ────────────────
+
+    [Test]
+    public async Task DisableReconnection_PreventsReconnect()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCalled = false;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCalled = true;
+                    return Task.FromResult(
+                        CreateSseResponse("id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n")
+                    );
+                },
+                maxReconnectAttempts: 5,
+                disableReconnection: true, // Disabled!
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(reconnectCalled, Is.False, "Should not reconnect when disabled");
+        Assert.That(items, Has.Count.EqualTo(1));
+    }
+
+    // ─── Test: Cancellation during backoff stops promptly ───────────────
+
+    [Test]
+    public async Task Cancellation_DuringBackoff_StopsPromptly()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        using var cts = new CancellationTokenSource();
+
+        var items = new List<string>();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        // Cancel after 200ms (well before the 1s default backoff completes)
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+        try
+        {
+            await foreach (
+                var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                    initialResponse,
+                    (lastId, ct) =>
+                    {
+                        // Should not be reached because cancellation fires during delay
+                        return Task.FromResult(
+                            CreateSseResponse("id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n")
+                        );
+                    },
+                    maxReconnectAttempts: 5,
+                    disableReconnection: false,
+                    terminator: "[DONE]",
+                    cancellationToken: cts.Token
+                )
+            )
+            {
+                items.Add(item.Data);
+            }
+            Assert.Fail("Expected OperationCanceledException");
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — Task.Delay throws on cancellation
+        }
+
+        sw.Stop();
+        Assert.That(items, Has.Count.EqualTo(1));
+        // Should have stopped well before the full 1s delay
+        Assert.That(
+            sw.ElapsedMilliseconds,
+            Is.LessThan(800),
+            $"Cancellation should stop promptly, took {sw.ElapsedMilliseconds}ms"
+        );
+    }
+
+    // ─── Test: Reconnect function failure treated as failed attempt ──────
+
+    [Test]
+    public async Task ReconnectFnThrows_TreatedAsFailedAttempt()
+    {
+        var sseText = "id: evt-1\ndata: {\"value\":1}\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCount = 0;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCount++;
+                    throw new HttpRequestException("Server returned 500");
+                },
+                maxReconnectAttempts: 2,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(items, Has.Count.EqualTo(1));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        // Should have retried up to the max
+        Assert.That(reconnectCount, Is.EqualTo(2));
+    }
+
+    // ─── Test: Normal reconnection works end-to-end ─────────────────────
+
+    [Test]
+    public async Task Reconnection_EndToEnd_AllEventsReceived()
+    {
+        var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\ndata: {\"value\":2}\n\n";
+        var sseText2 =
+            "id: evt-3\ndata: {\"value\":3}\n\nid: evt-4\ndata: {\"value\":4}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText1);
+        string? receivedLastEventId = null;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    receivedLastEventId = lastId;
+                    return Task.FromResult(CreateSseResponse(sseText2));
+                },
+                maxReconnectAttempts: 3,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(receivedLastEventId, Is.EqualTo("evt-2"));
+        Assert.That(items, Has.Count.EqualTo(4));
+        Assert.That(items[0], Is.EqualTo("{\"value\":1}"));
+        Assert.That(items[1], Is.EqualTo("{\"value\":2}"));
+        Assert.That(items[2], Is.EqualTo("{\"value\":3}"));
+        Assert.That(items[3], Is.EqualTo("{\"value\":4}"));
+    }
+
+    // ─── Test: Terminator stops stream without reconnection ─────────────
+
+    [Test]
+    public async Task Terminator_StopsStream_NoReconnection()
+    {
+        var sseText =
+            "id: evt-1\ndata: {\"value\":1}\n\nid: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
+        var initialResponse = CreateSseResponse(sseText);
+        var reconnectCalled = false;
+
+        var items = new List<string>();
+        await foreach (
+            var item in SseReconnectHelper.EnumerateWithReconnectAsync(
+                initialResponse,
+                (lastId, ct) =>
+                {
+                    reconnectCalled = true;
+                    return Task.FromResult(CreateSseResponse(""));
+                },
+                maxReconnectAttempts: 5,
+                disableReconnection: false,
+                terminator: "[DONE]"
+            )
+        )
+        {
+            items.Add(item.Data);
+        }
+
+        Assert.That(reconnectCalled, Is.False, "Should not reconnect when terminator is reached");
+        Assert.That(items, Has.Count.EqualTo(2));
+    }
+}

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/Sse/SseReconnectHelperTests.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/Sse/SseReconnectHelperTests.cs
@@ -17,8 +17,6 @@ namespace SeedServerSentEventsResumable.Test.Core.Sse;
 [Parallelizable(ParallelScope.Children)]
 public class SseReconnectHelperTests
 {
-    private const int TimeoutMs = 10000;
-
     // ─── Helpers ─────────────────────────────────────────────────────────
 
     /// <summary>
@@ -53,7 +51,6 @@ public class SseReconnectHelperTests
     {
         private readonly byte[] _data;
         private int _position;
-        private bool _hasReadAll;
 
         public DroppingStream(string initialText)
         {
@@ -75,7 +72,6 @@ public class SseReconnectHelperTests
             var remaining = _data.Length - _position;
             if (remaining <= 0)
             {
-                _hasReadAll = true;
                 throw new IOException("Connection dropped");
             }
             var toCopy = Math.Min(count, remaining);
@@ -94,7 +90,6 @@ public class SseReconnectHelperTests
             var remaining = _data.Length - _position;
             if (remaining <= 0)
             {
-                _hasReadAll = true;
                 throw new IOException("Connection dropped");
             }
             var toCopy = Math.Min(count, remaining);
@@ -112,7 +107,6 @@ public class SseReconnectHelperTests
             var remaining = _data.Length - _position;
             if (remaining <= 0)
             {
-                _hasReadAll = true;
                 throw new IOException("Connection dropped");
             }
             var toCopy = Math.Min(buffer.Length, remaining);
@@ -178,18 +172,13 @@ public class SseReconnectHelperTests
         var sseText1 = "id: evt-1\ndata: {\"value\":1}\n\n";
         var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
         var initialResponse = CreateSseResponse(sseText1);
-        var reconnectTimestamp = DateTime.MinValue;
-        var initialTimestamp = DateTime.UtcNow;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
 
         var items = new List<string>();
         await foreach (
             var item in SseReconnectHelper.EnumerateWithReconnectAsync(
                 initialResponse,
-                (lastId, ct) =>
-                {
-                    reconnectTimestamp = DateTime.UtcNow;
-                    return Task.FromResult(CreateSseResponse(sseText2));
-                },
+                (lastId, ct) => Task.FromResult(CreateSseResponse(sseText2)),
                 maxReconnectAttempts: 3,
                 disableReconnection: false,
                 terminator: "[DONE]"
@@ -199,12 +188,12 @@ public class SseReconnectHelperTests
             items.Add(item.Data);
         }
 
+        sw.Stop();
         Assert.That(items, Has.Count.EqualTo(2));
-        var elapsed = reconnectTimestamp - initialTimestamp;
         Assert.That(
-            elapsed.TotalMilliseconds,
+            sw.ElapsedMilliseconds,
             Is.GreaterThanOrEqualTo(900),
-            $"Expected >= 900ms delay before reconnect, got {elapsed.TotalMilliseconds}ms"
+            $"Expected >= 900ms delay before reconnect, got {sw.ElapsedMilliseconds}ms"
         );
     }
 
@@ -217,18 +206,13 @@ public class SseReconnectHelperTests
         var sseText1 = "retry: 200\nid: evt-1\ndata: {\"value\":1}\n\n";
         var sseText2 = "id: evt-2\ndata: {\"value\":2}\n\ndata: [DONE]\n\n";
         var initialResponse = CreateSseResponse(sseText1);
-        var reconnectTimestamp = DateTime.MinValue;
-        var initialTimestamp = DateTime.UtcNow;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
 
         var items = new List<string>();
         await foreach (
             var item in SseReconnectHelper.EnumerateWithReconnectAsync(
                 initialResponse,
-                (lastId, ct) =>
-                {
-                    reconnectTimestamp = DateTime.UtcNow;
-                    return Task.FromResult(CreateSseResponse(sseText2));
-                },
+                (lastId, ct) => Task.FromResult(CreateSseResponse(sseText2)),
                 maxReconnectAttempts: 3,
                 disableReconnection: false,
                 terminator: "[DONE]"
@@ -238,13 +222,12 @@ public class SseReconnectHelperTests
             items.Add(item.Data);
         }
 
+        sw.Stop();
         Assert.That(items, Has.Count.EqualTo(2));
-        var elapsed = reconnectTimestamp - initialTimestamp;
-        // Should be at least ~150ms (allowing variance)
         Assert.That(
-            elapsed.TotalMilliseconds,
+            sw.ElapsedMilliseconds,
             Is.GreaterThanOrEqualTo(150),
-            $"Expected >= 150ms (server retry: 200), got {elapsed.TotalMilliseconds}ms"
+            $"Expected >= 150ms (server retry: 200), got {sw.ElapsedMilliseconds}ms"
         );
     }
 

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
@@ -193,6 +193,11 @@ internal static class SseReconnectHelper
                 continue;
             }
 
+            // Successful reconnect — clear any stale failure so it doesn't
+            // cause a misleading IOException if a later cap-exhaustion occurs
+            // via empty-body reconnects (which don't set lastReconnectException).
+            lastReconnectException = null;
+
             // Only dispose the old response after a new one is successfully obtained.
             if (isReconnectedResponse)
             {

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
@@ -63,6 +63,7 @@ internal static class SseReconnectHelper
         // blank line, reconnecting with the parsed-but-undispatched id would
         // skip an event that was never delivered to the caller.
         string? lastDispatchedEventId = null;
+        Exception? lastReconnectException = null;
 
         while (true)
         {
@@ -145,10 +146,16 @@ internal static class SseReconnectHelper
                 || reconnectAttempts >= maxAttempts
             )
             {
-                if (streamDropped)
+                if (streamDropped || lastReconnectException != null)
                 {
                     throw new IOException(
-                        "SSE stream connection lost and reconnection was not attempted."
+                        "SSE stream connection lost and reconnection "
+                            + (
+                                lastReconnectException != null
+                                    ? "failed after exhausting all attempts."
+                                    : "was not attempted."
+                            ),
+                        lastReconnectException
                     );
                 }
                 yield break;
@@ -176,12 +183,13 @@ internal static class SseReconnectHelper
                 newResponse = await reconnectFn(lastDispatchedEventId!, cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
                 // Failed reconnect (e.g. HTTP error or null body). Treat as a
                 // failed attempt — the next loop iteration will check the cap.
                 // Do NOT dispose the previous response here: we need it to stay
                 // valid in case the retry loop re-enters the stream-read path.
+                lastReconnectException = ex;
                 continue;
             }
 

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
@@ -170,22 +170,27 @@ internal static class SseReconnectHelper
                 .Threading.Tasks.Task.Delay(delay, cancellationToken)
                 .ConfigureAwait(false);
 
+            ApiResponse newResponse;
+            try
+            {
+                newResponse = await reconnectFn(lastDispatchedEventId!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Failed reconnect (e.g. HTTP error or null body). Treat as a
+                // failed attempt — the next loop iteration will check the cap.
+                // Do NOT dispose the previous response here: we need it to stay
+                // valid in case the retry loop re-enters the stream-read path.
+                continue;
+            }
+
+            // Only dispose the old response after a new one is successfully obtained.
             if (isReconnectedResponse)
             {
                 response.Raw?.Dispose();
             }
-
-            try
-            {
-                response = await reconnectFn(lastDispatchedEventId!, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch
-            {
-                // Failed reconnect (e.g. HTTP error or null body). Treat as a
-                // failed attempt — the next loop iteration will check the cap.
-                continue;
-            }
+            response = newResponse;
             isReconnectedResponse = true;
         }
     }

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/SseReconnectHelper.cs
@@ -12,6 +12,7 @@ namespace SeedServerSentEventsResumable.Core;
 internal static class SseReconnectHelper
 {
     private const int DefaultMaxReconnectAttempts = 5;
+    private static readonly TimeSpan DefaultReconnectDelay = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromSeconds(30);
 
     /// <summary>
@@ -25,13 +26,16 @@ internal static class SseReconnectHelper
     /// </param>
     /// <param name="maxReconnectAttempts">
     /// The maximum number of consecutive reconnection attempts before giving up.
-    /// Defaults to <c>5</c> when <c>null</c>.
+    /// Defaults to <c>5</c> when <c>null</c>. The counter resets to zero each
+    /// time a reconnected stream successfully yields at least one event.
     /// </param>
     /// <param name="disableReconnection">
     /// When <c>true</c>, reconnection is disabled and the stream ends on premature EOF.
     /// </param>
     /// <param name="terminator">
-    /// The SSE data value that signals the end of the stream.
+    /// The SSE data value that signals the end of the stream. When <c>null</c>,
+    /// reconnection is disabled because the client cannot distinguish a completed
+    /// stream from a dropped connection.
     /// </param>
     /// <param name="cancellationToken">A token to cancel the enumeration.</param>
     /// <returns>An async enumerable of <see cref="SseItem{T}"/> items.</returns>
@@ -52,6 +56,13 @@ internal static class SseReconnectHelper
         var maxAttempts = maxReconnectAttempts ?? DefaultMaxReconnectAttempts;
         var reconnectAttempts = 0;
         var isReconnectedResponse = false;
+        // Track the last event ID from the most recently *dispatched* (yielded)
+        // event, not the last parsed id. Per the WHATWG EventSource spec the
+        // "last event ID" is only committed when an event is dispatched — if a
+        // connection drops after an id: line but before the event's terminating
+        // blank line, reconnecting with the parsed-but-undispatched id would
+        // skip an event that was never delivered to the caller.
+        string? lastDispatchedEventId = null;
 
         while (true)
         {
@@ -102,6 +113,15 @@ internal static class SseReconnectHelper
                     }
 
                     yield return item;
+                    // Capture parser.LastEventId immediately after a successful
+                    // dispatch — at this point it reflects the just-dispatched
+                    // event's id. We must snapshot it before the next
+                    // MoveNextAsync could partially update it with a new id:
+                    // line from an incomplete event.
+                    if (!string.IsNullOrEmpty(parser.LastEventId))
+                    {
+                        lastDispatchedEventId = parser.LastEventId;
+                    }
                     reconnectAttempts = 0;
                 }
             }
@@ -115,9 +135,13 @@ internal static class SseReconnectHelper
                 yield break;
             }
 
+            // Determine whether reconnection should be attempted.
+            // Without a terminator the client cannot distinguish "stream
+            // completed" from "connection dropped", so reconnection is disabled.
             if (
                 disableReconnection
-                || string.IsNullOrEmpty(parser.LastEventId)
+                || terminator == null
+                || string.IsNullOrEmpty(lastDispatchedEventId)
                 || reconnectAttempts >= maxAttempts
             )
             {
@@ -132,25 +156,36 @@ internal static class SseReconnectHelper
 
             reconnectAttempts++;
 
-            var delay = parser.ReconnectionInterval;
+            // Use the server-sent retry interval if available; otherwise fall
+            // back to DefaultReconnectDelay (1s) to avoid hammering the server.
+            var delay =
+                parser.ReconnectionInterval > TimeSpan.Zero
+                    ? parser.ReconnectionInterval
+                    : DefaultReconnectDelay;
             if (delay > MaxReconnectDelay)
             {
                 delay = MaxReconnectDelay;
             }
-            if (delay > TimeSpan.Zero)
-            {
-                await global::System
-                    .Threading.Tasks.Task.Delay(delay, cancellationToken)
-                    .ConfigureAwait(false);
-            }
+            await global::System
+                .Threading.Tasks.Task.Delay(delay, cancellationToken)
+                .ConfigureAwait(false);
 
             if (isReconnectedResponse)
             {
                 response.Raw?.Dispose();
             }
 
-            response = await reconnectFn(parser.LastEventId, cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                response = await reconnectFn(lastDispatchedEventId!, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // Failed reconnect (e.g. HTTP error or null body). Treat as a
+                // failed attempt — the next loop iteration will check the cap.
+                continue;
+            }
             isReconnectedResponse = true;
         }
     }

--- a/seed/csharp-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
@@ -6,8 +6,7 @@
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }


### PR DESCRIPTION
## Description

Audits the C# SDK's `SseReconnectHelper` against the hardened TypeScript SSE auto-reconnection implementation (PR #16864) and closes all parity gaps with minimal, targeted changes.

## Changes Made

### Runtime fixes (`SseReconnectHelper.Template.cs`)

1. **Terminator gating**: when `terminator == null`, reconnection is disabled — the client cannot distinguish "stream completed" from "connection dropped" without a terminator. Previously reconnected unconditionally if `LastEventId` was non-empty.

2. **Default 1 s backoff**: added `DefaultReconnectDelay = TimeSpan.FromSeconds(1)` used when the server sends no `retry:` directive. Previously reconnected with zero delay, hammering the server.

3. **Last-dispatched-ID tracking**: captures `parser.LastEventId` only *after* a successful `yield return` (i.e. event dispatched to the caller), not when `id:` line is parsed mid-event. Prevents silent event loss on mid-event connection drop.

4. **Null/throwing `reconnectFn` handling**: wraps `reconnectFn` in `try/catch (Exception ex) when (!cancellationToken.IsCancellationRequested)` so HTTP errors are treated as failed attempts rather than unhandled exceptions mid-enumeration. `OperationCanceledException` propagates immediately instead of burning a retry attempt.

5. **Dispose ordering**: old `HttpResponseMessage` is disposed only *after* a new response is successfully obtained, preventing `ObjectDisposedException` if the retry loop re-enters the stream-read path after a failed reconnect.

6. **Loud failure on exhausted reconnect cap**: when all reconnect attempts fail (reconnectFn keeps throwing), throws `IOException("SSE stream connection lost and reconnection failed after exhausting all attempts.")` with the last reconnect exception as `InnerException`, instead of silently truncating the stream. Consistent with the existing loud-failure path for "not attempted" reconnects.

### Parity comparison

| Behavior | TS | C# before | C# after |
|---|---|---|---|
| Reconnect on premature EOF | ✅ | ✅ | ✅ |
| Terminator gating (no terminator → no reconnect) | ✅ | ❌ reconnects anyway | ✅ |
| Default 1 s backoff | ✅ | ❌ zero delay | ✅ |
| Last-dispatched-ID (not last-parsed) | ✅ | ❌ uses parser.LastEventId | ✅ captures after yield |
| Max attempts cap with reset-on-progress | ✅ | ✅ | ✅ |
| disableReconnection flag | ✅ | ✅ | ✅ |
| Cancellation during backoff | ✅ | ✅ | ✅ |
| Cancellation in reconnectFn propagates immediately | ✅ | ❌ swallowed by catch | ✅ `when` filter |
| Null/throwing reconnectFn guard | ✅ | ❌ unhandled | ✅ try/catch |
| Loud failure on exhausted cap | N/A (TS silently returns) | ❌ silent truncation | ✅ throws IOException |
| Dispose ordering on failed reconnect | N/A | ❌ premature dispose | ✅ dispose after success |

### Breaking-changes note

Items 2 (default backoff) and the terminator gating in item 1 change runtime behavior for existing users. These are **bug-fix-shaped** changes that bring C# in line with the documented/reference behavior:
- Default backoff prevents reconnect storms when the server sends no `retry:` directive.
- Terminator gating prevents infinite reconnect loops on endpoints with no terminator.

No public API surface changes. No new config flags needed — these are correctness fixes.

### Tests (`SseReconnectHelperTests.Template.cs`)

11 tests covering all parity checklist behaviors:
- `NoTerminator_DoesNotReconnect_StreamEndsOnEof`
- `DefaultBackoff_WaitsAtLeast900ms_WhenNoRetryDirective`
- `ServerRetry_IsRespectedAndClamped`
- `MidEventDrop_ReconnectsWithLastDispatchedId_NotParsedId`
- `MaxReconnectAttempts_CapsConsecutiveFailures`
- `DisableReconnection_PreventsReconnect`
- `Cancellation_DuringBackoff_StopsPromptly`
- `ReconnectFnThrows_SurfacesIOException_AfterExhaustingCap`
- `Cancellation_InReconnectFn_PropagatesImmediately`
- `Reconnection_EndToEnd_AllEventsReceived`
- (plus the `DroppingStream` helper with its own verification)

### Regenerated fixtures
`server-sent-events`, `server-sent-events-resumable`, `streaming`, `streaming-parameter`, `server-sent-event-examples`, `server-sent-events-openapi`

## Testing
- [x] Unit tests added (11 tests, all passing on net9.0)
- [x] `dotnet build` / `dotnet test` on regenerated fixtures
- [x] All 6 seed fixtures regenerated and passing
- [x] E2E tested against live local HTTP SSE server (8 scenarios)

Link to Devin session: https://app.devin.ai/sessions/9c34ce1e42324ae3a22874b4c38b73bb
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->